### PR TITLE
Add force_extension_build option for packages with compiled files

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -107,7 +107,7 @@ var projectCI = &cobra.Command{
 			Browserslist:                 shopCfg.Build.Browserslist,
 			SkipExtensionsWithBuildFiles: true,
 			DisableStorefrontBuild:       shopCfg.Build.DisableStorefrontBuild,
-			ForceExtensionBuild:          shopCfg.Build.ForceExtensionBuild,
+			ForceExtensionBuild:          convertForceExtensionBuild(shopCfg.Build.ForceExtensionBuild),
 		}
 
 		if err := extension.BuildAssetsForExtensions(cmd.Context(), sources, assetCfg); err != nil {
@@ -487,4 +487,14 @@ func cleanupJavaScriptSourceMaps(folder string) error {
 
 		return os.WriteFile(expectedJsFile, []byte(overwrittenContent), os.ModePerm)
 	})
+}
+
+func convertForceExtensionBuild(configExtensions []shop.ConfigBuildExtension) []extension.ExtensionBuildConfig {
+	extensionConfigs := make([]extension.ExtensionBuildConfig, len(configExtensions))
+	for i, ext := range configExtensions {
+		extensionConfigs[i] = extension.ExtensionBuildConfig{
+			Name: ext.Name,
+		}
+	}
+	return extensionConfigs
 }

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -489,12 +489,10 @@ func cleanupJavaScriptSourceMaps(folder string) error {
 	})
 }
 
