### PR TITLE
feat(commands): add common aliases to project commands

### DIFF
--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -12,8 +12,9 @@ import (
 )
 
 var projectAdminBuildCmd = &cobra.Command{
-	Use:   "admin-build [project-dir]",
-	Short: "Builds the Administration",
+	Use:     "admin-build [project-dir]",
+	Short:   "Builds the Administration",
+	Aliases: []string{"build-admin"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -13,8 +13,9 @@ import (
 )
 
 var projectAdminWatchCmd = &cobra.Command{
-	Use:   "admin-watch [path]",
-	Short: "Starts the Shopware Admin Watcher",
+	Use:     "admin-watch [path]",
+	Short:   "Starts the Shopware Admin Watcher",
+	Aliases: []string{"watch-admin"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -12,8 +12,9 @@ import (
 )
 
 var projectStorefrontBuildCmd = &cobra.Command{
-	Use:   "storefront-build [path]",
-	Short: "Builds the Storefront",
+	Use:     "storefront-build [path]",
+	Short:   "Builds the Storefront",
+	Aliases: []string{"build-storefront"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -13,8 +13,9 @@ import (
 )
 
 var projectStorefrontWatchCmd = &cobra.Command{
-	Use:   "storefront-watch [path]",
-	Short: "Starts the Shopware Storefront Watcher",
+	Use:     "storefront-watch [path]",
+	Short:   "Starts the Shopware Storefront Watcher",
+	Aliases: []string{"watch-storefront"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectRoot string
 		var err error


### PR DESCRIPTION
I added some aliases which come in handy in daily use. Origin of this change is my own inability to memorize which way around these commands go.

As I think others might be as stupid as me, have a look :)