### PR TITLE
Ensure cobra can validate the need for the path argument by adding more command info

### DIFF
--- a/cmd/extension/extension_fix.go
+++ b/cmd/extension/extension_fix.go
@@ -22,9 +22,9 @@ var extensionFixCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		allowNonGit, _ := cmd.Flags().GetBool("allow-non-git")
-		gitPath := filepath.Join(args[0], ".git")
+
 		if !allowNonGit {
-			if stat, err := os.Stat(gitPath); err != nil || !stat.IsDir() {
+			if stat, err := os.Stat(filepath.Join(args[0], ".git")); err != nil || !stat.IsDir() {
 				return fmt.Errorf("provided folder is not a git repository. Use --allow-non-git flag to run anyway")
 			}
 		}

--- a/cmd/extension/extension_fix.go
+++ b/cmd/extension/extension_fix.go
@@ -14,8 +14,9 @@ import (
 )
 
 var extensionFixCmd = &cobra.Command{
-	Use:   "fix",
+	Use:   "fix [path]",
 	Short: "Fix an extension",
+	Args:  cobra.MinimumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},


### PR DESCRIPTION
This will improve the usage of the extension fix command when one is missing the argument. The argument was not listed by the help instruction so it was easy to forget.