### PR TITLE
fix: Do not fail ZIP file generation if extension version cannot be determined

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -199,7 +199,7 @@ var extensionZipCmd = &cobra.Command{
 		}
 
 		// Generate checksums.json file before creating the zip
-		if err := extension.GenerateChecksumJSON(extDir, ext); err != nil {
+		if err := extension.GenerateChecksumJSON(cmd.Context(), extDir, ext); err != nil {
 			return fmt.Errorf("generate checksum.json: %w", err)
 		}
 

--- a/extension/zip.go
+++ b/extension/zip.go
@@ -170,11 +170,12 @@ type ChecksumJSON struct {
 }
 
 // GenerateChecksumJSON creates a checksum.json file in the given folder
-func GenerateChecksumJSON(baseFolder string, ext Extension) error {
-	// Get extension version
+func GenerateChecksumJSON(ctx context.Context, baseFolder string, ext Extension) error {
 	version, err := ext.GetVersion()
 	if err != nil {
-		return fmt.Errorf("get extension version: %w", err)
+		logging.FromContext(ctx).Info("Could not determine extension version skipping checksum.json generation: ", err)
+
+		return nil
 	}
 
 	ignores := ext.GetExtensionConfig().Build.Zip.Checksum.Ignore

--- a/extension/zip_test.go
+++ b/extension/zip_test.go
@@ -108,7 +108,7 @@ func TestGenerateChecksumJSON(t *testing.T) {
 	}
 
 	// Generate checksum.json
-	err := GenerateChecksumJSON(extensionDir, mockExt)
+	err := GenerateChecksumJSON(t.Context(), extensionDir, mockExt)
 	require.NoError(t, err, "GenerateChecksumJSON should not return an error")
 
 	// Verify checksum.json was created
@@ -165,7 +165,7 @@ func TestGenerateChecksumJSONIgnores(t *testing.T) {
 		"src/Resources/test.txt",
 	}
 
-	err := GenerateChecksumJSON(extensionDir, mockExt)
+	err := GenerateChecksumJSON(t.Context(), extensionDir, mockExt)
 	require.NoError(t, err, "GenerateChecksumJSON should not return an error")
 
 	// Verify checksum.json was created


### PR DESCRIPTION
in the generation of the checksum.json file