### PR TITLE
Refactor validation logic to use new validation package

### DIFF
--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -117,7 +117,7 @@ var extensionValidateCmd = &cobra.Command{
 			return err
 		}
 
-		return verifier.DoCheckReport(result.RemoveByIdentifier(toolCfg.ValidationIgnores), reportingFormat)
+		return verifier.DoCheckReport(result.RemoveByIdentifier(toolCfg.ValidationIgnores).(*verifier.Check), reportingFormat)
 	},
 }
 

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shopware/shopware-cli/extension"
+	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -151,7 +152,7 @@ var extensionZipCmd = &cobra.Command{
 		}
 
 		if cmd.Flags().Changed("overwrite-app-backend-secret") {
-			extCfg.Validation.Ignore = append(extCfg.Validation.Ignore, extension.ConfigValidationIgnoreItem{Identifier: "metadata.setup"})
+			extCfg.Validation.Ignore = append(extCfg.Validation.Ignore, validation.ToolConfigIgnore{Identifier: "metadata.setup"})
 			if err := extCfg.Dump(extDir); err != nil {
 				return fmt.Errorf("dump extension config: %w", err)
 			}

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -89,7 +89,7 @@ var projectValidateCmd = &cobra.Command{
 			return err
 		}
 
-		return verifier.DoCheckReport(result.RemoveByIdentifier(toolCfg.ValidationIgnores), reportingFormat)
+		return verifier.DoCheckReport(result.RemoveByIdentifier(toolCfg.ValidationIgnores).(*verifier.Check), reportingFormat)
 	},
 }
 

