### PR TITLE
feat: add support for keeping specified node_modules in the final build

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -116,6 +116,7 @@ var projectCI = &cobra.Command{
 			DisableStorefrontBuild:       shopCfg.Build.DisableStorefrontBuild,
 			ForceExtensionBuild:          convertForceExtensionBuild(shopCfg.Build.ForceExtensionBuild),
 			ContributeProject:            shopCfg.Build.ForceAdminBuild,
+			KeepNodeModules:              shopCfg.Build.KeepNodeModules,
 		}
 
 		if err := extension.BuildAssetsForExtensions(cmd.Context(), sources, assetCfg); err != nil {

--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -44,6 +45,7 @@ type AssetBuildConfig struct {
 	NPMForceInstall              bool
 	ContributeProject            bool
 	ForceExtensionBuild          []string
+	KeepNodeModules              []string
 }
 
 func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, assetConfig AssetBuildConfig) error { // nolint:gocyclo
@@ -83,6 +85,21 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 	}
 
 	nodeInstallSection.End(ctx)
+
+	log.Println(assetConfig.KeepNodeModules)
+
+	log.Println(paths)
+	if shopwareRoot != "" && len(assetConfig.KeepNodeModules) > 0 {
+		paths = slices.DeleteFunc(paths, func(path string) bool {
+			rel, err := filepath.Rel(shopwareRoot, path)
+			if err != nil {
+				return false
+			}
+
+			return slices.Contains(assetConfig.KeepNodeModules, rel)
+		})
+	}
+	log.Println(paths)
 
 	defer deletePaths(ctx, paths...)
 

--- a/shop/config.go
+++ b/shop/config.go
@@ -52,6 +52,8 @@ type ConfigBuild struct {
 	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
 	// When enabled, the shopware admin will be built
 	ForceAdminBuild bool `yaml:"force_admin_build,omitempty"`
+	// Keep following node_modules in the final build
+	KeepNodeModules []string `yaml:"keep_node_modules,omitempty"`
 }
 
 // ConfigBuildExtension defines the configuration for forcing extension builds.

--- a/shop/shopware-project-schema.json
+++ b/shop/shopware-project-schema.json
@@ -116,6 +116,13 @@
         "force_admin_build": {
           "type": "boolean",
           "description": "When enabled, the shopware admin will be built"
+        },
+        "keep_node_modules": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Keep following node_modules in the final build"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
exampe config
```
build:
  keep_node_modules:
    - custom/plugins/FroshProductCompare/src/Resources/app/storefront/node_modules
```