### PR TITLE
Fix DATABASE_URL handling

### DIFF
--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -312,8 +313,8 @@ func loadDatabaseURLIntoConnection(ctx context.Context, projectRoot string, cfg 
 	if parsedUri.Host != "" {
 		cfg.Addr = parsedUri.Host
 
-		if parsedUri.Port() != "" {
-			cfg.Addr = fmt.Sprintf("%s:%s", parsedUri.Host, parsedUri.Port())
+		if parsedUri.Port() == "" {
+			cfg.Addr = net.JoinHostPort(parsedUri.Host, "3306")
 		}
 	}
 


### PR DESCRIPTION
Previously the code would double the port in the address since the `URL.Host` already contains the port.