### PR TITLE
feat: Add meta title and description support for extensions

### DIFF
--- a/cmd/account/account_producer_extension_info_pull.go
+++ b/cmd/account/account_producer_extension_info_pull.go
@@ -119,6 +119,10 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 		englishDescription := ""
 		germanInstallationManual := ""
 		englishInstallationManual := ""
+		germanMetaTitle := ""
+		englishMetaTitle := ""
+		germanMetaDescription := ""
+		englishMetaDescription := ""
 
 		for _, info := range storeExt.Infos {
 			language := info.Locale.Name[0:2]
@@ -126,6 +130,8 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 			if language == "de" {
 				germanDescription = "file:src/Resources/store/description.de.html"
 				germanInstallationManual = "file:src/Resources/store/installation_manual.de.html"
+				germanMetaTitle = info.MetaTitle
+				germanMetaDescription = info.MetaDescription
 
 				if err := os.WriteFile(path.Join(zipExt.GetPath(), germanDescription[5:]), []byte(info.Description), os.ModePerm); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
@@ -156,6 +162,8 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 			} else {
 				englishDescription = "file:src/Resources/store/description.en.html"
 				englishInstallationManual = "file:src/Resources/store/installation_manual.en.html"
+				englishMetaTitle = info.MetaTitle
+				englishMetaDescription = info.MetaDescription
 
 				if err := os.WriteFile(path.Join(zipExt.GetPath(), englishDescription[5:]), []byte(info.Description), os.ModePerm); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
@@ -209,6 +217,8 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 		newCfg.Store.Highlights = extension.ConfigTranslated[[]string]{German: &highlightsDE, English: &highlightsEN}
 		newCfg.Store.Features = extension.ConfigTranslated[[]string]{German: &featuresDE, English: &featuresEN}
 		newCfg.Store.Faq = extension.ConfigTranslated[[]extension.ConfigStoreFaq]{German: &faqDE, English: &faqEN}
+		newCfg.Store.MetaTitle = extension.ConfigTranslated[string]{German: &germanMetaTitle, English: &englishMetaTitle}
+		newCfg.Store.MetaDescription = extension.ConfigTranslated[string]{German: &germanMetaDescription, English: &englishMetaDescription}
 		newCfg.Store.Images = nil
 
 		if len(storeImages) > 0 {

--- a/cmd/account/account_producer_extension_info_push.go
+++ b/cmd/account/account_producer_extension_info_push.go
@@ -270,6 +270,16 @@ func updateStoreInfo(ext *accountApi.Extension, zipExt extension.Extension, cfg 
 				return err
 			}
 		}
+
+		storeMetaTitle := getTranslation(language, cfg.Store.MetaTitle)
+		if storeMetaTitle != nil {
+			info.MetaTitle = *storeMetaTitle
+		}
+
+		storeMetaDescription := getTranslation(language, cfg.Store.MetaDescription)
+		if storeMetaDescription != nil {
+			info.MetaDescription = *storeMetaDescription
+		}
 	}
 
 	return nil

--- a/extension/config.go
+++ b/extension/config.go
@@ -24,11 +24,11 @@ type ConfigBuild struct {
 // Configuration for zipping.
 type ConfigBuildZip struct {
 	// Configuration for composer
-	Composer ConfigBuildZipComposer `yaml:"composer"`
+	Composer ConfigBuildZipComposer `yaml:"composer,omitempty"`
 	// Configuration for assets
-	Assets ConfigBuildZipAssets `yaml:"assets"`
+	Assets ConfigBuildZipAssets `yaml:"assets,omitempty"`
 	// Configuration for packing
-	Pack ConfigBuildZipPack `yaml:"pack"`
+	Pack ConfigBuildZipPack `yaml:"pack,omitempty"`
 }
 
 type ConfigBuildZipComposer struct {
@@ -102,11 +102,11 @@ type ConfigStore struct {
 	// Installation manual of the extension in store.
 	InstallationManual ConfigTranslated[string] `yaml:"installation_manual"`
 	// Specifies the tags of the extension.
-	Tags ConfigTranslated[[]string] `yaml:"tags"`
+	Tags ConfigTranslated[[]string] `yaml:"tags,omitempty"`
 	// Specifies the links of YouTube-Videos to show or describe the extension.
-	Videos ConfigTranslated[[]string] `yaml:"videos"`
+	Videos ConfigTranslated[[]string] `yaml:"videos,omitempty"`
 	// Specifies the highlights of the extension.
-	Highlights ConfigTranslated[[]string] `yaml:"highlights"`
+	Highlights ConfigTranslated[[]string] `yaml:"highlights,omitempty"`
 	// Specifies the features of the extension.
 	Features ConfigTranslated[[]string] `yaml:"features"`
 	// Specifies Frequently Asked Questions for the extension.
@@ -122,8 +122,8 @@ type Translatable interface {
 }
 
 type ConfigTranslated[T Translatable] struct {
-	German  *T `yaml:"de"`
-	English *T `yaml:"en"`
+	German  *T `yaml:"de,omitempty"`
+	English *T `yaml:"en,omitempty"`
 }
 
 type ConfigStoreFaq struct {
@@ -223,15 +223,15 @@ func (c ConfigValidationIgnoreItem) JSONSchema() *jsonschema.Schema {
 }
 
 type Config struct {
-	FileName string `jsonschema:"-"`
+	FileName string `yaml:"-" jsonschema:"-"`
 	// Store is the store configuration of the extension.
-	Store ConfigStore `yaml:"store"`
+	Store ConfigStore `yaml:"store,omitempty"`
 	// Build is the build configuration of the extension.
-	Build ConfigBuild `yaml:"build"`
+	Build ConfigBuild `yaml:"build,omitempty"`
 	// Changelog is the changelog configuration of the extension.
-	Changelog changelog.Config `yaml:"changelog"`
+	Changelog changelog.Config `yaml:"changelog,omitempty"`
 	// Validation is the validation configuration of the extension.
-	Validation ConfigValidation `yaml:"validation"`
+	Validation ConfigValidation `yaml:"validation,omitempty"`
 }
 
 func readExtensionConfig(dir string) (*Config, error) {

--- a/extension/config.go
+++ b/extension/config.go
@@ -93,6 +93,10 @@ type ConfigStore struct {
 	Icon *string `yaml:"icon"`
 	// Specifies whether the extension should automatically be set compatible with Shopware bugfix versions.
 	AutomaticBugfixVersionCompatibility *bool `yaml:"automatic_bugfix_version_compatibility"`
+	// Specifies the meta title of the extension in store.
+	MetaTitle ConfigTranslated[string] `yaml:"meta_title" jsonschema:"maxLength=50"`
+	// Specifies the meta description of the extension in store.
+	MetaDescription ConfigTranslated[string] `yaml:"meta_description" jsonschema:"maxLength=185"`
 	// Specifies the description of the extension in store.
 	Description ConfigTranslated[string] `yaml:"description"`
 	// Installation manual of the extension in store.

--- a/extension/shopware-extension-schema.json
+++ b/extension/shopware-extension-schema.json
@@ -3,6 +3,38 @@
   "$id": "https://github.com/shopware/shopware-cli/extension/config",
   "$ref": "#/$defs/Config",
   "$defs": {
+    "ChangelogConfig": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://github.com/shopware/shopware-cli/internal/changelog/config",
+      "$ref": "#/$defs/Config",
+      "$defs": {
+        "Config": {
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Specifies whether the changelog should be generated."
+            },
+            "pattern": {
+              "type": "string",
+              "description": "Specifies the pattern to match the commits."
+            },
+            "template": {
+              "type": "string",
+              "description": "Specifies the template to use for the changelog."
+            },
+            "variables": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object",
+              "description": "Specifies the variables to use for the changelog."
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      }
+    },
     "Config": {
       "properties": {
         "store": {
@@ -14,7 +46,7 @@
           "description": "Build is the build configuration of the extension."
         },
         "changelog": {
-          "$ref": "#/$defs/Config",
+          "$ref": "#/$defs/ChangelogConfig",
           "description": "Changelog is the changelog configuration of the extension."
         },
         "validation": {

--- a/extension/shopware-extension-schema.json
+++ b/extension/shopware-extension-schema.json
@@ -63,7 +63,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "Configuration for zipping"
+      "description": "Configuration for zipping."
     },
     "ConfigBuildZipAssets": {
       "properties": {
@@ -316,6 +316,14 @@
         "automatic_bugfix_version_compatibility": {
           "type": "boolean",
           "description": "Specifies whether the extension should automatically be set compatible with Shopware bugfix versions."
+        },
+        "meta_title": {
+          "$ref": "#/$defs/ConfigTranslated[string]",
+          "description": "Specifies the meta title of the extension in store."
+        },
+        "meta_description": {
+          "$ref": "#/$defs/ConfigTranslated[string]",
+          "description": "Specifies the meta description of the extension in store."
         },
         "description": {
           "$ref": "#/$defs/ConfigTranslated[string]",

--- a/internal/account-api/producer.go
+++ b/internal/account-api/producer.go
@@ -269,6 +269,8 @@ type Extension struct {
 		ShortDescription   string       `json:"shortDescription"`
 		Highlights         string       `json:"highlights"`
 		Features           string       `json:"features"`
+		MetaTitle          string       `json:"metaTitle"`
+		MetaDescription    string       `json:"metaDescription"`
 		Tags               []StoreTag   `json:"tags"`
 		Videos             []StoreVideo `json:"videos"`
 		Faqs               []StoreFaq   `json:"faqs"`
@@ -363,7 +365,6 @@ func (e ProducerEndpoint) GetSoftwareVersions(ctx context.Context, generation st
 	var versions SoftwareVersionList
 
 	err = json.Unmarshal(body, &versions)
-
 	if err != nil {
 		return nil, fmt.Errorf(errorFormat, err)
 	}
@@ -483,7 +484,6 @@ func (e ProducerEndpoint) GetExtensionGeneralInfo(ctx context.Context) (*Extensi
 	var info *ExtensionGeneralInformation
 
 	err = json.Unmarshal(body, &info)
-
 	if err != nil {
 		return nil, fmt.Errorf("shopware_versions: %v", err)
 	}

--- a/internal/account-api/producer_extension.go
+++ b/internal/account-api/producer_extension.go
@@ -189,7 +189,9 @@ func (e ProducerEndpoint) UpdateExtensionIcon(ctx context.Context, extensionId i
 		return fmt.Errorf(errorFormat, "extension icon must be 256x256")
 	}
 
-	iconFile.Seek(0, io.SeekStart)
+	if _, err = iconFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf(errorFormat, err)
+	}
 
 	if _, err = io.Copy(fileWritter, iconFile); err != nil {
 		return fmt.Errorf(errorFormat, err)

--- a/internal/account-api/producer_extension.go
+++ b/internal/account-api/producer_extension.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"image"
 	"io"
 	"mime/multipart"
 	"os"
@@ -163,23 +164,34 @@ func (e ProducerEndpoint) UpdateExtensionBinaryFile(ctx context.Context, extensi
 	return err
 }
 
-func (e ProducerEndpoint) UpdateExtensionIcon(ctx context.Context, extensionId int, iconFile string) error {
+func (e ProducerEndpoint) UpdateExtensionIcon(ctx context.Context, extensionId int, iconFilePath string) error {
 	errorFormat := "UpdateExtensionIcon: %v"
 
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 
-	fileWritter, err := w.CreateFormFile("file", filepath.Base(iconFile))
+	fileWritter, err := w.CreateFormFile("file", filepath.Base(iconFilePath))
 	if err != nil {
 		return fmt.Errorf(errorFormat, err)
 	}
 
-	zipFile, err := os.Open(iconFile)
+	iconFile, err := os.Open(iconFilePath)
 	if err != nil {
 		return fmt.Errorf(errorFormat, err)
 	}
 
-	if _, err = io.Copy(fileWritter, zipFile); err != nil {
+	imageConfig, _, err := image.DecodeConfig(iconFile)
+	if err != nil {
+		return fmt.Errorf(errorFormat, err)
+	}
+
+	if imageConfig.Width != 256 || imageConfig.Height != 256 {
+		return fmt.Errorf(errorFormat, "extension icon must be 256x256")
+	}
+
+	iconFile.Seek(0, io.SeekStart)
+
+	if _, err = io.Copy(fileWritter, iconFile); err != nil {
 		return fmt.Errorf(errorFormat, err)
 	}
 

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -24,8 +24,6 @@ type Config struct {
 	Template string `yaml:"template,omitempty"`
 	// Specifies the variables to use for the changelog.
 	Variables map[string]string `yaml:"variables,omitempty"`
-	// Specifies whether the AI should be enabled.
-	AiEnabled bool `yaml:"ai_enabled,omitempty"`
 	// Specifies the URL of the VCS repository.
 	VCSURL string `yaml:"-"`
 }

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -16,12 +16,18 @@ import (
 var defaultChangelogTpl string
 
 type Config struct {
-	Enabled   bool              `yaml:"enabled"`
-	Pattern   string            `yaml:"pattern,omitempty"`
-	Template  string            `yaml:"template,omitempty"`
+	// Specifies whether the changelog should be generated.
+	Enabled bool `yaml:"enabled"`
+	// Specifies the pattern to match the commits.
+	Pattern string `yaml:"pattern,omitempty"`
+	// Specifies the template to use for the changelog.
+	Template string `yaml:"template,omitempty"`
+	// Specifies the variables to use for the changelog.
 	Variables map[string]string `yaml:"variables,omitempty"`
-	AiEnabled bool              `yaml:"ai_enabled,omitempty"`
-	VCSURL    string            `yaml:"-"`
+	// Specifies whether the AI should be enabled.
+	AiEnabled bool `yaml:"ai_enabled,omitempty"`
+	// Specifies the URL of the VCS repository.
+	VCSURL string `yaml:"-"`
 }
 
 type Commit struct {


### PR DESCRIPTION
This update introduces new fields for meta title and description in the extension configuration, allowing for better SEO and presentation in the store. The changes include:
- Added `MetaTitle` and `MetaDescription` fields to `ConfigStore`.
- Updated the account producer extension info pull and push commands to handle these new fields.
- Enhanced the `Extension` struct to include meta title and description for better data handling.