### PR TITLE
fix: break out of code review loop on retry skip

### DIFF
--- a/cmd/account/account_producer_extension_upload.go
+++ b/cmd/account/account_producer_extension_upload.go
@@ -171,6 +171,7 @@ var accountCompanyProducerExtensionUploadCmd = &cobra.Command{
 
 				if maxTries == tried {
 					logging.FromContext(cmd.Context()).Infof("Skipping waiting for code review result as it took too long")
+					break
 				}
 			}
 		}


### PR DESCRIPTION
While trying to release a new version of Commercial, the Code-Review got stuck and shopware-cli got into the Code Review timeout.
I just got the output "Skipping waiting for code review result as it took too long" and the workflow got stuck.
I think we need to break out of the `for` at that point.