### PR TITLE
feat: introduce remote loader for missing files with esbuild

### DIFF
--- a/internal/esbuild/remote_loader_plugin.go
+++ b/internal/esbuild/remote_loader_plugin.go
@@ -1,0 +1,110 @@
+package esbuild
+
+import (
+	"context"
+	"fmt"
+	"github.com/evanw/esbuild/pkg/api"
+	"io"
+	"net/http"
+	"path/filepath"
+	"regexp"
+)
+
+const RemoteLoaderName = "sw-remote-loader"
+
+type RemoteLoaderOptions struct {
+	BaseUrl  string
+	Matchers map[string]RemoteLoaderReplacer
+}
+
+type RemoteLoaderReplacer struct {
+	Matching *regexp.Regexp
+	Replace  string
+}
+
+func newRemoteLoaderPlugin(ctx context.Context, options RemoteLoaderOptions) api.Plugin {
+	return api.Plugin{
+		Name: RemoteLoaderName,
+		Setup: func(build api.PluginBuild) {
+			for matcher, matcherOptions := range options.Matchers {
+				build.OnResolve(api.OnResolveOptions{Filter: matcher}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
+					path := matcherOptions.Matching.ReplaceAllString(args.Path, matcherOptions.Replace)
+
+					return api.OnResolveResult{
+						Path:      options.BaseUrl + path,
+						Namespace: RemoteLoaderName,
+					}, nil
+				})
+			}
+
+			build.OnResolve(api.OnResolveOptions{Filter: "deepmerge", Namespace: RemoteLoaderName}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
+				return api.OnResolveResult{
+					Path:      "https://unpkg.com/deepmerge@4.3.1",
+					Namespace: RemoteLoaderName,
+				}, nil
+			})
+
+			// When our namespace is used, we load the remote file
+			build.OnLoad(api.OnLoadOptions{Filter: "/.*/", Namespace: RemoteLoaderName}, func(args api.OnLoadArgs) (api.OnLoadResult, error) {
+				ext := filepath.Ext(args.Path)
+
+				// When we have a file extension, try direct load. But maybe the file has two file extensions, therefore, we need to fallback to .js/.ts
+				if ext != "" {
+					if content, err := fetchRemoteAsset(ctx, args.Path); err == nil {
+						return api.OnLoadResult{
+							Contents: &content,
+							Loader:   api.LoaderTS,
+						}, nil
+					}
+				}
+
+				// Try to load the file with .ts and .js extension
+				if content, err := fetchRemoteAsset(ctx, args.Path+".ts"); err == nil {
+					return api.OnLoadResult{
+						Contents: &content,
+						Loader:   api.LoaderTS,
+					}, nil
+				}
+
+				if content, err := fetchRemoteAsset(ctx, args.Path+".js"); err == nil {
+					return api.OnLoadResult{
+						Contents: &content,
+						Loader:   api.LoaderTS,
+					}, nil
+				}
+
+				return api.OnLoadResult{}, fmt.Errorf("file does not exists")
+			})
+		},
+	}
+}
+
+func fetchRemoteAsset(ctx context.Context, url string) (string, error) {
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	r.Header.Add("User-Agent", "Shopware CLI")
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("url does not exists")
+	}
+
+	content, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}

--- a/internal/esbuild/remote_loader_plugin_test.go
+++ b/internal/esbuild/remote_loader_plugin_test.go
@@ -1,0 +1,104 @@
+package esbuild
+
+import (
+	"context"
+	"github.com/evanw/esbuild/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestLoadRegularJSFileWithImportPrefixAdmin(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file
+	filePath := tmpDir + "/test.js"
+	fileContent := "import {searchRankingPoint} from \"@administration/app/service/search-ranking.service\";"
+
+	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+
+	options := RemoteLoaderOptions{
+		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Administration/Resources/app/administration/",
+		Matchers: map[string]RemoteLoaderReplacer{
+			"^@administration/": {Matching: regexp.MustCompile("^@administration/"), Replace: "src/"},
+		},
+	}
+
+	build := api.BuildOptions{
+		EntryPoints: []string{filePath},
+		Plugins:     []api.Plugin{newRemoteLoaderPlugin(context.Background(), options)},
+		Outfile:     "extension.js",
+		Bundle:      true,
+		Write:       false,
+	}
+
+	result := api.Build(build)
+	assert.Len(t, result.Errors, 0)
+
+	assert.Contains(t, string(result.OutputFiles[0].Contents), "HIGH_SEARCH_RANKING")
+}
+
+func TestLoadRegularJSFileAdmin(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file
+	filePath := tmpDir + "/test.js"
+	fileContent := "import {searchRankingPoint} from \"src/app/service/search-ranking.service\";"
+
+	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+
+	options := RemoteLoaderOptions{
+		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Administration/Resources/app/administration/",
+		Matchers: map[string]RemoteLoaderReplacer{
+			"^src\\/": {Matching: regexp.MustCompile("^src/"), Replace: "src/"},
+		},
+	}
+
+	build := api.BuildOptions{
+		EntryPoints: []string{filePath},
+		Plugins:     []api.Plugin{newRemoteLoaderPlugin(context.Background(), options)},
+		Outfile:     "extension.js",
+		Bundle:      true,
+		Write:       false,
+	}
+
+	result := api.Build(build)
+	assert.Len(t, result.Errors, 0)
+
+	assert.Len(t, result.OutputFiles, 1)
+
+	assert.Contains(t, string(result.OutputFiles[0].Contents), "HIGH_SEARCH_RANKING")
+}
+
+func TestLoadRegularJSFileStorefront(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file
+	filePath := tmpDir + "/test.js"
+	fileContent := "import Plugin from \"src/plugin-system/plugin.class\"; class Foo extends Plugin {}; export {Foo}"
+
+	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+
+	options := RemoteLoaderOptions{
+		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Storefront/Resources/app/storefront/",
+		Matchers: map[string]RemoteLoaderReplacer{
+			"^src\\/": {Matching: regexp.MustCompile("^src/"), Replace: "src/"},
+		},
+	}
+
+	build := api.BuildOptions{
+		EntryPoints: []string{filePath},
+		Plugins:     []api.Plugin{newRemoteLoaderPlugin(context.Background(), options)},
+		Outfile:     "extension.js",
+		Bundle:      true,
+		Write:       false,
+	}
+
+	result := api.Build(build)
+	assert.Len(t, result.Errors, 0)
+
+	assert.Len(t, result.OutputFiles, 1)
+
+	assert.Contains(t, string(result.OutputFiles[0].Contents), "There is no valid element given")
+}

