### PR TITLE
fix(project): keep Docker upgrades connected when recipes reset .env

### DIFF
--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -19,6 +19,22 @@ type DockerExecutor struct {
 	relDir      string
 	shopCfg     *shop.Config
 	envCfg      *shop.EnvironmentConfig
+	// composeProjectName pins the Compose project (-p) for every invocation.
+	// It is resolved from the project .env once at construction: Compose
+	// re-reads .env per command, so a mid-run rewrite of that file (e.g.
+	// `composer recipes:install --force --reset` during an upgrade) would
+	// otherwise silently disconnect running containers.
+	composeProjectName string
+}
+
+// composeArgs starts a docker argument list for a compose subcommand, pinning
+// the project name when one is known.
+func (d *DockerExecutor) composeArgs(sub ...string) []string {
+	args := []string{"compose"}
+	if d.composeProjectName != "" {
+		args = append(args, "-p", d.composeProjectName)
+	}
+	return append(args, sub...)
 }
 
 func (d *DockerExecutor) ConsoleCommand(ctx context.Context, args ...string) *Process {
@@ -93,11 +109,11 @@ func (d *DockerExecutor) WithEnv(env map[string]string) Executor {
 		}
 	}
 
-	return &DockerExecutor{env: mergeEnv(d.env, env), projectRoot: d.projectRoot, relDir: d.relDir, shopCfg: d.shopCfg, envCfg: d.envCfg}
+	return &DockerExecutor{env: mergeEnv(d.env, env), projectRoot: d.projectRoot, relDir: d.relDir, shopCfg: d.shopCfg, envCfg: d.envCfg, composeProjectName: d.composeProjectName}
 }
 
 func (d *DockerExecutor) WithRelDir(relDir string) Executor {
-	return &DockerExecutor{env: d.env, projectRoot: d.projectRoot, relDir: relDir, shopCfg: d.shopCfg, envCfg: d.envCfg}
+	return &DockerExecutor{env: d.env, projectRoot: d.projectRoot, relDir: relDir, shopCfg: d.shopCfg, envCfg: d.envCfg, composeProjectName: d.composeProjectName}
 }
 
 func (d *DockerExecutor) AdminAPIClient(ctx context.Context) (*adminSdk.Client, error) {
@@ -116,12 +132,12 @@ func (d *DockerExecutor) newProcess(cmd *exec.Cmd, innerArgs []string) *Process 
 	projectRoot := d.projectRoot
 	pattern := strings.Join(innerArgs, " ")
 
+	killArgs := append(d.composeArgs("exec", "-T", "web"), "pkill", "-INT", "-f", pattern)
+
 	return &Process{
 		Cmd: cmd,
 		stop: func(ctx context.Context) error {
-			killCmd := exec.CommandContext(ctx, "docker", "compose", "exec", "-T", "web",
-				"pkill", "-INT", "-f", pattern,
-			)
+			killCmd := exec.CommandContext(ctx, "docker", killArgs...)
 			killCmd.Dir = projectRoot
 			_ = killCmd.Run()
 
@@ -135,7 +151,7 @@ func (d *DockerExecutor) newProcess(cmd *exec.Cmd, innerArgs []string) *Process 
 }
 
 func (d *DockerExecutor) StartEnvironment(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "docker", "compose", "up", "-d")
+	cmd := exec.CommandContext(ctx, "docker", d.composeArgs("up", "-d")...)
 	cmd.Dir = d.projectRoot
 
 	output, err := cmd.CombinedOutput()
@@ -147,7 +163,7 @@ func (d *DockerExecutor) StartEnvironment(ctx context.Context) error {
 }
 
 func (d *DockerExecutor) StopEnvironment(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "docker", "compose", "down")
+	cmd := exec.CommandContext(ctx, "docker", d.composeArgs("down")...)
 	cmd.Dir = d.projectRoot
 
 	output, err := cmd.CombinedOutput()
@@ -159,7 +175,7 @@ func (d *DockerExecutor) StopEnvironment(ctx context.Context) error {
 }
 
 func (d *DockerExecutor) EnvironmentStatus(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx, "docker", "compose", "ps", "--status=running", "-q")
+	cmd := exec.CommandContext(ctx, "docker", d.composeArgs("ps", "--status=running", "-q")...)
 	cmd.Dir = d.projectRoot
 
 	output, err := cmd.Output()
@@ -171,7 +187,7 @@ func (d *DockerExecutor) EnvironmentStatus(ctx context.Context) (bool, error) {
 }
 
 func (d *DockerExecutor) baseArgs() []string {
-	args := []string{"compose", "exec"}
+	args := d.composeArgs("exec")
 
 	args = append(args, "-T")
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
@@ -288,6 +289,80 @@ func TestDockerExecutorPHPCommand(t *testing.T) {
 	assert.Contains(t, p.Cmd.Args, "web")
 	assert.Contains(t, p.Cmd.Args, "php")
 	assert.Contains(t, p.Cmd.Args, "-v")
+}
+
+// composeProjectArgIndex returns the index of the "-p" flag in args, or -1.
+func composeProjectArgIndex(args []string) int {
+	for i, arg := range args {
+		if arg == "-p" {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestDockerExecutorPinsComposeProjectName(t *testing.T) {
+	exec := &DockerExecutor{projectRoot: "/project", composeProjectName: "sw-shop-abc123"}
+
+	for _, p := range []*Process{
+		exec.ConsoleCommand(t.Context(), "cache:clear"),
+		exec.ComposerCommand(t.Context(), "install"),
+		exec.PHPCommand(t.Context(), "-v"),
+		exec.NPMCommand(t.Context(), "run", "dev"),
+	} {
+		i := composeProjectArgIndex(p.Cmd.Args)
+		require.Greater(t, i, 0, "compose invocation carries -p: %v", p.Cmd.Args)
+		assert.Equal(t, "compose", p.Cmd.Args[i-1], "-p directly follows compose")
+		assert.Equal(t, "sw-shop-abc123", p.Cmd.Args[i+1])
+	}
+
+	// The pin survives the executor's copy-on-write helpers.
+	for _, derived := range []Executor{
+		exec.WithEnv(map[string]string{"FOO": "bar"}),
+		exec.WithRelDir("custom/plugins"),
+	} {
+		p := derived.PHPCommand(t.Context(), "-v")
+		i := composeProjectArgIndex(p.Cmd.Args)
+		require.Greater(t, i, 0)
+		assert.Equal(t, "sw-shop-abc123", p.Cmd.Args[i+1])
+	}
+}
+
+func TestDockerExecutorWithoutComposeProjectName(t *testing.T) {
+	exec := &DockerExecutor{projectRoot: "/project"}
+
+	p := exec.PHPCommand(t.Context(), "-v")
+	assert.Equal(t, -1, composeProjectArgIndex(p.Cmd.Args), "no -p flag without a configured project name")
+}
+
+func TestNewDockerExecutorReadsComposeProjectName(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("COMPOSE_PROJECT_NAME=sw-shop-abc123\n"), 0o644))
+
+	t.Run("snapshots the .env value at construction", func(t *testing.T) {
+		t.Setenv(shop.ComposeProjectNameEnvKey, "")
+		exec, err := New(dir, &shop.EnvironmentConfig{Type: "docker"}, &shop.Config{})
+		require.NoError(t, err)
+
+		// A later .env rewrite (e.g. a Flex recipe reset mid-upgrade) must not
+		// detach the executor from the containers it started with.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_ENV=prod\n"), 0o644))
+
+		p := exec.PHPCommand(t.Context(), "-v")
+		i := composeProjectArgIndex(p.Cmd.Args)
+		require.Greater(t, i, 0)
+		assert.Equal(t, "sw-shop-abc123", p.Cmd.Args[i+1])
+	})
+
+	t.Run("a process-level COMPOSE_PROJECT_NAME stays authoritative", func(t *testing.T) {
+		t.Setenv(shop.ComposeProjectNameEnvKey, "from-shell")
+		exec, err := New(dir, &shop.EnvironmentConfig{Type: "docker"}, &shop.Config{})
+		require.NoError(t, err)
+
+		p := exec.PHPCommand(t.Context(), "-v")
+		assert.Equal(t, -1, composeProjectArgIndex(p.Cmd.Args),
+			"the inherited environment variable already outranks .env for every docker invocation")
+	})
 }
 
 func TestConsoleCommandNameDefault(t *testing.T) {

--- a/internal/executor/factory.go
+++ b/internal/executor/factory.go
@@ -26,7 +26,16 @@ func New(projectRoot string, cfg *shop.EnvironmentConfig, shopCfg *shop.Config) 
 		}
 		return &SymfonyCLIExecutor{BinaryPath: path, projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
 	case TypeDocker:
-		return &DockerExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
+		// Snapshot the Compose project name from .env now — Compose re-reads
+		// .env per command, so a later rewrite of that file must not detach
+		// the executor from the containers it started with. A process-level
+		// COMPOSE_PROJECT_NAME outranks .env in Compose's own precedence and
+		// is inherited by every docker invocation, so it stays authoritative.
+		composeProjectName := ""
+		if os.Getenv(shop.ComposeProjectNameEnvKey) == "" {
+			composeProjectName = shop.ReadComposeProjectName(projectRoot)
+		}
+		return &DockerExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg, composeProjectName: composeProjectName}, nil
 	default:
 		return nil, fmt.Errorf("unsupported environment type: %s", cfg.Type)
 	}

--- a/internal/shop/compose_project_name.go
+++ b/internal/shop/compose_project_name.go
@@ -63,6 +63,16 @@ func EnvFileContent(useDocker bool, projectFolder string) (string, error) {
 	return ComposeProjectNameEnvKey + "=" + name + "\n", nil
 }
 
+// ReadComposeProjectName returns the COMPOSE_PROJECT_NAME configured in the
+// project's .env, or "" when the file or the key is missing.
+func ReadComposeProjectName(projectRoot string) string {
+	content, err := os.ReadFile(filepath.Join(projectRoot, ".env"))
+	if err != nil {
+		return ""
+	}
+	return ExtractComposeProjectName(content)
+}
+
 // ExtractComposeProjectName returns the COMPOSE_PROJECT_NAME value from raw
 // dotenv content, or "" when unset.
 func ExtractComposeProjectName(envContent []byte) string {
@@ -87,6 +97,23 @@ func ExtractComposeProjectName(envContent []byte) string {
 // when it is not already set. Existing values are left untouched (no silent
 // volume disconnect for established stacks). The file is created when missing.
 func EnsureComposeProjectName(projectRoot string) error {
+	name, err := GenerateComposeProjectName(projectRoot)
+	if err != nil {
+		return err
+	}
+	return RestoreComposeProjectName(projectRoot, name)
+}
+
+// RestoreComposeProjectName re-adds a known COMPOSE_PROJECT_NAME to the
+// project .env when the key was lost — e.g. after `composer recipes:install
+// --force --reset` replaced .env with the recipe template. A present value is
+// left untouched, an empty name is a no-op, and the file is created when
+// missing.
+func RestoreComposeProjectName(projectRoot, name string) error {
+	if name == "" {
+		return nil
+	}
+
 	envPath := filepath.Join(projectRoot, ".env")
 	existing, err := os.ReadFile(envPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -95,11 +122,6 @@ func EnsureComposeProjectName(projectRoot string) error {
 
 	if ExtractComposeProjectName(existing) != "" {
 		return nil
-	}
-
-	name, err := GenerateComposeProjectName(projectRoot)
-	if err != nil {
-		return err
 	}
 
 	content := existing

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -98,3 +98,53 @@ func TestEnsureComposeProjectName(t *testing.T) {
 		assert.Contains(t, string(content), ComposeProjectNameEnvKey+"=")
 	})
 }
+
+func TestReadComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	assert.Empty(t, ReadComposeProjectName(dir), "missing .env reads as unset")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_ENV=dev\nCOMPOSE_PROJECT_NAME=sw-shop-abc123\n"), 0o644))
+	assert.Equal(t, "sw-shop-abc123", ReadComposeProjectName(dir))
+}
+
+func TestRestoreComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("re-adds a lost name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// A recipe reset replaced .env and dropped the key.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_ENV=prod\n"), 0o644))
+
+		require.NoError(t, RestoreComposeProjectName(dir, "sw-shop-abc123"))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "APP_ENV=prod")
+		assert.Equal(t, "sw-shop-abc123", ExtractComposeProjectName(content))
+	})
+
+	t.Run("empty name is a no-op", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		require.NoError(t, RestoreComposeProjectName(dir, ""))
+
+		_, err := os.Stat(filepath.Join(dir, ".env"))
+		assert.True(t, os.IsNotExist(err), "no .env is created for projects without a compose project name")
+	})
+
+	t.Run("present value stays untouched", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("COMPOSE_PROJECT_NAME=sw-keep-ffffff\n"), 0o644))
+
+		require.NoError(t, RestoreComposeProjectName(dir, "sw-other-000000"))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env"))
+		require.NoError(t, err)
+		assert.Equal(t, "sw-keep-ffffff", ExtractComposeProjectName(content))
+	})
+}

