### PR TITLE
Fix condition in project dump command

### DIFF
--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -258,10 +258,10 @@ func assembleConnectionURI(cmd *cobra.Command) (*mysql.Config, error) {
 	db, _ := cmd.Flags().GetString("database")
 
 	if host != "" {
-		if port != "" {
-			cfg.Addr = host
-		} else {
+		if port == "" {
 			cfg.Addr = fmt.Sprintf("%s:%s", host, port)
+		} else {
+			cfg.Addr = host
 		}
 	}
 


### PR DESCRIPTION
Fixes #480

Adjust the inner if condition in the project dump command to call `sprintf` only when the port is not set.

* Change the condition to check if the port is an empty string.
* Call `sprintf` to set `cfg.Addr` only when the port is not set.
* Set `cfg.Addr` to the host directly when the port is set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopware/shopware-cli/pull/483?shareId=12e2e1f8-5210-4573-9e6f-f7353f184396).