### PR TITLE
Allow parsing repositories when given as map/dictionary/associative array

### DIFF
--- a/internal/packagist/composer.go
+++ b/internal/packagist/composer.go
@@ -48,6 +48,31 @@ type ComposerJsonRepository struct {
 
 type ComposerJsonRepositories []ComposerJsonRepository
 
+func (e *ComposerJsonRepositories) UnmarshalJSON(data []byte) error {
+	var asMap map[string]ComposerJsonRepository
+
+	if err := json.Unmarshal(data, &asMap); err == nil {
+		*e = ComposerJsonRepositories{}
+
+		for _, v := range asMap {
+			*e = append(*e, v)
+		}
+
+		return nil
+	}
+
+	var asArray []ComposerJsonRepository
+	err := json.Unmarshal(data, &asArray)
+
+	if err != nil {
+		return err
+	}
+
+	*e = asArray
+
+	return nil
+}
+
 func (r *ComposerJsonRepositories) HasRepository(url string) bool {
 	for _, repository := range *r {
 		if repository.URL == url {

--- a/internal/packagist/composer_test.go
+++ b/internal/packagist/composer_test.go
@@ -182,3 +182,65 @@ func TestReadComposerJson(t *testing.T) {
 		assert.Nil(t, composer)
 	})
 }
+
+func TestReadComposerJsonDifferentRepositoryWritings(t *testing.T) {
+	t.Run("repository list", func(t *testing.T) {
+		tempDir := t.TempDir()
+		composerFile := filepath.Join(tempDir, "composer.json")
+
+		var content = `
+{
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/shopware/platform"
+		},
+		{
+			"type": "path",
+			"url": "custom/plugins"
+		}
+	]
+}
+`
+		err := os.WriteFile(composerFile, []byte(content), 0o644)
+		assert.NoError(t, err)
+
+		composer, err := ReadComposerJson(composerFile)
+		assert.NoError(t, err)
+		assert.Equal(t, composerFile, composer.path)
+		assert.Equal(t, "vcs", composer.Repositories[0].Type)
+		assert.Equal(t, "https://github.com/shopware/platform", composer.Repositories[0].URL)
+		assert.Equal(t, "path", composer.Repositories[1].Type)
+		assert.Equal(t, "custom/plugins", composer.Repositories[1].URL)
+	})
+
+	t.Run("repository map", func(t *testing.T) {
+		tempDir := t.TempDir()
+		composerFile := filepath.Join(tempDir, "composer.json")
+
+		var content = `
+{
+	"repositories": {
+		"remote": {
+			"type": "vcs",
+			"url": "https://github.com/shopware/platform"
+		},
+		"local": {
+			"type": "path",
+			"url": "custom/plugins"
+		}
+	}
+}
+`
+		err := os.WriteFile(composerFile, []byte(content), 0o644)
+		assert.NoError(t, err)
+
+		composer, err := ReadComposerJson(composerFile)
+		assert.NoError(t, err)
+		assert.Equal(t, composerFile, composer.path)
+		assert.Equal(t, "vcs", composer.Repositories[0].Type)
+		assert.Equal(t, "https://github.com/shopware/platform", composer.Repositories[0].URL)
+		assert.Equal(t, "path", composer.Repositories[1].Type)
+		assert.Equal(t, "custom/plugins", composer.Repositories[1].URL)
+	})
+}


### PR DESCRIPTION
Projects, that have repositories configured as map/dictionary/associative array, cannot be processed with extension-verifier. So do whatever you have to do to rebuild extension-verifier that builds upon this code :D 