### PR TITLE
Add DisableComposerScripts flag to project config

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -75,6 +75,10 @@ var projectCI = &cobra.Command{
 			composerFlags = append(composerFlags, "--no-dev")
 		}
 
+		if shopCfg.DisableComposerScripts {
+			composerFlags = append(composerFlags, "--no-scripts")
+		}
+
 		token, err := prepareComposerAuth(cmd.Context(), args[0])
 		if err != nil {
 			return err

--- a/shop/config.go
+++ b/shop/config.go
@@ -29,7 +29,9 @@ type Config struct {
 	ConfigDeployment *ConfigDeployment `yaml:"deployment,omitempty"`
 	Validation       *ConfigValidation `yaml:"validation,omitempty"`
 	ImageProxy       *ConfigImageProxy `yaml:"image_proxy,omitempty"`
-	foundConfig      bool
+	// When enabled, composer scripts will be disabled during CI builds
+	DisableComposerScripts bool `yaml:"disable_composer_scripts,omitempty"`
+	foundConfig            bool
 }
 
 func (c *Config) IsAdminAPIConfigured() bool {

--- a/shop/shopware-project-schema.json
+++ b/shop/shopware-project-schema.json
@@ -35,6 +35,10 @@
         },
         "image_proxy": {
           "$ref": "#/$defs/ConfigImageProxy"
+        },
+        "disable_composer_scripts": {
+          "type": "boolean",
+          "description": "When enabled, composer scripts will be disabled during CI builds"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This adds a new `disable_composer_scripts` flag to .shopware-project.yml that, when set to true, adds the `--no-scripts` option to the composer install command during CI builds. This prevents failures when services like Redis are not active during the build process.

Fixes #706

Generated with [Claude Code](https://claude.ai/code)