### PR TITLE
fix(project): change config merge priority

### DIFF
--- a/shop/config.go
+++ b/shop/config.go
@@ -309,12 +309,10 @@ func ReadConfig(fileName string, allowFallback bool) (*Config, error) {
 				return nil, fmt.Errorf("error while reading included config: %s", err.Error())
 			}
 
-			err = mergo.Merge(additionalConfig, config, mergo.WithOverride, mergo.WithSliceDeepCopy)
+			err = mergo.Merge(config, additionalConfig, mergo.WithOverride, mergo.WithSliceDeepCopy)
 			if err != nil {
 				return nil, fmt.Errorf("error while merging included config: %s", err.Error())
 			}
-
-			config = additionalConfig
 		}
 	}
 

--- a/shop/config_test.go
+++ b/shop/config_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestConfigMerging(t *testing.T) {
 	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
 
 	t.Chdir(tmpDir)
 
@@ -48,4 +47,6 @@ sync:
 	assert.NotNil(t, config.Sync.Config)
 	assert.Len(t, config.Sync.Config, 1)
 	assert.Equal(t, "xyz.nuonic.dev", config.Sync.Config[0].Settings["core.store.licenseHost"])
+
+	assert.NoError(t, os.RemoveAll(tmpDir))
 }

--- a/shop/config_test.go
+++ b/shop/config_test.go
@@ -1,0 +1,51 @@
+package shop
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigMerging(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+
+	t.Chdir(tmpDir)
+
+	baseConfig := []byte(`
+admin_api:
+  client_id: ${SHOPWARE_CLI_CLIENT_ID}
+  client_secret: ${SHOPWARE_CLI_CLIENT_SECRET}
+dump:
+  where:
+    customer: "email LIKE '%@nuonic.de' OR email LIKE '%@xyz.com'"
+  nodata:
+    - promotion
+`)
+
+	stagingConfig := []byte(`
+url: https://xyz.nuonic.dev
+include:
+  - base.yml
+sync:
+  config:
+    - settings:
+        core.store.licenseHost: xyz.nuonic.dev
+`)
+
+	baseFilePath := path.Join(tmpDir, "base.yml")
+	stagingFilePath := path.Join(tmpDir, "staging.yml")
+
+	assert.NoError(t, os.WriteFile(baseFilePath, baseConfig, 0644))
+	assert.NoError(t, os.WriteFile(stagingFilePath, stagingConfig, 0644))
+
+	config, err := ReadConfig(stagingFilePath, false)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, config.Sync)
+	assert.NotNil(t, config.Sync.Config)
+	assert.Len(t, config.Sync.Config, 1)
+	assert.Equal(t, "xyz.nuonic.dev", config.Sync.Config[0].Settings["core.store.licenseHost"])
+}


### PR DESCRIPTION
Having the following configurations:

File: **shopware-project.staging.yml**
```yaml,.shopware-project.staging.yml
url: https://xyz.nuonic.dev
include:
    - .shopware-project.base.yml
sync:
    config:
        - settings:
              core.store.licenseHost: xyz.nuonic.dev

```

File: **shopware-project.base.yml**
```yaml,.shopware-project.base.yml
admin_api:
    client_id: ${SHOPWARE_CLI_CLIENT_ID}
    client_secret: ${SHOPWARE_CLI_CLIENT_SECRET}
dump:
    where:
        customer: "email LIKE '%@nuonic.de' OR email LIKE '%@xyz.com'"
    nodata:
        - promotion
        - promotion_cart_rule
        - promotion_discount
        - promotion_discount_prices
        - promotion_discount_rule
        - promotion_individual_code
        - promotion_order_rule
        - promotion_persona_customer
        - promotion_persona_rule
        - promotion_sales_channel
        - promotion_setgroup
        - promotion_setgroup_rule
        - promotion_translation
        - newsletter_recipient
        - order
        - order_address
        - order_customer
        - order_delivery
        - order_delivery_position
        - order_line_item
        - order_line_item_download
        - order_tag
        - order_transaction
        - order_transaction_capture
        - order_transaction_capture_refund
        - order_transaction_capture_refund_position
    rewrite:
        product_review:
            email: "faker.Internet.Email()"
        log_entry:
            provider: ""
```

Running any `shopware-cli project ... --project-config shopware-project.staging.yml`

The current merging order removes `sync.config[0]` from the merged config as it was `nil` in my `shopware-project.base.yml`. Changing the config merging order fixes this behavior and gives the topmost config precedence.

@shyim maybe there is a better fix for this (smth like `mergo.WithOverwriteWithEmptyValue`)