### PR TITLE
docs(project): clarify --docker as local setup option

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -179,7 +179,7 @@ func applyNonInteractiveDefaults(opts *createOptions) error {
 
 func init() {
 	projectRootCmd.AddCommand(projectCreateCmd)
-	projectCreateCmd.PersistentFlags().Bool("docker", false, "Use Docker to run Composer instead of local installation")
+	projectCreateCmd.PersistentFlags().Bool("docker", false, "Use Docker for local setup")
 	projectCreateCmd.PersistentFlags().Bool("with-elasticsearch", false, "Include Elasticsearch/OpenSearch support")
 	projectCreateCmd.PersistentFlags().Bool("without-elasticsearch", false, "Remove Elasticsearch from the installation")
 	_ = projectCreateCmd.PersistentFlags().MarkDeprecated("without-elasticsearch", "use --with-elasticsearch instead")

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -179,7 +179,7 @@ func applyNonInteractiveDefaults(opts *createOptions) error {
 
 func init() {
 	projectRootCmd.AddCommand(projectCreateCmd)
-	projectCreateCmd.PersistentFlags().Bool("docker", false, "Use Docker for local setup")
+	projectCreateCmd.PersistentFlags().Bool("docker", false, "Use Docker for local setup.")
 	projectCreateCmd.PersistentFlags().Bool("with-elasticsearch", false, "Include Elasticsearch/OpenSearch support")
 	projectCreateCmd.PersistentFlags().Bool("without-elasticsearch", false, "Remove Elasticsearch from the installation")
 	_ = projectCreateCmd.PersistentFlags().MarkDeprecated("without-elasticsearch", "use --with-elasticsearch instead")

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -151,7 +151,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 			formGroups = append(formGroups, huh.NewGroup(
 				tui.NewYesNo().
 					Title("Docker").
-					Description("Use Docker to run Shopware locally").
+					Description("Use Docker for local setup").
 					Value(&selectDocker),
 			))
 		}

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -151,7 +151,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 			formGroups = append(formGroups, huh.NewGroup(
 				tui.NewYesNo().
 					Title("Docker").
-					Description("Use Docker for local setup").
+					Description("Use Docker for local setup.").
 					Value(&selectDocker),
 			))
 		}


### PR DESCRIPTION
## What changed?
Aligned the `project create --docker` flag help and the interactive form description to the same wording: **Use Docker for local setup**.

Before:
- Flag: `Use Docker to run Composer instead of local installation`
- Form: `Use Docker to run Shopware locally`

After:
- Flag and form: `Use Docker for local setup`

## Why?
The flag and interactive form disagreed about what `--docker` means (#1342). Without changing behavior, this makes the descriptions match each other and better reflect the local Docker setup intent.

## How was this tested?
- Reviewed the flag help and interactive form copy against the existing `--docker` behavior.
- No runtime behavior changes.

## Related issue or discussion
Fixes #1342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker setup descriptions in project creation options and prompts.
  * Updated wording to indicate Docker supports local setup without implying it is specifically required for running Composer or Shopware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->