-func convertForceExtensionBuild(configExtensions []shop.ConfigBuildExtension) []extension.ExtensionBuildConfig {
-	extensionConfigs := make([]extension.ExtensionBuildConfig, len(configExtensions))
+func convertForceExtensionBuild(configExtensions []shop.ConfigBuildExtension) []string {
+	extensionConfigs := make([]string, len(configExtensions))
 	for i, ext := range configExtensions {
-		extensionConfigs[i] = extension.ExtensionBuildConfig{
-			Name: ext.Name,
-		}
+		extensionConfigs[i] = ext.Name
 	}
 	return extensionConfigs
 }

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -107,6 +107,7 @@ var projectCI = &cobra.Command{
 			Browserslist:                 shopCfg.Build.Browserslist,
 			SkipExtensionsWithBuildFiles: true,
 			DisableStorefrontBuild:       shopCfg.Build.DisableStorefrontBuild,
+			ForceExtensionBuild:          shopCfg.Build.ForceExtensionBuild,
 		}
 
 		if err := extension.BuildAssetsForExtensions(cmd.Context(), sources, assetCfg); err != nil {

--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -39,12 +39,7 @@ type AssetBuildConfig struct {
 	SkipExtensionsWithBuildFiles bool
 	NPMForceInstall              bool
 	ContributeProject            bool
-	ForceExtensionBuild          []ExtensionBuildConfig
-}
-
-// ExtensionBuildConfig defines configuration for forcing extension builds
-type ExtensionBuildConfig struct {
-	Name string
+	ForceExtensionBuild          []string
 }
 
 func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, assetConfig AssetBuildConfig) error { // nolint:gocyclo
@@ -467,13 +462,7 @@ func BuildAssetConfigFromExtensions(ctx context.Context, sources []asset.Source,
 			expectedStorefrontCompiledFile := path.Join(source.Path, "Resources", "app", "storefront", "dist", "storefront", "js", esbuild.ToKebabCase(source.Name), esbuild.ToKebabCase(source.Name)+".js")
 
 			// Check if extension is in the ForceExtensionBuild list
-			forceExtensionBuild := false
-			for _, ext := range assetCfg.ForceExtensionBuild {
-				if ext.Name == source.Name {
-					forceExtensionBuild = true
-					break
-				}
-			}
+			forceExtensionBuild := slices.Contains(assetCfg.ForceExtensionBuild, source.Name)
 
 			if _, err := os.Stat(expectedAdminCompiledFile); err == nil && !forceExtensionBuild {
 				// clear out the entrypoint, so the admin does not build it

--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -39,7 +39,12 @@ type AssetBuildConfig struct {
 	SkipExtensionsWithBuildFiles bool
 	NPMForceInstall              bool
 	ContributeProject            bool
-	ForceExtensionBuild          []string
+	ForceExtensionBuild          []ExtensionBuildConfig
+}
+
+// ExtensionBuildConfig defines configuration for forcing extension builds
+type ExtensionBuildConfig struct {
+	Name string
 }
 
 func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, assetConfig AssetBuildConfig) error { // nolint:gocyclo
@@ -462,7 +467,13 @@ func BuildAssetConfigFromExtensions(ctx context.Context, sources []asset.Source,
 			expectedStorefrontCompiledFile := path.Join(source.Path, "Resources", "app", "storefront", "dist", "storefront", "js", esbuild.ToKebabCase(source.Name), esbuild.ToKebabCase(source.Name)+".js")
 
 			// Check if extension is in the ForceExtensionBuild list
-			forceExtensionBuild := slices.Contains(assetCfg.ForceExtensionBuild, source.Name)
+			forceExtensionBuild := false
+			for _, ext := range assetCfg.ForceExtensionBuild {
+				if ext.Name == source.Name {
+					forceExtensionBuild = true
+					break
+				}
+			}
 
 			if _, err := os.Stat(expectedAdminCompiledFile); err == nil && !forceExtensionBuild {
 				// clear out the entrypoint, so the admin does not build it

--- a/shop/config.go
+++ b/shop/config.go
@@ -50,7 +50,7 @@ type ConfigBuild struct {
 	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
 }
 
-// ConfigBuildExtension defines the configuration for forcing extension builds
+// ConfigBuildExtension defines the configuration for forcing extension builds.
 type ConfigBuildExtension struct {
 	// Name of the extension
 	Name string `yaml:"name" jsonschema:"required"`

--- a/shop/config.go
+++ b/shop/config.go
@@ -47,7 +47,13 @@ type ConfigBuild struct {
 	// When enabled, the storefront build will be skipped
 	DisableStorefrontBuild bool `yaml:"disable_storefront_build,omitempty"`
 	// Extensions to force build for, even if they have compiled files
-	ForceExtensionBuild []string `yaml:"force_extension_build,omitempty"`
+	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
+}
+
+// ConfigBuildExtension defines the configuration for forcing extension builds
+type ConfigBuildExtension struct {
+	// Name of the extension
+	Name string `yaml:"name" jsonschema:"required"`
 }
 
 type ConfigAdminApi struct {

--- a/shop/config.go
+++ b/shop/config.go
@@ -46,6 +46,8 @@ type ConfigBuild struct {
 	ExcludeExtensions []string `yaml:"exclude_extensions,omitempty"`
 	// When enabled, the storefront build will be skipped
 	DisableStorefrontBuild bool `yaml:"disable_storefront_build,omitempty"`
+	// Extensions to force build for, even if they have compiled files
+	ForceExtensionBuild []string `yaml:"force_extension_build,omitempty"`
 }
 
 type ConfigAdminApi struct {

--- a/shop/shopware-project-schema.json
+++ b/shop/shopware-project-schema.json
@@ -99,10 +99,31 @@
         "disable_storefront_build": {
           "type": "boolean",
           "description": "When enabled, the storefront build will be skipped"
+        },
+        "force_extension_build": {
+          "items": {
+            "$ref": "#/$defs/ConfigBuildExtension"
+          },
+          "type": "array",
+          "description": "Extensions to force build for, even if they have compiled files"
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "ConfigBuildExtension": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the extension"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "ConfigBuildExtension defines the configuration for forcing extension builds."
     },
     "ConfigDeployment": {
       "properties": {


### PR DESCRIPTION
## Description

This PR implements the feature requested in issue #487 by adding a configuration option to enable admin builds for packages that distribute compiled files.

### Changes

- Added a new `force_extension_build` configuration option to the `ConfigBuild` struct as a structured array of objects
- Updated `AssetBuildConfig` to include the `ForceExtensionBuild` field
- Modified asset platform logic to check if extensions are in the `force_extension_build` list before skipping builds
- Implemented a more extensible configuration format for future enhancements

### Usage

Users can now configure extensions that should always be built, even if they have compiled files:

```yaml
build:
  force_extension_build:
    - name: SwagCommercial
```

This structured format allows for adding more configuration options to each extension in the future.

This allows patching plugins which are installed using composer, as mentioned in the issue.

Fixes #487