### PR TITLE
feat: Add only-custom-static-extensions

### DIFF
--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -113,7 +113,6 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	onlyExtensions, _ := cmd.PersistentFlags().GetString("only-extensions")
 	skipExtensions, _ := cmd.PersistentFlags().GetString("skip-extensions")
 	onlyCustomStatic, _ := cmd.PersistentFlags().GetBool("only-custom-static-extensions")
-	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	if onlyExtensions != "" && skipExtensions != "" {
 		return nil, fmt.Errorf("only-extensions and skip-extensions cannot be used together")
@@ -121,53 +120,45 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 
 	if onlyCustomStatic {
 		logging.FromContext(cmd.Context()).Infof("Only including extensions from custom/static-plugins directory")
-		if verbose {
-			logging.FromContext(cmd.Context()).Infof("Found %d total extensions before filtering", len(sources))
-			for _, s := range sources {
-				logging.FromContext(cmd.Context()).Infof("Extension: %s, Path: %s", s.Name, s.Path)
-			}
+		logging.FromContext(cmd.Context()).Debugf("Found %d total extensions before filtering", len(sources))
+		for _, s := range sources {
+			logging.FromContext(cmd.Context()).Debugf("Extension: %s, Path: %s", s.Name, s.Path)
 		}
 
 		sources = slices.DeleteFunc(sources, func(s asset.Source) bool {
 			// First try to resolve any symlinks
 			resolvedPath, err := filepath.EvalSymlinks(s.Path)
 			if err != nil {
-				if verbose {
-					logging.FromContext(cmd.Context()).Errorf("Failed to resolve symlink for %s: %v", s.Path, err)
-				}
+				logging.FromContext(cmd.Context()).Errorf("Failed to resolve symlink for %s: %v", s.Path, err)
 				return true
 			}
 
 			absPath, err := filepath.Abs(resolvedPath)
 			if err != nil {
-				if verbose {
-					logging.FromContext(cmd.Context()).Errorf("Failed to get absolute path for %s: %v", resolvedPath, err)
-				}
+				logging.FromContext(cmd.Context()).Errorf("Failed to get absolute path for %s: %v", resolvedPath, err)
 				return true
 			}
 
-			if verbose {
-				logging.FromContext(cmd.Context()).Infof("Extension %s: Original path: %s, Resolved absolute path: %s", s.Name, s.Path, absPath)
-			}
+			logging.FromContext(cmd.Context()).Debugf("Extension %s: Original path: %s, Resolved absolute path: %s", s.Name, s.Path, absPath)
 
-			isCustomStatic := strings.Contains(absPath, string(filepath.Separator)+"custom"+string(filepath.Separator)+"static-plugins"+string(filepath.Separator)) ||
-				strings.HasSuffix(absPath, string(filepath.Separator)+"custom"+string(filepath.Separator)+"static-plugins")
-			if verbose && !isCustomStatic {
-				logging.FromContext(cmd.Context()).Infof("Excluding %s as it's not in custom/static-plugins", s.Name)
+			customStaticDir := filepath.Join("custom", "static-plugins")
+
+			isCustomStatic := strings.Contains(absPath, customStaticDir) || strings.HasSuffix(absPath, customStaticDir)
+
+			if !isCustomStatic {
+				logging.FromContext(cmd.Context()).Debugf("Excluding %s as it's not in custom/static-plugins", s.Name)
 			}
 			return !isCustomStatic
 		})
 
-		if verbose {
-			logging.FromContext(cmd.Context()).Infof("Found %d custom/static extensions after filtering", len(sources))
-			for _, s := range sources {
-				logging.FromContext(cmd.Context()).Infof("Included extension: %s, Path: %s", s.Name, s.Path)
-			}
-		} else {
-			logging.FromContext(cmd.Context()).Infof("Included extensions:")
-			for _, s := range sources {
-				logging.FromContext(cmd.Context()).Infof("  - %s", s.Name)
-			}
+		logging.FromContext(cmd.Context()).Debugf("Found %d custom/static extensions after filtering", len(sources))
+		for _, s := range sources {
+			logging.FromContext(cmd.Context()).Debugf("Included extension: %s, Path: %s", s.Name, s.Path)
+		}
+
+		logging.FromContext(cmd.Context()).Debugf("Included extensions:")
+		for _, s := range sources {
+			logging.FromContext(cmd.Context()).Debugf("  - %s", s.Name)
 		}
 	}
 

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -79,5 +79,4 @@ func init() {
 	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectAdminBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectAdminBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
-	projectAdminBuildCmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -78,4 +78,6 @@ func init() {
 	projectAdminBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
 	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectAdminBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
+	projectAdminBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
+	projectAdminBuildCmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -14,7 +14,6 @@ import (
 var projectStorefrontBuildCmd = &cobra.Command{
 	Use:   "storefront-build [path]",
 	Short: "Builds the Storefront",
-	Long:  "Builds the Storefront. Use --only-custom-static-extensions to only build extensions from custom/static-plugins directory.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error
@@ -80,5 +79,4 @@ func init() {
 	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectStorefrontBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
-	projectStorefrontBuildCmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -14,6 +14,7 @@ import (
 var projectStorefrontBuildCmd = &cobra.Command{
 	Use:   "storefront-build [path]",
 	Short: "Builds the Storefront",
+	Long:  "Builds the Storefront. Use --only-custom-static-extensions to only build extensions from custom/static-plugins directory.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error
@@ -78,4 +79,6 @@ func init() {
 	projectStorefrontBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
 	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectStorefrontBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
+	projectStorefrontBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
+	projectStorefrontBuildCmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"os"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -27,13 +28,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute(ctx context.Context) {
-	verbose := false
-
-	if err := rootCmd.ParseFlags(os.Args); err == nil {
-		verbose, _ = rootCmd.PersistentFlags().GetBool("verbose")
-	}
-
-	ctx = logging.WithLogger(ctx, logging.NewLogger(verbose))
+	ctx = logging.WithLogger(ctx, logging.NewLogger(slices.Contains(os.Args, "--verbose")))
 	accountApi.SetUserAgent("shopware-cli/" + version)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {


### PR DESCRIPTION
closes #524

by cursor.AI

Adds a switch --only-custom-static-extensions to only build those plugins coming from custom/static-plugins and usually need to be built in dev