--- a/extension/app_test.go
+++ b/extension/app_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
 const testAppManifest = `<?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
 	<meta>
@@ -129,11 +130,11 @@ func TestIconNotExists(t *testing.T) {
 	assert.Equal(t, "MyExampleApp", app.manifest.Meta.Name)
 	assert.Equal(t, "", app.manifest.Meta.Icon)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The extension icon Resources/config/plugin.png does not exist", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The extension icon Resources/config/plugin.png does not exist", check.Results[0].Message)
 }
 
 func TestAppNoLicense(t *testing.T) {
@@ -147,11 +148,11 @@ func TestAppNoLicense(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The element meta:license was not found in the manifest.xml", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The element meta:license was not found in the manifest.xml", check.Results[0].Message)
 }
 
 func TestAppNoCopyright(t *testing.T) {
@@ -165,11 +166,11 @@ func TestAppNoCopyright(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The element meta:copyright was not found in the manifest.xml", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The element meta:copyright was not found in the manifest.xml", check.Results[0].Message)
 }
 
 func TestAppNoAuthor(t *testing.T) {
@@ -183,11 +184,11 @@ func TestAppNoAuthor(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The element meta:author was not found in the manifest.xml", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The element meta:author was not found in the manifest.xml", check.Results[0].Message)
 }
 
 func TestAppHasSecret(t *testing.T) {
@@ -201,11 +202,11 @@ func TestAppHasSecret(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The xml element setup:secret is only for local development, please remove it. You can find your generated app secret on your extension detail page in the master data section. For more information see https://docs.shopware.com/en/shopware-platform-dev-en/app-system-guide/setup#authorisation", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The xml element setup:secret is only for local development, please remove it. You can find your generated app secret on your extension detail page in the master data section. For more information see https://docs.shopware.com/en/shopware-platform-dev-en/app-system-guide/setup#authorisation", check.Results[0].Message)
 }
 
 func TestIconExistsDefaultsPath(t *testing.T) {
@@ -223,10 +224,10 @@ func TestIconExistsDefaultsPath(t *testing.T) {
 	assert.Equal(t, "MyExampleApp", app.manifest.Meta.Name)
 	assert.Equal(t, "", app.manifest.Meta.Icon)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 0, len(ctx.errors))
+	assert.Equal(t, 0, len(check.Results))
 }
 
 func TestIconExistsDifferentPath(t *testing.T) {
@@ -242,10 +243,10 @@ func TestIconExistsDifferentPath(t *testing.T) {
 	assert.Equal(t, "MyExampleApp", app.manifest.Meta.Name)
 	assert.Equal(t, "app.png", app.manifest.Meta.Icon)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 0, len(ctx.errors))
+	assert.Equal(t, 0, len(check.Results))
 }
 
 func TestNoCompatibilityGiven(t *testing.T) {
@@ -291,11 +292,11 @@ func TestAppWithPHPFiles(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Contains(t, ctx.errors[0].Message, "Found unexpected PHP file")
+	assert.Equal(t, 1, len(check.Results))
+	assert.Contains(t, check.Results[0].Message, "Found unexpected PHP file")
 }
 
 func TestAppWithTwigFiles(t *testing.T) {
@@ -317,9 +318,9 @@ func TestAppWithTwigFiles(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	ctx := newValidationContext(app)
-	app.Validate(getTestContext(), ctx)
+	check := &testCheck{}
+	app.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Contains(t, ctx.errors[0].Message, "Twig files should be at")
+	assert.Equal(t, 1, len(check.Results))
+	assert.Contains(t, check.Results[0].Message, "Twig files should be at")
 }

--- a/extension/bundle.go
+++ b/extension/bundle.go
@@ -8,6 +8,8 @@ import (
 	"path"
 
 	"github.com/shyim/go-version"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type ShopwareBundle struct {
@@ -177,5 +179,6 @@ func (p ShopwareBundle) GetMetaData() *extensionMetadata {
 	}
 }
 
-func (p ShopwareBundle) Validate(c context.Context, ctx *ValidationContext) {
+func (p ShopwareBundle) Validate(c context.Context, check validation.Check) {
+	// ShopwareBundle validation is currently empty but signature updated to match interface
 }

--- a/extension/bundle_test.go
+++ b/extension/bundle_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
 func TestCreateBundleEmptyFolder(t *testing.T) {
 	dir := t.TempDir()
 
@@ -91,8 +92,8 @@ func TestCreateBundle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "1.0.0", version.String())
 
-	// does notthing
-	bundle.Validate(getTestContext(), &ValidationContext{})
+	// does nothing
+	bundle.Validate(getTestContext(), &testCheck{})
 
 	assert.Equal(t, "FALLBACK", bundle.GetMetaData().Description.German)
 }

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type mockExtension struct {
@@ -86,7 +87,7 @@ func (m *mockExtension) GetExtensionConfig() *Config {
 	return m.config
 }
 
-func (m *mockExtension) Validate(ctx context.Context, validationContext *ValidationContext) {
+func (m *mockExtension) Validate(ctx context.Context, check validation.Check) {
 }
 
 func TestMockExtension(t *testing.T) {

--- a/extension/platform_test.go
+++ b/extension/platform_test.go
@@ -59,12 +59,12 @@ func TestPluginIconNotExists(t *testing.T) {
 
 	plugin := getTestPlugin(dir)
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Equal(t, 1, len(ctx.errors))
-	assert.Equal(t, "The extension icon Resources/config/plugin.png does not exist", ctx.errors[0].Message)
+	assert.Equal(t, 1, len(check.Results))
+	assert.Equal(t, "The extension icon Resources/config/plugin.png does not exist", check.Results[0].Message)
 }
 
 func TestPluginIconExists(t *testing.T) {
@@ -75,11 +75,11 @@ func TestPluginIconExists(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Equal(t, 0, len(ctx.errors))
+	assert.Equal(t, 0, len(check.Results))
 }
 
 func TestPluginIconDifferntPathExists(t *testing.T) {
@@ -90,11 +90,11 @@ func TestPluginIconDifferntPathExists(t *testing.T) {
 
 	assert.NoError(t, createTestImage(filepath.Join(dir, "plugin.png")))
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Equal(t, 0, len(ctx.errors))
+	assert.Equal(t, 0, len(check.Results))
 }
 
 func TestPluginIconIsTooBig(t *testing.T) {
@@ -105,12 +105,12 @@ func TestPluginIconIsTooBig(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
 	assert.NoError(t, createTestImageWithSize(filepath.Join(dir, "src", "Resources", "config", "plugin.png"), 1000, 1000))
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Len(t, ctx.errors, 1)
-	assert.Equal(t, "The extension icon Resources/config/plugin.png dimensions (1000x1000) are larger than maximum 256x256 pixels with max file size 30kb and 72dpi", ctx.errors[0].Message)
+	assert.Len(t, check.Results, 1)
+	assert.Equal(t, "The extension icon Resources/config/plugin.png dimensions (1000x1000) are larger than maximum 256x256 pixels with max file size 30kb and 72dpi", check.Results[0].Message)
 }
 
 func TestPluginGermanDescriptionMissing(t *testing.T) {
@@ -121,14 +121,14 @@ func TestPluginGermanDescriptionMissing(t *testing.T) {
 		"en-GB": "Frosh Tools",
 	}
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Len(t, ctx.errors, 1)
-	assert.Equal(t, "extra.description for language de-DE is required", ctx.errors[0].Message)
+	assert.Len(t, check.Results, 1)
+	assert.Equal(t, "extra.description for language de-DE is required", check.Results[0].Message)
 }
 
 func TestPluginGermanDescriptionMissingOnlyEnglishMarket(t *testing.T) {
@@ -142,9 +142,9 @@ func TestPluginGermanDescriptionMissingOnlyEnglishMarket(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
-	ctx := newValidationContext(&plugin)
+	check := &testCheck{}
 
-	plugin.Validate(getTestContext(), ctx)
+	plugin.Validate(getTestContext(), check)
 
-	assert.Len(t, ctx.errors, 0)
+	assert.Len(t, check.Results, 0)
 }

--- a/extension/root.go
+++ b/extension/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/shyim/go-version"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 const (
@@ -117,5 +118,5 @@ type Extension interface {
 	GetChangelog() (*ExtensionChangelog, error)
 	GetMetaData() *extensionMetadata
 	GetExtensionConfig() *Config
-	Validate(context.Context, *ValidationContext)
+	Validate(context.Context, validation.Check)
 }

--- a/extension/snippet_validator.go
+++ b/extension/snippet_validator.go
@@ -10,20 +10,21 @@ import (
 	"strings"
 
 	"github.com/wI2L/jsondiff"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
-func validateStorefrontSnippets(context *ValidationContext) {
-	rootDir := context.Extension.GetRootDir()
+func validateStorefrontSnippets(ext Extension, check validation.Check) {
+	rootDir := ext.GetRootDir()
 
-	for _, val := range context.Extension.GetResourcesDirs() {
+	for _, val := range ext.GetResourcesDirs() {
 		storefrontFolder := path.Join(val, "snippet")
 
-		if err := validateStorefrontSnippetsByPath(storefrontFolder, rootDir, context); err != nil {
+		if err := validateStorefrontSnippetsByPath(storefrontFolder, rootDir, ext, check); err != nil {
 			return
 		}
 	}
 
-	for _, extraBundle := range context.Extension.GetExtensionConfig().Build.ExtraBundles {
+	for _, extraBundle := range ext.GetExtensionConfig().Build.ExtraBundles {
 		bundlePath := rootDir
 
 		if extraBundle.Path != "" {
@@ -34,13 +35,13 @@ func validateStorefrontSnippets(context *ValidationContext) {
 
 		storefrontFolder := path.Join(bundlePath, "Resources", "snippet")
 
-		if err := validateStorefrontSnippetsByPath(storefrontFolder, rootDir, context); err != nil {
+		if err := validateStorefrontSnippetsByPath(storefrontFolder, rootDir, ext, check); err != nil {
 			return
 		}
 	}
 }
 
-func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, context *ValidationContext) error {
+func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, ext Extension, check validation.Check) error {
 	if _, err := os.Stat(snippetFolder); err != nil {
 		return nil //nolint:nilerr
 	}
@@ -85,7 +86,11 @@ func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, context *Va
 		}
 
 		if len(mainFile) == 0 {
-			context.AddWarning("snippet.validator", fmt.Sprintf("No en-GB.json file found in %s, using %s", snippetFolder, files[0]))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("No en-GB.json file found in %s, using %s", snippetFolder, files[0]),
+				Severity:   validation.SeverityWarning,
+			})
 			mainFile = files[0]
 		}
 
@@ -95,7 +100,11 @@ func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, context *Va
 		}
 
 		if !json.Valid(mainFileContent) {
-			context.AddError("snippet.validator", fmt.Sprintf("File '%s' contains invalid JSON", mainFile))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("File '%s' contains invalid JSON", mainFile),
+				Severity:   validation.SeverityError,
+			})
 
 			continue
 		}
@@ -106,25 +115,25 @@ func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, context *Va
 				continue
 			}
 
-			compareSnippets(mainFileContent, mainFile, file, context, rootDir)
+			compareSnippets(mainFileContent, mainFile, file, ext, check, rootDir)
 		}
 	}
 
 	return nil
 }
 
-func validateAdministrationSnippets(context *ValidationContext) {
-	rootDir := context.Extension.GetRootDir()
+func validateAdministrationSnippets(ext Extension, check validation.Check) {
+	rootDir := ext.GetRootDir()
 
-	for _, val := range context.Extension.GetResourcesDirs() {
+	for _, val := range ext.GetResourcesDirs() {
 		adminFolder := path.Join(val, "app", "administration")
 
-		if err := validateAdministrationByPath(adminFolder, rootDir, context); err != nil {
+		if err := validateAdministrationByPath(adminFolder, rootDir, ext, check); err != nil {
 			return
 		}
 	}
 
-	for _, extraBundle := range context.Extension.GetExtensionConfig().Build.ExtraBundles {
+	for _, extraBundle := range ext.GetExtensionConfig().Build.ExtraBundles {
 		bundlePath := rootDir
 
 		if extraBundle.Path != "" {
@@ -135,13 +144,13 @@ func validateAdministrationSnippets(context *ValidationContext) {
 
 		adminFolder := path.Join(bundlePath, "Resources", "app", "administration")
 
-		if err := validateAdministrationByPath(adminFolder, rootDir, context); err != nil {
+		if err := validateAdministrationByPath(adminFolder, rootDir, ext, check); err != nil {
 			return
 		}
 	}
 }
 
-func validateAdministrationByPath(adminFolder, rootDir string, context *ValidationContext) error {
+func validateAdministrationByPath(adminFolder, rootDir string, ext Extension, check validation.Check) error {
 	if _, err := os.Stat(adminFolder); err != nil {
 		return nil //nolint:nilerr
 	}
@@ -190,7 +199,11 @@ func validateAdministrationByPath(adminFolder, rootDir string, context *Validati
 		}
 
 		if len(mainFile) == 0 {
-			context.AddWarning("snippet.validator", fmt.Sprintf("No en-GB.json file found in %s, using %s", strings.ReplaceAll(folder, rootDir+"/", ""), strings.ReplaceAll(files[0], rootDir+"/", "")))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("No en-GB.json file found in %s, using %s", strings.ReplaceAll(folder, rootDir+"/", ""), strings.ReplaceAll(files[0], rootDir+"/", "")),
+				Severity:   validation.SeverityWarning,
+			})
 			mainFile = files[0]
 		}
 
@@ -200,7 +213,11 @@ func validateAdministrationByPath(adminFolder, rootDir string, context *Validati
 		}
 
 		if !json.Valid(mainFileContent) {
-			context.AddError("snippet.validator", fmt.Sprintf("File '%s' contains invalid JSON", mainFile))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("File '%s' contains invalid JSON", mainFile),
+				Severity:   validation.SeverityError,
+			})
 
 			continue
 		}
@@ -211,30 +228,42 @@ func validateAdministrationByPath(adminFolder, rootDir string, context *Validati
 				continue
 			}
 
-			compareSnippets(mainFileContent, mainFile, file, context, rootDir)
+			compareSnippets(mainFileContent, mainFile, file, ext, check, rootDir)
 		}
 	}
 
 	return nil
 }
 
-func compareSnippets(mainFile []byte, mainFilePath, file string, context *ValidationContext, extensionRoot string) {
+func compareSnippets(mainFile []byte, mainFilePath, file string, ext Extension, check validation.Check, extensionRoot string) {
 	checkFile, err := os.ReadFile(file)
 	if err != nil {
-		context.AddError("snippet.validator", fmt.Sprintf("Cannot read file '%s', due '%s'", file, err))
+		check.AddResult(validation.CheckResult{
+			Identifier: "snippet.validator",
+			Message:    fmt.Sprintf("Cannot read file '%s', due '%s'", file, err),
+			Severity:   validation.SeverityError,
+		})
 
 		return
 	}
 
 	if !json.Valid(checkFile) {
-		context.AddError("snippet.validator", fmt.Sprintf("File '%s' contains invalid JSON", file))
+		check.AddResult(validation.CheckResult{
+			Identifier: "snippet.validator",
+			Message:    fmt.Sprintf("File '%s' contains invalid JSON", file),
+			Severity:   validation.SeverityError,
+		})
 
 		return
 	}
 
 	compare, err := jsondiff.CompareJSON(mainFile, checkFile)
 	if err != nil {
-		context.AddError("snippet.validator", fmt.Sprintf("Cannot compare file '%s', due '%s'", file, err))
+		check.AddResult(validation.CheckResult{
+			Identifier: "snippet.validator",
+			Message:    fmt.Sprintf("Cannot compare file '%s', due '%s'", file, err),
+			Severity:   validation.SeverityError,
+		})
 
 		return
 	}
@@ -245,17 +274,29 @@ func compareSnippets(mainFile []byte, mainFilePath, file string, context *Valida
 		normalizedPath := strings.ReplaceAll(file, extensionRoot+"/", "")
 
 		if diff.Type == jsondiff.OperationReplace && reflect.TypeOf(diff.OldValue) != reflect.TypeOf(diff.Value) {
-			context.AddWarning("snippet.validator", fmt.Sprintf("Snippet file: %s, key: %s, has the type %s, but in the main language it is %s", normalizedPath, diff.Path, reflect.TypeOf(diff.OldValue), reflect.TypeOf(diff.Value)))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("Snippet file: %s, key: %s, has the type %s, but in the main language it is %s", normalizedPath, diff.Path, reflect.TypeOf(diff.OldValue), reflect.TypeOf(diff.Value)),
+				Severity:   validation.SeverityWarning,
+			})
 			continue
 		}
 
 		if diff.Type == jsondiff.OperationAdd {
-			context.AddWarning("snippet.validator", fmt.Sprintf("Snippet file: %s, missing key \"%s\" in this snippet file, but defined in the main language (%s)", normalizedPath, diff.Path, normalizedMainFilePath))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("Snippet file: %s, missing key \"%s\" in this snippet file, but defined in the main language (%s)", normalizedPath, diff.Path, normalizedMainFilePath),
+				Severity:   validation.SeverityWarning,
+			})
 			continue
 		}
 
 		if diff.Type == jsondiff.OperationRemove {
-			context.AddWarning("snippet.validator", fmt.Sprintf("Snippet file: %s, key %s is missing, but defined in the main language file", normalizedPath, diff.Path))
+			check.AddResult(validation.CheckResult{
+				Identifier: "snippet.validator",
+				Message:    fmt.Sprintf("Snippet file: %s, key %s is missing, but defined in the main language file", normalizedPath, diff.Path),
+				Severity:   validation.SeverityWarning,
+			})
 			continue
 		}
 	}

--- a/extension/snippet_validator_test.go
+++ b/extension/snippet_validator_test.go
@@ -9,107 +9,111 @@ import (
 )
 
 func TestSnippetValidateNoExistingFolderAdmin(t *testing.T) {
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   "test",
 		config: &Config{},
-	})
+	}
 
-	validateAdministrationSnippets(context)
+	validateAdministrationSnippets(plugin, check)
 }
 
 func TestSnippetValidateNoExistingFolderStorefront(t *testing.T) {
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   "test",
 		config: &Config{},
-	})
+	}
 
-	validateAdministrationSnippets(context)
+	validateAdministrationSnippets(plugin, check)
 }
 
 func TestSnippetValidateStorefrontByPathOneFileIsIgnored(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   tmpDir,
 		config: &Config{},
-	})
+	}
 
 	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{}`), os.ModePerm)
 
