### PR TITLE
feat(twig-linter): add image alt attribute validation

### DIFF
--- a/internal/verifier/twiglinter/storefronttwiglinter/image.go
+++ b/internal/verifier/twiglinter/storefronttwiglinter/image.go
@@ -1,0 +1,68 @@
+package storefronttwiglinter
+
+import (
+	"strings"
+
+	"github.com/shyim/go-version"
+
+	"github.com/shopware/shopware-cli/internal/html"
+	"github.com/shopware/shopware-cli/internal/validation"
+	"github.com/shopware/shopware-cli/internal/verifier/twiglinter"
+)
+
+type ImageAltCheck struct{}
+
+func (i ImageAltCheck) Check(nodes []html.Node) []validation.CheckResult {
+	var errors []validation.CheckResult
+	html.TraverseNode(nodes, func(node *html.ElementNode) {
+		if node.Tag != "img" {
+			return
+		}
+
+		var hasAlt bool
+		var altValue string
+
+		for _, attr := range node.Attributes {
+			attrElement, ok := attr.(html.Attribute)
+			if !ok {
+				continue
+			}
+
+			if attrElement.Key == "alt" {
+				hasAlt = true
+				altValue = strings.TrimSpace(attrElement.Value)
+				break
+			}
+		}
+
+		if !hasAlt {
+			errors = append(errors, validation.CheckResult{
+				Message:    "Image tags must have an alt attribute for accessibility",
+				Severity:   validation.SeverityWarning,
+				Identifier: "twig-linter/image-missing-alt",
+				Line:       node.Line,
+			})
+		} else if altValue == "" {
+			errors = append(errors, validation.CheckResult{
+				Message:    "Image alt attribute should not be empty - provide meaningful description or use empty alt=\"\" for decorative images",
+				Severity:   validation.SeverityWarning,
+				Identifier: "twig-linter/image-empty-alt",
+				Line:       node.Line,
+			})
+		}
+	})
+
+	return errors
+}
+
+func (i ImageAltCheck) Supports(v *version.Version) bool {
+	return true
+}
+
+func (i ImageAltCheck) Fix(nodes []html.Node) error {
+	return nil // No automatic fix for alt attributes, requires manual intervention
+}
+
+func init() {
+	twiglinter.AddStorefrontFixer(ImageAltCheck{})
+}

--- a/internal/verifier/twiglinter/storefronttwiglinter/image_test.go
+++ b/internal/verifier/twiglinter/storefronttwiglinter/image_test.go
@@ -1,0 +1,118 @@
+package storefronttwiglinter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/verifier/twiglinter"
+)
+
+func TestImageAltDetection(t *testing.T) {
+	cases := []struct {
+		name          string
+		content       string
+		expectedCount int
+	}{
+		{
+			name:          "Valid image with meaningful alt text",
+			content:       `<img src="test.jpg" alt="A beautiful sunset over the mountains">`,
+			expectedCount: 0,
+		},
+		{
+			name:          "Image without alt attribute",
+			content:       `<img src="test.jpg">`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Image with empty alt attribute",
+			content:       `<img src="test.jpg" alt="">`,
+			expectedCount: 1, // Info level warning for empty alt
+		},
+		{
+			name:          "Image with whitespace-only alt attribute",
+			content:       `<img src="test.jpg" alt="   ">`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Multiple images - some valid, some invalid",
+			content: `
+				<img src="valid.jpg" alt="Valid description">
+				<img src="invalid1.jpg">
+				<img src="invalid2.jpg" alt="">
+				<img src="valid2.jpg" alt="Another valid description">
+			`,
+			expectedCount: 2, // Two invalid images
+		},
+		{
+			name:          "Image with other attributes and valid alt",
+			content:       `<img src="test.jpg" class="responsive" width="100" height="100" alt="Test image description">`,
+			expectedCount: 0,
+		},
+		{
+			name:          "Image with Twig variables in alt",
+			content:       `<img src="{{ image.url }}" alt="{{ image.description }}">`,
+			expectedCount: 0,
+		},
+		{
+			name:          "Image with Twig variables but no alt",
+			content:       `<img src="{{ image.url }}" class="{{ image.class }}">`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Nested image in complex HTML",
+			content: `
+				<div class="gallery">
+					<figure>
+						<img src="gallery1.jpg" alt="First gallery image">
+					</figure>
+					<figure>
+						<img src="gallery2.jpg">
+					</figure>
+				</div>
+			`,
+			expectedCount: 1, // Second image missing alt
+		},
+		{
+			name:          "Self-closing image tag",
+			content:       `<img src="test.jpg" alt="Self-closing tag" />`,
+			expectedCount: 0,
+		},
+		{
+			name:          "Self-closing image tag without alt",
+			content:       `<img src="test.jpg" />`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Empty content",
+			content:       ``,
+			expectedCount: 0,
+		},
+		{
+			name:          "No image tags",
+			content:       `<div><p>Some text without images</p></div>`,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checks, err := twiglinter.RunCheckerOnString(ImageAltCheck{}, tc.content)
+			assert.NoError(t, err)
+			assert.Len(t, checks, tc.expectedCount, "Expected %d validation errors but got %d", tc.expectedCount, len(checks))
+		})
+	}
+}
+
+func TestImageAltCheckIdentifiers(t *testing.T) {
+	// Test that correct identifiers are used for different types of errors
+	missingAltChecks, err := twiglinter.RunCheckerOnString(ImageAltCheck{}, `<img src="test.jpg">`)
+	assert.NoError(t, err)
+	assert.Len(t, missingAltChecks, 1)
+	assert.Equal(t, "twig-linter/image-missing-alt", missingAltChecks[0].Identifier)
+
+	emptyAltChecks, err := twiglinter.RunCheckerOnString(ImageAltCheck{}, `<img src="test.jpg" alt="">`)
+	assert.NoError(t, err)
+	assert.Len(t, emptyAltChecks, 1)
+	assert.Equal(t, "twig-linter/image-empty-alt", emptyAltChecks[0].Identifier)
+}


### PR DESCRIPTION
## Summary
- Add Twig linter to validate img tags have alt attributes for accessibility
- Check for missing alt attributes on img tags  
- Warn about empty alt attributes to encourage meaningful descriptions
- Comprehensive test coverage for various scenarios including Twig variables, nested HTML, and edge cases

## Implementation Details
- Follows existing linter patterns similar to `LinkCheck`
- Integrates with storefront Twig linter system
- Two validation rules:
  - `twig-linter/image-missing-alt`: Missing alt attribute (Warning)
  - `twig-linter/image-empty-alt`: Empty alt attribute (Warning)

## Test Plan
- [x] Unit tests covering valid/invalid images
- [x] Tests for Twig variables in alt attributes
- [x] Tests for nested HTML and self-closing tags
- [x] Tests for edge cases (empty content, no images)
- [x] All existing tests still pass
- [x] Proper error identifiers and messages

Fixes #639

🤖 Generated with [Claude Code](https://claude.ai/code)