### PR TITLE
fix: Deprecate project config push/pull instead of extension info push/pull

### DIFF
--- a/cmd/account/account_producer_extension_info_pull.go
+++ b/cmd/account/account_producer_extension_info_pull.go
@@ -20,10 +20,9 @@ import (
 
 var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 	Use:   "pull [path]",
-	Short: "[Deprecated] Generates local store configuration from account data",
+	Short: "Generates local store configuration from account data",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logging.FromContext(cmd.Context()).Warnf("This command is deprecated and will be removed in the future. Please use Fixture Bundle instead https://developer.shopware.com/docs/resources/tooling/fixture-bundle/")
 		absolutePath, err := filepath.Abs(args[0])
 		if err != nil {
 			return fmt.Errorf("cannot open file: %w", err)

--- a/cmd/account/account_producer_extension_info_push.go
+++ b/cmd/account/account_producer_extension_info_push.go
@@ -20,11 +20,9 @@ import (
 
 var accountCompanyProducerExtensionInfoPushCmd = &cobra.Command{
 	Use:   "push [zip or path]",
-	Short: "[Deprecate] Update store information of extension",
+	Short: "Update store information of extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logging.FromContext(cmd.Context()).Warnf("This command is deprecated and will be removed in the future. Please use Fixture Bundle instead https://developer.shopware.com/docs/resources/tooling/fixture-bundle/")
-
 		absolutePath, err := filepath.Abs(args[0])
 		if err != nil {
 			return fmt.Errorf("cannot open file: %w", err)

--- a/cmd/project/project_config_pull.go
+++ b/cmd/project/project_config_pull.go
@@ -13,8 +13,10 @@ import (
 
 var projectConfigPullCmd = &cobra.Command{
 	Use:   "pull",
-	Short: "Synchronizes your shop config to local",
+	Short: "[Deprecated] Synchronizes your shop config to local",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		logging.FromContext(cmd.Context()).Warnf("This command is deprecated and will be removed in the future. Please use Fixture Bundle instead https://developer.shopware.com/docs/resources/tooling/fixture-bundle/")
+
 		var cfg *shop.Config
 		var err error
 

--- a/cmd/project/project_config_push.go
+++ b/cmd/project/project_config_push.go
@@ -13,8 +13,10 @@ import (
 
 var projectConfigPushCmd = &cobra.Command{
 	Use:   "push",
-	Short: "Synchronizes your local config to the external shop",
+	Short: "[Deprecated] Synchronizes your local config to the external shop",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		logging.FromContext(cmd.Context()).Warnf("This command is deprecated and will be removed in the future. Please use Fixture Bundle instead https://developer.shopware.com/docs/resources/tooling/fixture-bundle/")
+
 		logFormat := "Payload: %s"
 
 		var cfg *shop.Config


### PR DESCRIPTION
Relates #535