### PR TITLE
Enhance invalid git repository test assertions

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -14,10 +14,9 @@ func TestInvalidGitRepository(t *testing.T) {
 	repo := "invalid"
 	ctx := context.Background()
 
-	_, err := getPreviousTag(ctx, repo)
-	if err == nil {
-		t.Errorf("expected error, got nil")
-	}
+	tag, err := getPreviousTag(ctx, repo)
+	assert.Error(t, err)
+	assert.Empty(t, tag)
 }
 
 func TestNoTags(t *testing.T) {


### PR DESCRIPTION
Improving the TestInvalidGitRepository by:
- Adding assertion for empty tag return value
- Adding explicit error assertion using testify
- Simplify the test suite by remove the error condition
