### PR TITLE
Use correct escape strategy by encoding entities

### DIFF
--- a/internal/html/testdata/39-attributes-escaped-content.txt
+++ b/internal/html/testdata/39-attributes-escaped-content.txt
@@ -1,3 +1,5 @@
-<mt-select :options="[{\"label\":$tc('admin'),\"value\":\"admin\"}]"></mt-select>
+<mt-select :options="[{&quot;label&quot;:$tc('admin'),&quot;value&quot;:&quot;admin&quot;}]"></mt-select>
 -----
-<mt-select :options="[{\"label\":$tc('admin'),\"value\":\"admin\"}]"></mt-select>
+<mt-select
+    :options="[{&quot;label&quot;:$tc('admin'),&quot;value&quot;:&quot;admin&quot;}]"
+></mt-select>

--- a/internal/verifier/admintwiglinter/fix_select_field_test.go
+++ b/internal/verifier/admintwiglinter/fix_select_field_test.go
@@ -36,7 +36,7 @@ func TestSelectFieldFixer(t *testing.T) {
     <option value="2">Option 2</option>
 </sw-select-field>`,
 			after: `<mt-select
-    :options="[{\"label\":\"Option 1\",\"value\":\"1\"},{\"label\":\"Option 2\",\"value\":\"2\"}]"
+    :options="[{&quot;label&quot;:&quot;Option 1&quot;,&quot;value&quot;:&quot;1&quot;},{&quot;label&quot;:&quot;Option 2&quot;,&quot;value&quot;:&quot;2&quot;}]"
 ></mt-select>`,
 		},
 		{


### PR DESCRIPTION
This is not a full-featured implementation but it will solve a lot of cases without requiring html/template