### PR TITLE
feat/implement only static extensions watcher

### DIFF
--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -108,6 +108,11 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 		}
 
 		sources = slices.DeleteFunc(sources, func(s asset.Source) bool {
+			// We want to always include the Storefront extension, otherwise the watchers have problems
+			if s.Name == "Storefront" {
+				return false
+			}
+
 			// First try to resolve any symlinks
 			resolvedPath, err := filepath.EvalSymlinks(s.Path)
 			if err != nil {
@@ -147,6 +152,11 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	if onlyExtensions == "" && skipExtensions == "" && !onlyCustomStatic {
 		logging.FromContext(cmd.Context()).Infof("Excluding extensions based on project config: %s", strings.Join(shopCfg.Build.ExcludeExtensions, ", "))
 		sources = slices.DeleteFunc(sources, func(s asset.Source) bool {
+			// We want to always include the Storefront extension, otherwise the watchers have problems
+			if s.Name == "Storefront" {
+				return false
+			}
+
 			return slices.Contains(shopCfg.Build.ExcludeExtensions, s.Name)
 		})
 	}
@@ -154,11 +164,21 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	if onlyExtensions != "" {
 		logging.FromContext(cmd.Context()).Infof("Only including extensions: %s", onlyExtensions)
 		sources = slices.DeleteFunc(sources, func(s asset.Source) bool {
+			// We want to always include the Storefront extension, otherwise the watchers have problems
+			if s.Name == "Storefront" {
+				return false
+			}
+
 			return !slices.Contains(strings.Split(onlyExtensions, ","), s.Name)
 		})
 	} else if skipExtensions != "" {
 		logging.FromContext(cmd.Context()).Infof("Excluding extensions: %s", skipExtensions)
 		sources = slices.DeleteFunc(sources, func(s asset.Source) bool {
+			// We want to always include the Storefront extension, otherwise the watchers have problems
+			if s.Name == "Storefront" {
+				return false
+			}
+
 			return slices.Contains(strings.Split(skipExtensions, ","), s.Name)
 		})
 	}

--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -63,30 +63,12 @@ func findClosestShopwareProject() (string, error) {
 }
 
 func filterAndWritePluginJson(cmd *cobra.Command, projectRoot string, shopCfg *shop.Config) error {
-	sources, err := extension.DumpAndLoadAssetSourcesOfProject(cmd.Context(), projectRoot, shopCfg)
+	sources, err := filterAndGetSources(cmd, projectRoot, shopCfg)
 	if err != nil {
 		return err
 	}
 
 	cfgs := extension.BuildAssetConfigFromExtensions(cmd.Context(), sources, extension.AssetBuildConfig{})
-
-	onlyExtensions, _ := cmd.PersistentFlags().GetString("only-extensions")
-	skipExtensions, _ := cmd.PersistentFlags().GetString("skip-extensions")
-
-	if onlyExtensions != "" && skipExtensions != "" {
-		return fmt.Errorf("only-extensions and skip-extensions cannot be used together")
-	}
-
-	if onlyExtensions != "" {
-		cfgs = cfgs.Only(strings.Split(onlyExtensions, ","))
-	}
-
-	if skipExtensions != "" {
-		cfgs = cfgs.Not(strings.Split(skipExtensions, ","))
-	} else {
-		logging.FromContext(cmd.Context()).Infof("Excluding extensions based on project config: %s", strings.Join(shopCfg.Build.ExcludeExtensions, ", "))
-		cfgs = cfgs.Not(shopCfg.Build.ExcludeExtensions)
-	}
 
 	if _, err := extension.InstallNodeModulesOfConfigs(cmd.Context(), cfgs, false); err != nil {
 		return err

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -83,4 +83,5 @@ func init() {
 	projectRootCmd.AddCommand(projectAdminWatchCmd)
 	projectAdminWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectAdminWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
+	projectAdminWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -89,4 +89,5 @@ func init() {
 	projectRootCmd.AddCommand(projectStorefrontWatchCmd)
 	projectStorefrontWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
 	projectStorefrontWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
+	projectStorefrontWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }


### PR DESCRIPTION
- **feat: add flag to only build custom/static-plugins extensions in project watch commands**
- **feat: always include Storefront extension in source filtering to prevent watcher issues**