--- a/internal/esbuild/remote_loader_plugin_test.go
+++ b/internal/esbuild/remote_loader_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/evanw/esbuild/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path"
 	"regexp"
 	"testing"
 )
@@ -12,11 +13,7 @@ import (
 func TestLoadRegularJSFileWithImportPrefixAdmin(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a file
-	filePath := tmpDir + "/test.js"
-	fileContent := "import {searchRankingPoint} from \"@administration/app/service/search-ranking.service\";"
-
-	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+	filePath := createEntrypoint(tmpDir, "import {searchRankingPoint} from \"@administration/app/service/search-ranking.service\";")
 
 	options := RemoteLoaderOptions{
 		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Administration/Resources/app/administration/",
@@ -39,14 +36,18 @@ func TestLoadRegularJSFileWithImportPrefixAdmin(t *testing.T) {
 	assert.Contains(t, string(result.OutputFiles[0].Contents), "HIGH_SEARCH_RANKING")
 }
 
+func createEntrypoint(tmpDir, content string) string {
+	filePath := tmpDir + "/test.js"
+
+	_ = os.WriteFile(path.Join(tmpDir, "test.js"), []byte(content), 0644)
+
+	return filePath
+}
+
 func TestLoadRegularJSFileAdmin(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a file
-	filePath := tmpDir + "/test.js"
-	fileContent := "import {searchRankingPoint} from \"src/app/service/search-ranking.service\";"
-
-	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+	filePath := createEntrypoint(tmpDir, "import {searchRankingPoint} from \"src/app/service/search-ranking.service\";")
 
 	options := RemoteLoaderOptions{
 		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Administration/Resources/app/administration/",
@@ -71,14 +72,34 @@ func TestLoadRegularJSFileAdmin(t *testing.T) {
 	assert.Contains(t, string(result.OutputFiles[0].Contents), "HIGH_SEARCH_RANKING")
 }
 
+func TestLoadSCSSFromExternalSource(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	filePath := createEntrypoint(tmpDir, "import \"src/module/sw-cms/component/sw-cms-block/sw-cms-block.scss\";")
+
+	options := RemoteLoaderOptions{
+		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Administration/Resources/app/administration/",
+		Matchers: map[string]RemoteLoaderReplacer{
+			"^src\\/": {Matching: regexp.MustCompile("^src/"), Replace: "src/"},
+		},
+	}
+
+	build := api.BuildOptions{
+		EntryPoints: []string{filePath},
+		Plugins:     []api.Plugin{newScssPlugin(context.Background()), newRemoteLoaderPlugin(context.Background(), options)},
+		Outfile:     "extension.js",
+		Bundle:      true,
+		Write:       false,
+	}
+
+	result := api.Build(build)
+	assert.Len(t, result.Errors, 0)
+}
+
 func TestLoadRegularJSFileStorefront(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a file
-	filePath := tmpDir + "/test.js"
-	fileContent := "import Plugin from \"src/plugin-system/plugin.class\"; class Foo extends Plugin {}; export {Foo}"
-
-	assert.NoError(t, os.WriteFile(filePath, []byte(fileContent), 0644))
+	filePath := createEntrypoint(tmpDir, "import Plugin from \"src/plugin-system/plugin.class\"; class Foo extends Plugin {}; export {Foo}")
 
 	options := RemoteLoaderOptions{
 		BaseUrl: "https://raw.githubusercontent.com/shopware/shopware/v6.5.7.3/src/Storefront/Resources/app/storefront/",


### PR DESCRIPTION
Right now the Users get a Could not resolve message when they import an Administration or Storefront JS / CSS file with esbuild like this:

```
✘ [ERROR] Could not resolve "@administration/app/service/search-ranking.service"

    ../Resources/app/administration/src/module/sw-quote/default-search-configuration.ts:3:35:
      3 │ import { searchRankingPoint } from "@administration/app/service/search-ranking.service";
        ╵                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "@administration/app/service/search-ranking.service" as external to exclude
  it from the bundle, which will remove this error and leave the unresolved path in the bundle.
```

These problems can be solved by using the Globals only in the Administration and for Storefront using the Frosh Storefront SDK. But Developers are lazy and adopt it very slowly. 

Therefore, with this PR we add a remote loader, which fetches the missing files from GitHub and caches them locally. After this change Storefront and Administration compilation should require no change to the plugin source code base.

Open Todos:

- [x] Support `src/...` and `@administration/` imports in Administration and importing inside that file other files.
- [x] Add Support for `src/...` imports in the Storefront and importing inside that file other files.
- [x] Add Support for SCSS files in the Administration
- [ ] Rewrite SaaS Plugin to use also remote loader
- [x] Add proper caching for the downloads
- [x] Use minimum supported Shopware version for loading the remote files.
- [ ] Support loading dependencies of core files without having node_modules locally
	- [ ] Allow partial loading of dependencies aka: `import test from 'lodash/flow'`
- [ ] Integration into existing code