-	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, context))
-	assert.Len(t, context.errors, 0)
-	assert.Len(t, context.warnings, 0)
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, plugin, check))
+	assert.Len(t, check.Results, 0)
+	assert.Len(t, check.Results, 0)
 }
 
 func TestSnippetValidateStorefrontByPathSameFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   tmpDir,
 		config: &Config{},
-	})
+	}
 
 	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"test": "1"}`), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"test": "2"}`), os.ModePerm)
 
-	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, context))
-	assert.Len(t, context.errors, 0)
-	assert.Len(t, context.warnings, 0)
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, plugin, check))
+	assert.Len(t, check.Results, 0)
+	assert.Len(t, check.Results, 0)
 }
 
 func TestSnippetValidateStorefrontByPathTestDifferent(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   tmpDir,
 		config: &Config{},
-	})
+	}
 
 	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"b": "2"}`), os.ModePerm)
 
-	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, context))
-	assert.Len(t, context.errors, 0)
-	assert.Len(t, context.warnings, 2)
-	assert.Contains(t, context.warnings[0].Message, "key /a is missing, but defined in the main language file")
-	assert.Contains(t, context.warnings[1].Message, "missing key \"/b\" in this snippet file, but defined in the main language")
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, plugin, check))
+	assert.Len(t, check.Results, 2)
+	assert.Contains(t, check.Results[0].Message, "key /a is missing, but defined in the main language file")
+	assert.Contains(t, check.Results[1].Message, "missing key \"/b\" in this snippet file, but defined in the main language")
 }
 
 func TestSnippetValidateFindsInvalidJsonInMainFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   tmpDir,
 		config: &Config{},
-	})
+	}
 
 	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1",}`), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2"}`), os.ModePerm)
 
-	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, context))
-	assert.Len(t, context.errors, 1)
-	assert.Len(t, context.warnings, 0)
-	assert.Contains(t, context.errors[0].Message, "contains invalid JSON")
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, plugin, check))
+	assert.Len(t, check.Results, 1)
+	assert.Contains(t, check.Results[0].Message, "contains invalid JSON")
 }
 
 func TestSnippetValidateFindsInvalidJsonInGermanFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	context := newValidationContext(PlatformPlugin{
+	check := &testCheck{}
+	plugin := PlatformPlugin{
 		path:   tmpDir,
 		config: &Config{},
-	})
+	}
 
 	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), os.ModePerm)
 	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2",}`), os.ModePerm)
 
-	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, context))
-	assert.Len(t, context.errors, 1)
-	assert.Len(t, context.warnings, 0)
-	assert.Contains(t, context.errors[0].Message, "contains invalid JSON")
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, plugin, check))
+	assert.Len(t, check.Results, 1)
+	assert.Contains(t, check.Results[0].Message, "contains invalid JSON")
 }

