### PR TITLE
Add ForceAdminBuild support to admin-build command

### DIFF
--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -57,6 +57,7 @@ var projectAdminBuildCmd = &cobra.Command{
 			ShopwareRoot:           projectRoot,
 			ShopwareVersion:        shopwareConstraint,
 			NPMForceInstall:        forceInstall,
+			ForceAdminBuild:        shopCfg.Build.ForceAdminBuild,
 		}
 
 		if err := extension.BuildAssetsForExtensions(cmd.Context(), sources, assetCfg); err != nil {


### PR DESCRIPTION
Pass down ForceAdminBuild flag from shopware-project config to the admin-build command, similar to how it's already done in the ci command. This allows rebuilding core administration files when they have been patched.

Fixes #676

Generated with [Claude Code](https://claude.ai/code)