### PR TITLE
Ensure HTML attributes escape quotes to prevent syntax errors

### DIFF
--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -25,7 +25,7 @@ func (a Attribute) Dump(indent int) string {
 	if a.Value == "" {
 		return builder.String() + a.Key
 	}
-	return builder.String() + a.Key + "=\"" + a.Value + "\""
+	return builder.String() + a.Key + "=\"" + strings.ReplaceAll(a.Value, "\"", "\\\"") + "\""
 }
 
 // Node is the interface for nodes in our AST.
@@ -1016,13 +1016,21 @@ func (p *Parser) parseAttrValue() string {
 		start := p.pos
 		// Continue until we find a closing quote or reach the end
 		for p.pos < p.length && p.current() != '"' {
+			// skip when escaped
+			if p.current() == '\\' && (p.pos+1) < p.length {
+				p.pos++
+			}
+
 			p.pos++
 		}
+
 		val := p.input[start:p.pos]
+
 		if p.pos < p.length && p.current() == '"' {
 			p.pos++ // skip closing "
 		}
-		return val
+
+		return strings.ReplaceAll(val, "\\\"", "\"")
 	}
 	// Allow unquoted values.
 	start := p.pos

--- a/internal/html/testdata/39-attributes-escaped-content.txt
+++ b/internal/html/testdata/39-attributes-escaped-content.txt
@@ -1,0 +1,3 @@
+<mt-select :options="[{\"label\":$tc('admin'),\"value\":\"admin\"}]"></mt-select>
+-----
+<mt-select :options="[{\"label\":$tc('admin'),\"value\":\"admin\"}]"></mt-select>

--- a/internal/verifier/admintwiglinter/fix_select_field_test.go
+++ b/internal/verifier/admintwiglinter/fix_select_field_test.go
@@ -36,7 +36,7 @@ func TestSelectFieldFixer(t *testing.T) {
     <option value="2">Option 2</option>
 </sw-select-field>`,
 			after: `<mt-select
-    :options="[{"label":"Option 1","value":"1"},{"label":"Option 2","value":"2"}]"
+    :options="[{\"label\":\"Option 1\",\"value\":\"1\"},{\"label\":\"Option 2\",\"value\":\"2\"}]"
 ></mt-select>`,
 		},
 		{


### PR DESCRIPTION
When one has quotes in attribute values the output HTML is not understood by different tools. So I start to escape quotes. This is important for other pull requests I will make :D 