--- a/extension/theme.go
+++ b/extension/theme.go
@@ -4,34 +4,52 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
-func validateTheme(ctx *ValidationContext) {
-	themeJSONPath := fmt.Sprintf("%s/src/Resources/theme.json", ctx.Extension.GetPath())
+func validateTheme(ext Extension, check validation.Check) {
+	themeJSONPath := fmt.Sprintf("%s/src/Resources/theme.json", ext.GetPath())
 
 	if _, err := os.Stat(themeJSONPath); !os.IsNotExist(err) {
 		content, err := os.ReadFile(themeJSONPath)
 		if err != nil {
-			ctx.AddError("theme.validator", "Invalid theme.json")
+			check.AddResult(validation.CheckResult{
+				Identifier: "theme.validator",
+				Message:    "Invalid theme.json",
+				Severity:   validation.SeverityError,
+			})
 			return
 		}
 
 		var theme themeJSON
 		err = json.Unmarshal(content, &theme)
 		if err != nil {
-			ctx.AddError("theme.validator", "Cannot decode theme.json")
+			check.AddResult(validation.CheckResult{
+				Identifier: "theme.validator",
+				Message:    "Cannot decode theme.json",
+				Severity:   validation.SeverityError,
+			})
 			return
 		}
 
 		if len(theme.PreviewMedia) == 0 {
-			ctx.AddError("theme.validator", "Required field \"previewMedia\" missing in theme.json")
+			check.AddResult(validation.CheckResult{
+				Identifier: "theme.validator",
+				Message:    "Required field \"previewMedia\" missing in theme.json",
+				Severity:   validation.SeverityError,
+			})
 			return
 		}
 
-		expectedMediaPath := fmt.Sprintf("%s/src/Resources/%s", ctx.Extension.GetPath(), theme.PreviewMedia)
+		expectedMediaPath := fmt.Sprintf("%s/src/Resources/%s", ext.GetPath(), theme.PreviewMedia)
 
 		if _, err := os.Stat(expectedMediaPath); os.IsNotExist(err) {
-			ctx.AddError("theme.validator", fmt.Sprintf("Theme preview image file is expected to be placed at %s, but not found there.", expectedMediaPath))
+			check.AddResult(validation.CheckResult{
+				Identifier: "theme.validator",
+				Message:    fmt.Sprintf("Theme preview image file is expected to be placed at %s, but not found there.", expectedMediaPath),
+				Severity:   validation.SeverityError,
+			})
 		}
 	}
 }

--- a/extension/validator.go
+++ b/extension/validator.go
@@ -11,85 +11,13 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/shopware/shopware-cli/internal/spdx"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
-type ValidationMessage struct {
-	Identifier string
-	Message    string
-}
 
-type ValidationContext struct {
-	Extension Extension
-	errors    []ValidationMessage
-	warnings  []ValidationMessage
-}
-
-func newValidationContext(ext Extension) *ValidationContext {
-	return &ValidationContext{Extension: ext}
-}
-
-func (c *ValidationContext) AddError(id, message string) {
-	c.errors = append(c.errors, ValidationMessage{Identifier: id, Message: message})
-}
-
-func (c *ValidationContext) HasErrors() bool {
-	return len(c.errors) > 0
-}
-
-func (c *ValidationContext) Errors() []ValidationMessage {
-	return c.errors
-}
-
-func (c *ValidationContext) AddWarning(id, message string) {
-	c.warnings = append(c.warnings, ValidationMessage{Identifier: id, Message: message})
-}
-
-func (c *ValidationContext) HasWarnings() bool {
-	return len(c.warnings) > 0
-}
-
-func (c *ValidationContext) Warnings() []ValidationMessage {
-	return c.warnings
-}
-
-func (c *ValidationContext) ApplyIgnores(ignores []ConfigValidationIgnoreItem) {
-	for _, ignore := range ignores {
-		for i := 0; i < len(c.errors); i++ {
-			if c.errors[i].Identifier == ignore.Identifier && ignore.Message == "" {
-				c.errors = append(c.errors[:i], c.errors[i+1:]...)
-				i--
-				continue
-			}
-
-			if c.errors[i].Identifier == ignore.Identifier && ignore.Message != "" && strings.Contains(c.errors[i].Message, ignore.Message) {
-				c.errors = append(c.errors[:i], c.errors[i+1:]...)
-				i--
-				continue
-			}
-		}
-	}
-
-	// Apply the same logic to warnings
-	for _, ignore := range ignores {
-		for i := 0; i < len(c.warnings); i++ {
-			if c.warnings[i].Identifier == ignore.Identifier && ignore.Message == "" {
-				c.warnings = append(c.warnings[:i], c.warnings[i+1:]...)
-				i--
-				continue
-			}
-
-			if c.warnings[i].Identifier == ignore.Identifier && ignore.Message != "" && strings.Contains(c.warnings[i].Message, ignore.Message) {
-				c.warnings = append(c.warnings[:i], c.warnings[i+1:]...)
-				i--
-				continue
-			}
-		}
-	}
-}
-
-func validateExtensionIcon(ctx *ValidationContext) {
-	fullIconPath := ctx.Extension.GetIconPath()
-	relPath, err := filepath.Rel(ctx.Extension.GetRootDir(), fullIconPath)
+func validateExtensionIcon(ext Extension, check validation.Check) {
+	fullIconPath := ext.GetIconPath()
+	relPath, err := filepath.Rel(ext.GetRootDir(), fullIconPath)
 	if err != nil {
 		relPath = fullIconPath
 	}
@@ -97,109 +25,182 @@ func validateExtensionIcon(ctx *ValidationContext) {
 	info, err := os.Stat(fullIconPath)
 
 	if os.IsNotExist(err) {
-		ctx.AddError("metadata.icon", fmt.Sprintf("The extension icon %s does not exist", relPath))
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.icon",
+			Message:    fmt.Sprintf("The extension icon %s does not exist", relPath),
+			Severity:   validation.SeverityError,
+		})
 	} else if err == nil {
 		if info.Size() > 30*1024 {
-			ctx.AddError("metadata.icon.size", fmt.Sprintf("The extension icon %s is bigger than 30kb", relPath))
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.icon.size",
+				Message:    fmt.Sprintf("The extension icon %s is bigger than 30kb", relPath),
+				Severity:   validation.SeverityError,
+			})
 		}
 
 		file, err := os.Open(fullIconPath)
 		if err != nil {
-			ctx.AddError("metadata.icon", fmt.Sprintf("Could not open icon file %s: %s", relPath, err.Error()))
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.icon",
+				Message:    fmt.Sprintf("Could not open icon file %s: %s", relPath, err.Error()),
+				Severity:   validation.SeverityError,
+			})
 		} else {
 			config, _, err := image.DecodeConfig(file)
 			if err != nil {
-				ctx.AddError("metadata.icon", fmt.Sprintf("Could not decode icon image %s: %s", relPath, err.Error()))
+				check.AddResult(validation.CheckResult{
+					Identifier: "metadata.icon",
+					Message:    fmt.Sprintf("Could not decode icon image %s: %s", relPath, err.Error()),
+					Severity:   validation.SeverityError,
+				})
 			} else {
 				if config.Width < 112 || config.Height < 112 {
-					ctx.AddError("metadata.icon.size", fmt.Sprintf("The extension icon %s dimensions (%dx%d) are smaller than required 112x112 and maximum 256x256 pixels with max file size 30kb and 72dpi", relPath, config.Width, config.Height))
+					check.AddResult(validation.CheckResult{
+						Identifier: "metadata.icon.size",
+						Message:    fmt.Sprintf("The extension icon %s dimensions (%dx%d) are smaller than required 112x112 and maximum 256x256 pixels with max file size 30kb and 72dpi", relPath, config.Width, config.Height),
+						Severity:   validation.SeverityError,
+					})
 				} else if config.Width > 256 || config.Height > 256 {
-					ctx.AddError("metadata.icon.size", fmt.Sprintf("The extension icon %s dimensions (%dx%d) are larger than maximum 256x256 pixels with max file size 30kb and 72dpi", relPath, config.Width, config.Height))
+					check.AddResult(validation.CheckResult{
+						Identifier: "metadata.icon.size",
+						Message:    fmt.Sprintf("The extension icon %s dimensions (%dx%d) are larger than maximum 256x256 pixels with max file size 30kb and 72dpi", relPath, config.Width, config.Height),
+						Severity:   validation.SeverityError,
+					})
 				}
 			}
 
 			if err := file.Close(); err != nil {
-				ctx.AddError("metadata.icon", fmt.Sprintf("Failed to close icon file %s: %s", relPath, err.Error()))
+				check.AddResult(validation.CheckResult{
+					Identifier: "metadata.icon",
+					Message:    fmt.Sprintf("Failed to close icon file %s: %s", relPath, err.Error()),
+					Severity:   validation.SeverityError,
+				})
 			}
 		}
 	}
 }
 