--- a/internal/shop/upgrade/run.go
+++ b/internal/shop/upgrade/run.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -168,8 +169,17 @@ func (u *ProjectUpgrader) runSteps(ctx context.Context, opts *RunOptions, emit f
 		// web-installer refreshes recipe-managed files. It is best effort:
 		// a failure downgrades to a warning instead of rolling back.
 		{StepRecipesInstall, true, func(ctx context.Context, line func(string)) error {
-			return streamProcess(ctx, exec.ComposerCommand(ctx,
+			// The reset replaces .env with the recipe template, which drops
+			// the host-side COMPOSE_PROJECT_NAME — Docker environments would
+			// lose their running containers for the remaining steps and every
+			// later shopware-cli command. Re-add it once the recipes ran.
+			composeName := shop.ReadComposeProjectName(u.projectRoot)
+			err := streamProcess(ctx, exec.ComposerCommand(ctx,
 				"symfony:recipes:install", "--force", "--reset", "--yes", "--no-interaction", "--no-ansi", "-v"), line)
+			if restoreErr := shop.RestoreComposeProjectName(u.projectRoot, composeName); restoreErr != nil {
+				line("Could not restore " + shop.ComposeProjectNameEnvKey + " in .env: " + restoreErr.Error())
+			}
+			return err
 		}},
 		{StepDeploymentHelper, false, func(ctx context.Context, line func(string)) error {
 			return streamProcess(ctx, exec.PHPCommand(ctx, "vendor/bin/shopware-deployment-helper", "run"), line)

--- a/internal/shop/upgrade/run_test.go
+++ b/internal/shop/upgrade/run_test.go
@@ -246,6 +246,37 @@ func TestRunnerRecipesInstallIsNonFatal(t *testing.T) {
 	assert.Contains(t, string(content), `"shopware/core": "6.7.11.0"`, "no rollback happened")
 }
 
+func TestRunnerRestoresComposeProjectNameAfterRecipesReset(t *testing.T) {
+	dir := setupProject(t)
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("COMPOSE_PROJECT_NAME=sw-shop-abc123\nAPP_ENV=prod\n"), 0o644))
+
+	u := NewProjectUpgrader(dir, &fakeExecutor{
+		composer: func(ctx context.Context, args ...string) *executor.Process {
+			if args[0] == "symfony:recipes:install" {
+				// The recipe reset replaces .env with the template, dropping
+				// the host-side compose project name.
+				if err := os.WriteFile(envPath, []byte("APP_ENV=prod\n"), 0o644); err != nil {
+					return shellProcess(ctx, "exit 3")
+				}
+			}
+			return shellProcess(ctx, "true")
+		},
+		php: func(ctx context.Context, _ ...string) *executor.Process {
+			return shellProcess(ctx, "true")
+		},
+	})
+
+	events := collectEvents(t, u.Run(t.Context(), runnerOptions()))
+	require.Equal(t, StateOK, finalEvent(t, events).State)
+
+	content, err := os.ReadFile(envPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "APP_ENV=prod", "the recipe-reset .env is kept")
+	assert.Contains(t, string(content), "COMPOSE_PROJECT_NAME=sw-shop-abc123",
+		"the compose project name is re-added so later steps and commands still reach the containers")
+}
+
 func TestRunnerCancelledContext(t *testing.T) {
 	dir := setupProject(t)
 	ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
## Problem

On Docker projects created after #1252 (unique `COMPOSE_PROJECT_NAME` in `.env`), `shopware-cli project upgrade` reproducibly fails at the deployment-helper step with `service "web" is not running` — while the web container is running.

Failure chain:

1. `docker compose exec` resolves the project name from `.env` (`COMPOSE_PROJECT_NAME=sw-<name>-<hex>`), so readiness checks and `composer update` work.
2. The `composer recipes:install --force --reset` step rewrites `.env` from the shopware/core recipe template. `COMPOSE_PROJECT_NAME` sits outside any `###> package ###` marker block, so Flex drops it.
3. The next `docker compose exec` derives the project name from the directory basename, finds no containers under that name, and the deployment-helper step fails → the upgrade rolls back.
4. Rollback only restores `composer.json`/`composer.lock`; the reset `.env` persists, so every later shopware-cli command (readiness tooling check, `project console`, …) is also cut off from the still-running stack.

Projects whose compose project name equals the directory basename (created before #1252) are unaffected, which is why this went unnoticed.

## Fix

Two layers:

- **Executor**: `DockerExecutor` snapshots the compose project name from `.env` once at construction and pins it with `docker compose -p <name>` on every invocation (`exec`, `up`, `down`, `ps`, and the stop-side `pkill`). A mid-run `.env` rewrite can no longer detach an in-flight upgrade. A process-level `COMPOSE_PROJECT_NAME` keeps precedence, matching Compose's own rules.
- **Upgrade runner**: after the recipes step, the previously configured `COMPOSE_PROJECT_NAME` is re-added to `.env` (via the new `shop.RestoreComposeProjectName`, which `EnsureComposeProjectName` now shares), so the project stays reachable after the wizard finishes and on rolled-back runs. The recipe-reset `.env` is otherwise kept as-is.

## Tests

- `shop`: `ReadComposeProjectName`, `RestoreComposeProjectName` (re-add, no-op on empty name, present value untouched)
- `executor`: `-p` pinning across all command builders and the copy-on-write helpers, no `-p` without a name, construction-time snapshot survives an `.env` rewrite, OS-env precedence
- `upgrade`: full runner pass where the recipes step resets `.env`, asserting the name is restored while the recipe changes are kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKvYSHbxfbkkondYdJ3Caw