### PR TITLE
Fix zip command to adjust ExtensionConfig and dump .shopware-extension.yml

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -151,9 +151,8 @@ var extensionZipCmd = &cobra.Command{
 			}
 		}
 
-		// Adjust the ExtensionConfig to set validation.ignore to meta.setup when --overwrite-app-backend-secret is passed
 		if cmd.Flags().Changed("overwrite-app-backend-secret") {
-			extCfg.Validation.Ignore = append(extCfg.Validation.Ignore, "meta.setup")
+			extCfg.Validation.Ignore = append(extCfg.Validation.Ignore, "metadata.setup")
 			if err := extCfg.Dump(extDir); err != nil {
 				return fmt.Errorf("dump extension config: %w", err)
 			}

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -151,6 +151,14 @@ var extensionZipCmd = &cobra.Command{
 			}
 		}
 
+		// Adjust the ExtensionConfig to set validation.ignore to meta.setup when --overwrite-app-backend-secret is passed
+		if cmd.Flags().Changed("overwrite-app-backend-secret") {
+			extCfg.Validation.Ignore = append(extCfg.Validation.Ignore, "meta.setup")
+			if err := extCfg.Dump(extDir); err != nil {
+				return fmt.Errorf("dump extension config: %w", err)
+			}
+		}
+
 		// Cleanup not wanted files
 		if err := extension.CleanupExtensionFolder(extDir, extCfg.Build.Zip.Pack.Excludes.Paths); err != nil {
 			return fmt.Errorf("cleanup package: %w", err)

--- a/extension/config.go
+++ b/extension/config.go
@@ -162,3 +162,17 @@ func validateExtensionConfig(config *Config) error {
 
 	return nil
 }
+
+func (c *Config) Dump(dir string) error {
+	filePath := filepath.Join(dir, c.FileName)
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := yaml.NewEncoder(file)
+	defer encoder.Close()
+
+	return encoder.Encode(c)
+}


### PR DESCRIPTION
Update the `ExtensionConfig` to set `validation.ignore` to `meta.setup` when `--overwrite-app-backend-secret` is passed to the zip command and dump the `.shopware-extension.yml` file again before zipping.

* Modify `cmd/extension/extension_zip.go` to adjust the `ExtensionConfig` and set `validation.ignore` to `meta.setup` when `--overwrite-app-backend-secret` is passed.
* Add logic to dump the `.shopware-extension.yml` file again before zipping when `--overwrite-app-backend-secret` is passed.
* Add a `Dump` method to the `Config` struct in `extension/config.go` to handle the dumping of the configuration to the `.shopware-extension.yml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopware/shopware-cli/pull/473?shareId=1369d453-2ccd-48a4-b9eb-fe25a24b6411).