### PR TITLE
refactor: Remove `.gitignore` from all subfolders when packing a ZIP

### DIFF
--- a/extension/zip.go
+++ b/extension/zip.go
@@ -27,7 +27,6 @@ var (
 		".editorconfig",
 		".git",
 		".github",
-		".gitignore",
 		".gitlab-ci.yml",
 		".gitpod.Dockerfile",
 		".gitpod.yml",
@@ -61,6 +60,7 @@ var (
 		".DS_Store",
 		"Thumbs.db",
 		"__MACOSX",
+		".gitignore",
 	}
 
 	defaultNotAllowedExtensions = []string{


### PR DESCRIPTION
I just removed a failed (manual) code review, where a `.gitignore` file is located in `src/Resources/` :-)

This should remove the file also from subfolders.