### PR TITLE
fix: create missing .env.local when starting the Docker dev environment

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -147,7 +148,26 @@ func WriteComposeFile(projectFolder string, opts *ComposeOptions) error {
 		return fmt.Errorf("failed to generate compose.yaml: %w", err)
 	}
 
+	if err := ensureEnvLocalFile(projectFolder); err != nil {
+		return err
+	}
+
 	return os.WriteFile(filepath.Join(projectFolder, "compose.yaml"), composeBytes, 0o644)
+}
+
+// ensureEnvLocalFile creates .env.local when it is missing. The generated
+// compose file declares it as env_file for every PHP service, and Compose
+// refuses to start when a declared env file does not exist — which is the
+// state of every fresh clone, since .env.local is gitignored.
+func ensureEnvLocalFile(projectFolder string) error {
+	envLocalPath := filepath.Join(projectFolder, ".env.local")
+	if _, err := os.Stat(envLocalPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return os.WriteFile(envLocalPath, []byte(shop.EnvLocalDockerContent), 0o644)
 }
 
 func buildCompose(hasAMQP, hasElasticsearch bool, opts *ComposeOptions) yaml.Node {

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1,10 +1,13 @@
 package docker
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shyim/go-composer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProfilerNeedsCredentials(t *testing.T) {
@@ -28,6 +31,42 @@ func TestProfilerIsPaid(t *testing.T) {
 	assert.False(t, ProfilerIsPaid(ProfilerSpx))
 	assert.True(t, ProfilerIsPaid(ProfilerBlackfire))
 	assert.True(t, ProfilerIsPaid(ProfilerTideways))
+}
+
+func TestWriteComposeFileEnvLocal(t *testing.T) {
+	t.Parallel()
+
+	setupProject := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		lock := `{"packages": [{"name": "shopware/core", "version": "6.6.0.0"}], "packages-dev": []}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(lock), 0o644))
+		return dir
+	}
+
+	t.Run("creates missing env.local", func(t *testing.T) {
+		t.Parallel()
+		dir := setupProject(t)
+
+		require.NoError(t, WriteComposeFile(dir, nil))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env.local"))
+		require.NoError(t, err)
+		assert.Equal(t, "APP_ENV=dev\n", string(content))
+	})
+
+	t.Run("keeps existing env.local untouched", func(t *testing.T) {
+		t.Parallel()
+		dir := setupProject(t)
+		existing := "APP_ENV=prod\nAPP_SECRET=abc\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env.local"), []byte(existing), 0o644))
+
+		require.NoError(t, WriteComposeFile(dir, nil))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env.local"))
+		require.NoError(t, err)
+		assert.Equal(t, existing, string(content))
+	})
 }
 
 func TestGenerateComposeFile(t *testing.T) {

--- a/internal/shop/project_scaffold.go
+++ b/internal/shop/project_scaffold.go
@@ -155,9 +155,14 @@ func (s *ShopwareProjectScaffold) WriteComposerJson(ctx context.Context) error {
 	return os.WriteFile(filepath.Join(s.ProjectFolder, "composer.json"), []byte(composerJSON), os.ModePerm)
 }
 
+// EnvLocalDockerContent is the initial .env.local of a Docker project. It is
+// what switches the containers into the dev environment: the committed .env
+// says APP_ENV=prod and the docker-dev image sets no environment of its own.
+const EnvLocalDockerContent = "APP_ENV=dev\n"
+
 func envLocalContent(useDocker bool) string {
 	if useDocker {
-		return "APP_ENV=dev\n"
+		return EnvLocalDockerContent
 	}
 
 	return ""


### PR DESCRIPTION
## Summary

Fixes #1341.

A `--docker` project's `.env.local` is gitignored, so it exists only for whoever ran `project create`. On a fresh clone the generated `compose.yaml` still declares `env_file: [.env.local]`, so Compose refuses to start and `project dev` surfaced the raw error:

```
stat /path/to/project/.env.local: no such file or directory
Failed: exit status 1
```

This implements the issue's preferred suggestion (option 1): `WriteComposeFile` now ensures `.env.local` exists before writing `compose.yaml`, creating it with the same `APP_ENV=dev` content that `project create --docker` writes. An existing file is never touched.

The fix lives in `WriteComposeFile` because it is the function that emits the compose file requiring the env file, and every container-start path regenerates the compose file first: `project dev` / `dev start` / `dev stop` / `dev status`, the TUI's config-change restart, and the migration wizard.

Option 3 from the issue (making the `env_file` reference optional) was deliberately not taken: `.env.local` is the only thing putting the containers into `dev` — the committed `.env` says `prod` — so an optional reference would silently boot a fresh clone with a production kernel. The extracted `shop.EnvLocalDockerContent` constant documents that.

## Changes

- `internal/docker/compose.go`: `ensureEnvLocalFile` creates a missing `.env.local` before `compose.yaml` is written
- `internal/shop/project_scaffold.go`: extract `EnvLocalDockerContent` so scaffold and dev startup share the same content
- `internal/docker/compose_test.go`: tests that a missing file is created with `APP_ENV=dev` and an existing one is left untouched

## Test plan

- [x] `go test ./internal/docker/ ./internal/shop/`
- [x] Issue repro: clone of a `--docker` project starts via `project dev` because `.env.local` is recreated during environment setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker project setup now automatically creates a missing `.env.local` file with the required development environment settings.
  * Existing `.env.local` files are preserved without modification.
  * Unexpected file system errors are now reported during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->