-func RunValidation(ctx context.Context, ext Extension) *ValidationContext {
-	vc := newValidationContext(ext)
-
-	runDefaultValidate(vc)
-	ext.Validate(ctx, vc)
-	validateAdministrationSnippets(vc)
-	validateStorefrontSnippets(vc)
-	validateAssets(vc)
-	vc.ApplyIgnores(ext.GetExtensionConfig().Validation.Ignore)
-
-	return vc
+func RunValidation(ctx context.Context, ext Extension, check validation.Check) {
+	runDefaultValidate(ext, check)
+	ext.Validate(ctx, check)
+	validateAdministrationSnippets(ext, check)
+	validateStorefrontSnippets(ext, check)
+	validateAssets(ext, check)
+	validateExtensionIcon(ext, check)
+	// Note: ignores are now applied in the verifier layer
 }
 
-func runDefaultValidate(vc *ValidationContext) {
-	_, versionErr := vc.Extension.GetVersion()
-	name, nameErr := vc.Extension.GetName()
-	_, shopwareVersionErr := vc.Extension.GetShopwareVersionConstraint()
+func runDefaultValidate(ext Extension, check validation.Check) {
+	_, versionErr := ext.GetVersion()
+	name, nameErr := ext.GetName()
+	_, shopwareVersionErr := ext.GetShopwareVersionConstraint()
 
 	// Skip version validation for ShopwareBundle
-	if versionErr != nil && vc.Extension.GetType() != TypeShopwareBundle {
-		vc.AddError("metadata.version", versionErr.Error())
+	if versionErr != nil && ext.GetType() != TypeShopwareBundle {
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.version",
+			Message:    versionErr.Error(),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if nameErr != nil {
-		vc.AddError("metadata.name", nameErr.Error())
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.name",
+			Message:    nameErr.Error(),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if shopwareVersionErr != nil {
-		vc.AddError("metadata.shopware_version", shopwareVersionErr.Error())
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.shopware_version",
+			Message:    shopwareVersionErr.Error(),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if len(name) == 0 {
-		vc.AddError("metadata.name", "Extension name cannot be empty")
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.name",
+			Message:    "Extension name cannot be empty",
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	notAllowedErrorFormat := "file %s is not allowed in the zip file"
-	_ = filepath.Walk(vc.Extension.GetPath(), func(p string, info fs.FileInfo, _ error) error {
+	_ = filepath.Walk(ext.GetPath(), func(p string, info fs.FileInfo, _ error) error {
 		base := filepath.Base(p)
 
 		if base == ".." {
-			vc.AddError("zip.path_travel", "Path travel detected in zip file")
+			check.AddResult(validation.CheckResult{
+				Identifier: "zip.path_travel",
+				Message:    "Path travel detected in zip file",
+				Severity:   validation.SeverityError,
+			})
 		}
 
 		for _, file := range defaultNotAllowedPaths {
 			if strings.HasPrefix(p, file) {
-				vc.AddError("zip.disallowed_file", fmt.Sprintf(notAllowedErrorFormat, p))
+				check.AddResult(validation.CheckResult{
+					Identifier: "zip.disallowed_file",
+					Message:    fmt.Sprintf(notAllowedErrorFormat, p),
+					Severity:   validation.SeverityError,
+				})
 			}
 		}
 
 		for _, file := range defaultNotAllowedFiles {
 			if file == base {
-				vc.AddError("zip.disallowed_file", fmt.Sprintf(notAllowedErrorFormat, p))
+				check.AddResult(validation.CheckResult{
+					Identifier: "zip.disallowed_file",
+					Message:    fmt.Sprintf(notAllowedErrorFormat, p),
+					Severity:   validation.SeverityError,
+				})
 			}
 		}
 
-		for _, ext := range defaultNotAllowedExtensions {
-			if strings.HasSuffix(base, ext) {
-				vc.AddError("zip.disallowed_file", fmt.Sprintf(notAllowedErrorFormat, p))
+		for _, extFile := range defaultNotAllowedExtensions {
+			if strings.HasSuffix(base, extFile) {
+				check.AddResult(validation.CheckResult{
+					Identifier: "zip.disallowed_file",
+					Message:    fmt.Sprintf(notAllowedErrorFormat, p),
+					Severity:   validation.SeverityError,
+				})
 			}
 		}
 
-		license, err := vc.Extension.GetLicense()
+		license, err := ext.GetLicense()
 
 		if err != nil {
-			vc.AddError("metadata.license", fmt.Sprintf("Could not read the license of the extension: %s", err.Error()))
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.license",
+				Message:    fmt.Sprintf("Could not read the license of the extension: %s", err.Error()),
+				Severity:   validation.SeverityError,
+			})
 		} else if strings.TrimSpace(strings.ToLower(license)) != "proprietary" {
 			spdxList, err := spdx.NewSpdxLicenses()
 			if err != nil {
-				vc.AddWarning("metadata.license", fmt.Sprintf("Could not load the SPDX license list: %s", err.Error()))
+				check.AddResult(validation.CheckResult{
+					Identifier: "metadata.license",
+					Message:    fmt.Sprintf("Could not load the SPDX license list: %s", err.Error()),
+					Severity:   validation.SeverityWarning,
+				})
 			} else {
 				valid, err := spdxList.Validate(license)
 				if err != nil {
-					vc.AddError("metadata.license", fmt.Sprintf("Could not validate the license: %s", err.Error()))
+					check.AddResult(validation.CheckResult{
+						Identifier: "metadata.license",
+						Message:    fmt.Sprintf("Could not validate the license: %s", err.Error()),
+						Severity:   validation.SeverityError,
+					})
 				} else if !valid {
-					vc.AddError("metadata.license", fmt.Sprintf("The license %s is not a valid SPDX license", license))
+					check.AddResult(validation.CheckResult{
+						Identifier: "metadata.license",
+						Message:    fmt.Sprintf("The license %s is not a valid SPDX license", license),
+						Severity:   validation.SeverityError,
+					})
 				}
 			}
 		}
@@ -207,31 +208,55 @@ func runDefaultValidate(vc *ValidationContext) {
 		return nil
 	})
 
-	metaData := vc.Extension.GetMetaData()
+	metaData := ext.GetMetaData()
 	if len([]rune(metaData.Label.German)) == 0 {
-		vc.AddError("metadata.label", "in composer.json, label is not translated in german")
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.label",
+			Message:    "in composer.json, label is not translated in german",
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if len(metaData.Label.English) == 0 {
-		vc.AddError("metadata.label", "in composer.json, label is not translated in english")
+		check.AddResult(validation.CheckResult{
+			Identifier: "metadata.label",
+			Message:    "in composer.json, label is not translated in english",
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	// Skip description validation for ShopwareBundle
-	if vc.Extension.GetType() != TypeShopwareBundle {
+	if ext.GetType() != TypeShopwareBundle {
 		if len([]rune(metaData.Description.German)) == 0 {
-			vc.AddError("metadata.description", "in composer.json, description is not translated in german")
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.description",
+				Message:    "in composer.json, description is not translated in german",
+				Severity:   validation.SeverityError,
+			})
 		}
 
 		if len(metaData.Description.English) == 0 {
-			vc.AddError("metadata.description", "in composer.json, description is not translated in english")
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.description",
+				Message:    "in composer.json, description is not translated in english",
+				Severity:   validation.SeverityError,
+			})
 		}
 
 		if len([]rune(metaData.Description.German)) < 150 || len([]rune(metaData.Description.German)) > 185 {
-			vc.AddError("metadata.description", fmt.Sprintf("in composer.json, the german description with length of %d should have a length from 150 up to 185 characters.", len([]rune(metaData.Description.German))))
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.description",
+				Message:    fmt.Sprintf("in composer.json, the german description with length of %d should have a length from 150 up to 185 characters.", len([]rune(metaData.Description.German))),
+				Severity:   validation.SeverityError,
+			})
 		}
 
 		if len(metaData.Description.English) < 150 || len(metaData.Description.English) > 185 {
-			vc.AddError("metadata.description", fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", len(metaData.Description.English)))
+			check.AddResult(validation.CheckResult{
+				Identifier: "metadata.description",
+				Message:    fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", len(metaData.Description.English)),
+				Severity:   validation.SeverityError,
+			})
 		}
 	}
 }

--- a/extension/validator_assets.go
+++ b/extension/validator_assets.go
@@ -4,19 +4,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
-func validateAssets(ctx *ValidationContext) {
-	if !ctx.Extension.GetExtensionConfig().Validation.StoreCompliance {
+func validateAssets(ext Extension, check validation.Check) {
+	if !ext.GetExtensionConfig().Validation.StoreCompliance {
 		return
 	}
 
-	for _, resourceDir := range ctx.Extension.GetResourcesDirs() {
-		validateAssetByResourceDir(ctx, resourceDir)
+	for _, resourceDir := range ext.GetResourcesDirs() {
+		validateAssetByResourceDir(ext, check, resourceDir)
 	}
 
-	for _, extraBundle := range ctx.Extension.GetExtensionConfig().Build.ExtraBundles {
-		bundlePath := ctx.Extension.GetRootDir()
+	for _, extraBundle := range ext.GetExtensionConfig().Build.ExtraBundles {
+		bundlePath := ext.GetRootDir()
 
 		if extraBundle.Path != "" {
 			bundlePath = fmt.Sprintf("%s/%s", bundlePath, extraBundle.Path)
@@ -24,30 +26,46 @@ func validateAssets(ctx *ValidationContext) {
 			bundlePath = fmt.Sprintf("%s/%s", bundlePath, extraBundle.Name)
 		}
 
-		validateAssetByResourceDir(ctx, filepath.Join(bundlePath, "Resources"))
+		validateAssetByResourceDir(ext, check, filepath.Join(bundlePath, "Resources"))
 	}
 }
 
-func validateAssetByResourceDir(ctx *ValidationContext, resourceDir string) {
+func validateAssetByResourceDir(ext Extension, check validation.Check, resourceDir string) {
 	_, foundAdminBuildFiles := os.Stat(filepath.Join(resourceDir, "public", "administration"))
 	foundAdminEntrypoint := hasJavascriptEntrypoint(filepath.Join(resourceDir, "app", "administration", "src"))
 	foundStorefrontEntrypoint := hasJavascriptEntrypoint(filepath.Join(resourceDir, "app", "storefront", "src"))
 	_, foundStorefrontDistFiles := os.Stat(filepath.Join(resourceDir, "app", "storefront", "dist"))
 
 	if foundAdminBuildFiles == nil && !foundAdminEntrypoint {
-		ctx.AddError("assets.administration.sources_missing", fmt.Sprintf("Found administration build files in %s but no source files to rebuild the assets.", resourceDir))
+		check.AddResult(validation.CheckResult{
+			Identifier: "assets.administration.sources_missing",
+			Message:    fmt.Sprintf("Found administration build files in %s but no source files to rebuild the assets.", resourceDir),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if foundAdminBuildFiles != nil && foundAdminEntrypoint {
-		ctx.AddError("assets.administration.build_missing", fmt.Sprintf("Found administration source files in %s but no build files. Please run the build command to generate the assets.", resourceDir))
+		check.AddResult(validation.CheckResult{
+			Identifier: "assets.administration.build_missing",
+			Message:    fmt.Sprintf("Found administration source files in %s but no build files. Please run the build command to generate the assets.", resourceDir),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if foundStorefrontDistFiles != nil && foundStorefrontEntrypoint {
-		ctx.AddError("assets.storefront.sources_missing", fmt.Sprintf("Found storefront build files in %s but no source files to rebuild the assets.", resourceDir))
+		check.AddResult(validation.CheckResult{
+			Identifier: "assets.storefront.sources_missing",
+			Message:    fmt.Sprintf("Found storefront build files in %s but no source files to rebuild the assets.", resourceDir),
+			Severity:   validation.SeverityError,
+		})
 	}
 
 	if foundStorefrontDistFiles == nil && !foundStorefrontEntrypoint {
-		ctx.AddError("assets.storefront.build_missing", fmt.Sprintf("Found storefront source files in %s but no build files. Please run the build command to generate the assets.", resourceDir))
+		check.AddResult(validation.CheckResult{
+			Identifier: "assets.storefront.build_missing",
+			Message:    fmt.Sprintf("Found storefront source files in %s but no build files. Please run the build command to generate the assets.", resourceDir),
+			Severity:   validation.SeverityError,
+		})
 	}
 }
 

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -1,0 +1,92 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/invopop/jsonschema"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// CheckResult represents a validation result
+type CheckResult struct {
+	// The path to the file that was checked
+	Path string `json:"path"`
+	// The line number of the issue
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+	// The severity of the issue
+	Severity string `json:"severity"`
+
+	Identifier string `json:"identifier"`
+}
+
+// ToolConfigIgnore represents a configuration item to ignore during validation
+type ToolConfigIgnore struct {
+	Identifier string `yaml:"identifier"`
+	Path       string `yaml:"path,omitempty"`
+	Message    string `yaml:"message,omitempty"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling for ToolConfigIgnore
+func (c *ToolConfigIgnore) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		c.Identifier = value.Value
+		return nil
+	}
+
+	type objectFormat struct {
+		Identifier string `yaml:"identifier"`
+		Path       string `yaml:"path,omitempty"`
+		Message    string `yaml:"message,omitempty"`
+	}
+	var obj objectFormat
+	if err := value.Decode(&obj); err != nil {
+		return fmt.Errorf("failed to decode ToolConfigIgnore: %w", err)
+	}
+
+	c.Identifier = obj.Identifier
+	c.Path = obj.Path
+	c.Message = obj.Message
+
+	return nil
+}
+
+// JSONSchema generates the JSON schema for ToolConfigIgnore
+func (c ToolConfigIgnore) JSONSchema() *jsonschema.Schema {
+	ordMap := orderedmap.New[string, *jsonschema.Schema]()
+
+	ordMap.Set("identifier", &jsonschema.Schema{
+		Type:        "string",
+		Description: "The identifier of the item to ignore.",
+	})
+
+	ordMap.Set("path", &jsonschema.Schema{
+		Type:        "string",
+		Description: "The path of the item to ignore.",
+	})
+
+	return &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{
+				Type:       "object",
+				Properties: ordMap,
+			},
+			{
+				Type: "string",
+			},
+		},
+	}
+}
+
+// Check interface for validation checking
+type Check interface {
+	AddResult(CheckResult)
+	RemoveByIdentifier([]ToolConfigIgnore) Check
+}
+
+// Severity constants
+const (
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+)

--- a/internal/verifier/admin_twig.go
+++ b/internal/verifier/admin_twig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shyim/go-version"
 
 	"github.com/shopware/shopware-cli/internal/html"
+	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/shopware/shopware-cli/internal/verifier/admintwiglinter"
 	"github.com/shopware/shopware-cli/logging"
 )
@@ -51,7 +52,7 @@ func (a AdminTwigLinter) Check(ctx context.Context, check *Check, config ToolCon
 
 			for _, fixer := range fixers {
 				for _, message := range fixer.Check(parsed) {
-					check.AddResult(CheckResult{
+					check.AddResult(validation.CheckResult{
 						Message:    message.Message,
 						Path:       strings.TrimPrefix(strings.TrimPrefix(path, "/private"), config.RootDir+"/"),
 						Line:       0,

--- a/internal/verifier/eslint.go
+++ b/internal/verifier/eslint.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type EslintOutput []struct {
@@ -83,13 +85,13 @@ func (e Eslint) Check(ctx context.Context, check *Check, config ToolConfig) erro
 				fixedPath := strings.TrimPrefix(strings.TrimPrefix(diagnostic.FilePath, "/private"), config.RootDir+"/")
 
 				for _, message := range diagnostic.Messages {
-					severity := SeverityWarning
+					severity := validation.SeverityWarning
 
 					if message.Severity == 2 {
-						severity = SeverityError
+						severity = validation.SeverityError
 					}
 
-					check.AddResult(CheckResult{
+					check.AddResult(validation.CheckResult{
 						Path:       fixedPath,
 						Line:       message.Line,
 						Message:    message.Message,

--- a/internal/verifier/extension.go
+++ b/internal/verifier/extension.go
@@ -9,13 +9,14 @@ import (
 	"github.com/shyim/go-version"
 
 	"github.com/shopware/shopware-cli/extension"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 func ConvertExtensionToToolConfig(ext extension.Extension) (*ToolConfig, error) {
-	var ignores []ToolConfigIgnore
+	var ignores []validation.ToolConfigIgnore
 
 	for _, ignore := range ext.GetExtensionConfig().Validation.Ignore {
-		ignores = append(ignores, ToolConfigIgnore{
+		ignores = append(ignores, validation.ToolConfigIgnore{
 			Identifier: ignore.Identifier,
 			Path:       ignore.Path,
 			Message:    ignore.Message,

--- a/internal/verifier/phpstan.go
+++ b/internal/verifier/phpstan.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 var possiblePHPStanConfigs = []string{
@@ -83,7 +85,7 @@ func (p PhpStan) Check(ctx context.Context, check *Check, config ToolConfig) err
 		var phpstanResult PhpStanOutput
 
 		if err := json.Unmarshal(log, &phpstanResult); err != nil {
-			check.AddResult(CheckResult{
+			check.AddResult(validation.CheckResult{
 				Path:       "phpstan.neon",
 				Message:    "failed to unmarshal phpstan output: " + stderr.String(),
 				Severity:   "error",
@@ -95,7 +97,7 @@ func (p PhpStan) Check(ctx context.Context, check *Check, config ToolConfig) err
 		}
 
 		for _, error := range phpstanResult.Errors {
-			check.AddResult(CheckResult{
+			check.AddResult(validation.CheckResult{
 				Path:       "phpstan.neon",
 				Message:    error,
 				Severity:   "error",
@@ -110,7 +112,7 @@ func (p PhpStan) Check(ctx context.Context, check *Check, config ToolConfig) err
 					continue
 				}
 
-				check.AddResult(CheckResult{
+				check.AddResult(validation.CheckResult{
 					Path:       strings.TrimPrefix(strings.TrimPrefix(fileName, "/private"), config.RootDir+"/"),
 					Line:       message.Line,
 					Message:    message.Message,

--- a/internal/verifier/project.go
+++ b/internal/verifier/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shyim/go-version"
 
 	"github.com/shopware/shopware-cli/extension"
+	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/shopware/shopware-cli/logging"
 	"github.com/shopware/shopware-cli/shop"
 )
@@ -166,11 +167,11 @@ func GetConfigFromProject(root string) (*ToolConfig, error) {
 		}
 	}
 
-	var validationIgnores []ToolConfigIgnore
+	var validationIgnores []validation.ToolConfigIgnore
 
 	if shopCfg.Validation != nil {
 		for _, ignore := range shopCfg.Validation.Ignore {
-			validationIgnores = append(validationIgnores, ToolConfigIgnore{
+			validationIgnores = append(validationIgnores, validation.ToolConfigIgnore{
 				Identifier: ignore.Identifier,
 				Path:       ignore.Path,
 				Message:    ignore.Message,

--- a/internal/verifier/reporter.go
+++ b/internal/verifier/reporter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 func DetectDefaultReporter() string {
@@ -35,7 +37,7 @@ func DoCheckReport(result *Check, reportingFormat string) error {
 
 func doSummaryReport(result *Check) error {
 	// Group results by file
-	fileGroups := make(map[string][]CheckResult)
+	fileGroups := make(map[string][]validation.CheckResult)
 	for _, r := range result.Results {
 		if r.Path == "" {
 			r.Path = "general"
@@ -55,9 +57,9 @@ func doSummaryReport(result *Check) error {
 		for _, r := range results {
 			totalProblems++
 			switch r.Severity {
-			case CheckSeverityError:
+			case "error":
 				errorCount++
-			case CheckSeverityWarn:
+			case "warn":
 				warningCount++
 			}
 			//nolint:forbidigo
@@ -223,7 +225,7 @@ func doMarkdownReport(result *Check) error {
 	return nil
 }
 
-func convertResultsToMarkdown(check []CheckResult) string {
+func convertResultsToMarkdown(check []validation.CheckResult) string {
 	var builder strings.Builder
 
 	builder.WriteString("# Results\n\n")

--- a/internal/verifier/result.go
+++ b/internal/verifier/result.go
@@ -3,20 +3,22 @@ package verifier
 import (
 	"strings"
 	"sync"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type Check struct {
-	Results []CheckResult `json:"results"`
+	Results []validation.CheckResult `json:"results"`
 	mutex   sync.Mutex
 }
 
 func NewCheck() *Check {
 	return &Check{
-		Results: []CheckResult{},
+		Results: []validation.CheckResult{},
 	}
 }
 
-func (c *Check) AddResult(result CheckResult) {
+func (c *Check) AddResult(result validation.CheckResult) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.Results = append(c.Results, result)
@@ -32,11 +34,11 @@ func (c *Check) HasErrors() bool {
 	return false
 }
 
-func (c *Check) RemoveByIdentifier(ignores []ToolConfigIgnore) *Check {
+func (c *Check) RemoveByIdentifier(ignores []validation.ToolConfigIgnore) validation.Check {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	filtered := make([]CheckResult, 0)
+	filtered := make([]validation.CheckResult, 0)
 	for _, r := range c.Results {
 		shouldKeep := true
 		for _, ignore := range ignores {
@@ -71,19 +73,3 @@ func (c *Check) RemoveByIdentifier(ignores []ToolConfigIgnore) *Check {
 	return c
 }
 
-type CheckResult struct {
-	// The path to the file that was checked
-	Path string `json:"path"`
-	// The line number of the issue
-	Line    int    `json:"line"`
-	Message string `json:"message"`
-	// The severity of the issue
-	Severity string `json:"severity"`
-
-	Identifier string `json:"identifier"`
-}
-
-const (
-	CheckSeverityError = "error"
-	CheckSeverityWarn  = "warning"
-)

--- a/internal/verifier/result_test.go
+++ b/internal/verifier/result_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 func TestNewCheck(t *testing.T) {
@@ -14,7 +16,7 @@ func TestNewCheck(t *testing.T) {
 
 func TestAddResult(t *testing.T) {
 	check := NewCheck()
-	result := CheckResult{
+	result := validation.CheckResult{
 		Path:       "test.go",
 		Line:       1,
 		Message:    "test message",
@@ -30,17 +32,17 @@ func TestAddResult(t *testing.T) {
 func TestHasErrors(t *testing.T) {
 	tests := []struct {
 		name     string
-		results  []CheckResult
+		results  []validation.CheckResult
 		expected bool
 	}{
 		{
 			name:     "no results",
-			results:  []CheckResult{},
+			results:  []validation.CheckResult{},
 			expected: false,
 		},
 		{
 			name: "no errors",
-			results: []CheckResult{
+			results: []validation.CheckResult{
 				{Severity: "warning"},
 				{Severity: "info"},
 			},
@@ -48,7 +50,7 @@ func TestHasErrors(t *testing.T) {
 		},
 		{
 			name: "has errors",
-			results: []CheckResult{
+			results: []validation.CheckResult{
 				{Severity: "warning"},
 				{Severity: "error"},
 				{Severity: "info"},
@@ -71,90 +73,90 @@ func TestHasErrors(t *testing.T) {
 func TestRemoveByIdentifier(t *testing.T) {
 	tests := []struct {
 		name            string
-		initialResults  []CheckResult
-		ignores         []ToolConfigIgnore
-		expectedResults []CheckResult
+		initialResults  []validation.CheckResult
+		ignores         []validation.ToolConfigIgnore
+		expectedResults []validation.CheckResult
 	}{
 		{
 			name: "remove single result",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001"},
 				{Path: "file2.go", Identifier: "TEST002"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Path: "file1.go", Identifier: "TEST001"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file2.go", Identifier: "TEST002"},
 			},
 		},
 		{
 			name: "remove by identifier only",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001"},
 				{Path: "file2.go", Identifier: "TEST001"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Identifier: "TEST001"},
 			},
-			expectedResults: []CheckResult{},
+			expectedResults: []validation.CheckResult{},
 		},
 		{
 			name: "no matches",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001"},
 				{Path: "file2.go", Identifier: "TEST002"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Path: "file3.go", Identifier: "TEST003"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001"},
 				{Path: "file2.go", Identifier: "TEST002"},
 			},
 		},
 		{
 			name: "identifier with message should not ignore all",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001", Message: "error 1"},
 				{Path: "file2.go", Identifier: "TEST001", Message: "error 2"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Identifier: "TEST001", Message: "error 1"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001", Message: "error 1"},
 				{Path: "file2.go", Identifier: "TEST001", Message: "error 2"},
 			},
 		},
 		{
 			name: "identifier only should ignore all matching errors",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001", Message: "error 1"},
 				{Path: "file2.go", Identifier: "TEST001", Message: "error 2"},
 				{Path: "file3.go", Identifier: "TEST002", Message: "error 3"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Identifier: "TEST001"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file3.go", Identifier: "TEST002", Message: "error 3"},
 			},
 		},
 		{
 			name: "multiple ignores with different conditions",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Identifier: "TEST001", Message: "error 1"},
 				{Path: "file2.go", Identifier: "TEST001", Message: "error 2"},
 				{Path: "file3.go", Identifier: "TEST002", Message: "error 3"},
 				{Path: "file4.go", Identifier: "TEST003", Message: "error 4"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Identifier: "TEST001"},                   // Should remove all TEST001
 				{Path: "file3.go", Identifier: "TEST002"}, // Should remove only TEST002 in file3.go
 				{Message: "error 4"},                      // Should remove anything with this message
 			},
-			expectedResults: []CheckResult{},
+			expectedResults: []validation.CheckResult{},
 		},
 	}
 
@@ -174,71 +176,71 @@ func TestRemoveByIdentifier(t *testing.T) {
 func TestRemoveByMessage(t *testing.T) {
 	tests := []struct {
 		name            string
-		initialResults  []CheckResult
-		ignores         []ToolConfigIgnore
-		expectedResults []CheckResult
+		initialResults  []validation.CheckResult
+		ignores         []validation.ToolConfigIgnore
+		expectedResults []validation.CheckResult
 	}{
 		{
 			name: "remove_single_result_by_exact_message",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Path: "file1.go", Message: "test error message"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
 		},
 		{
 			name: "remove_by_message_only",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "test error message", Severity: "error"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Message: "test error message"},
 			},
-			expectedResults: []CheckResult{},
+			expectedResults: []validation.CheckResult{},
 		},
 		{
 			name: "remove_by_partial_message_match",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Message: "test error"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
 		},
 		{
 			name: "no_matches",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Message: "non-existent message"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "another error message", Severity: "error"},
 			},
 		},
 		{
 			name: "remove_by_path_and_partial_message",
-			initialResults: []CheckResult{
+			initialResults: []validation.CheckResult{
 				{Path: "file1.go", Line: 1, Message: "test error message", Severity: "error"},
 				{Path: "file2.go", Line: 2, Message: "test error message", Severity: "error"},
 			},
-			ignores: []ToolConfigIgnore{
+			ignores: []validation.ToolConfigIgnore{
 				{Path: "file1.go", Message: "test"},
 			},
-			expectedResults: []CheckResult{
+			expectedResults: []validation.CheckResult{
 				{Path: "file2.go", Line: 2, Message: "test error message", Severity: "error"},
 			},
 		},

--- a/internal/verifier/stylelint.go
+++ b/internal/verifier/stylelint.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type StylintError struct {
@@ -80,7 +82,7 @@ func (s StyleLint) Check(ctx context.Context, check *Check, config ToolConfig) e
 						msg.Severity = "warn"
 					}
 
-					check.AddResult(CheckResult{
+					check.AddResult(validation.CheckResult{
 						Path:       fixedPath,
 						Line:       msg.Line,
 						Message:    msg.Text,
@@ -94,7 +96,7 @@ func (s StyleLint) Check(ctx context.Context, check *Check, config ToolConfig) e
 						msg.Severity = "warn"
 					}
 
-					check.AddResult(CheckResult{
+					check.AddResult(validation.CheckResult{
 						Path:       fixedPath,
 						Line:       msg.Line,
 						Message:    msg.Text,

--- a/internal/verifier/sw_cli.go
+++ b/internal/verifier/sw_cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/shopware/shopware-cli/extension"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 type SWCLI struct{}
@@ -17,34 +18,27 @@ func (s SWCLI) Check(ctx context.Context, check *Check, config ToolConfig) error
 		return nil
 	}
 
-	validationContext := extension.RunValidation(ctx, config.Extension)
+	extension.RunValidation(ctx, config.Extension, check)
 
+	// Apply ignores from extension config
+	ignores := make([]validation.ToolConfigIgnore, 0)
+	for _, ignore := range config.Extension.GetExtensionConfig().Validation.Ignore {
+		ignores = append(ignores, validation.ToolConfigIgnore{
+			Identifier: ignore.Identifier,
+			Path:       ignore.Path,
+			Message:    ignore.Message,
+		})
+	}
+	
 	if config.InputWasDirectory {
-		validationContext.ApplyIgnores([]extension.ConfigValidationIgnoreItem{
-			{
-				Identifier: "zip.disallowed_file",
-			},
+		// Add additional ignores for directory input
+		ignores = append(ignores, validation.ToolConfigIgnore{
+			Identifier: "zip.disallowed_file",
 		})
 	}
-
-	for _, err := range validationContext.Errors() {
-		check.AddResult(CheckResult{
-			Path:       "",
-			Line:       0,
-			Message:    err.Message,
-			Identifier: err.Identifier,
-			Severity:   "error",
-		})
-	}
-
-	for _, err := range validationContext.Warnings() {
-		check.AddResult(CheckResult{
-			Path:       "",
-			Line:       0,
-			Message:    err.Message,
-			Identifier: err.Identifier,
-			Severity:   "warning",
-		})
+	
+	if len(ignores) > 0 {
+		check.RemoveByIdentifier(ignores)
 	}
 
 	return nil

--- a/internal/verifier/tool.go
+++ b/internal/verifier/tool.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 
 	"github.com/shopware/shopware-cli/extension"
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
-const SeverityError = "error"
-const SeverityWarning = "warning"
 
 type ToolList []Tool
 
@@ -40,7 +39,7 @@ type ToolConfig struct {
 	// Contains a list of directories that are considered as source code
 	SourceDirectories []string
 	// Contains a list of identifiers that are ignored
-	ValidationIgnores []ToolConfigIgnore
+	ValidationIgnores []validation.ToolConfigIgnore
 	// Contains a list of directories that are considered as admin code
 	AdminDirectories []string
 	// Contains a list of directories that are considered as storefront code
@@ -49,11 +48,6 @@ type ToolConfig struct {
 	Extension extension.Extension
 }
 
-type ToolConfigIgnore struct {
-	Identifier string
-	Path       string
-	Message    string
-}
 
 type Tool interface {
 	Name() string


### PR DESCRIPTION
- Updated asset validation functions to utilize the new validation.Check interface and CheckResult struct.
- Replaced context-based error handling with a more structured approach using validation results.
- Refactored tests to align with the new validation structure, ensuring proper error and result assertions.
- Introduced ToolConfigIgnore struct for better management of validation ignores.
- Enhanced various verifier implementations (e.g., ESLint, Stylelint, PHPStan) to utilize the new validation results.
- Removed deprecated CheckResult struct and constants, centralizing validation logic within the validation package.