### PR TITLE
fix(project): let a successful composer resolve overrule stale extension blockers

### DIFF
--- a/internal/shop/upgrade/compat.go
+++ b/internal/shop/upgrade/compat.go
@@ -127,11 +127,16 @@ func classifyExtension(ctx context.Context, repos *repository.Set, target *versi
 	}
 
 	installedCompatible := false
+	sawConstraint := false
 	var lowestCompatible *version.Version
 
 	for _, rel := range pkg.Versions {
 		constraint := shopwareConstraintOf(rel)
-		if constraint == nil || !constraint.Check(target) {
+		if constraint == nil {
+			continue
+		}
+		sawConstraint = true
+		if !constraint.Check(target) {
 			continue
 		}
 
@@ -160,6 +165,12 @@ func classifyExtension(ctx context.Context, repos *repository.Set, target *versi
 		res.Status = ExtNeedsUpdate
 		res.Available = lowestCompatible.String()
 		res.Detail = "A compatible Composer release is available; the upgrade updates the extension automatically."
+	case !sawConstraint:
+		// No release declares a Shopware constraint (some repositories strip
+		// require metadata) — that is "unknown", not "incompatible". The
+		// Composer dry run remains the authoritative gate.
+		res.Status = ExtReview
+		res.Detail = "The repository metadata does not declare Shopware compatibility; the Composer resolution check decides."
 	default:
 		res.Status = ExtBlocked
 		res.Detail = "No released version of this extension is compatible with the selected Shopware version."

--- a/internal/shop/upgrade/compat_test.go
+++ b/internal/shop/upgrade/compat_test.go
@@ -199,3 +199,38 @@ func TestTargetPHPRequirement(t *testing.T) {
 	assert.Equal(t, ">=8.2", u.TargetPHPRequirement(t.Context(), target))
 	assert.Empty(t, u.TargetPHPRequirement(t.Context(), version.Must(version.NewVersion("6.9.0.0"))))
 }
+
+func TestClassifyExtensionWithoutConstraintMetadataIsReviewNotBlocked(t *testing.T) {
+	dir := setupProject(t)
+	current, target := compatVersions(t)
+
+	// Some repositories (e.g. the Store packagist) strip require metadata
+	// entirely — that must read as "unknown", not "incompatible".
+	u := compatUpgrader(t, dir, fakeProvider{
+		"frosh/tools": {Name: "frosh/tools", Versions: []repository.Version{
+			release("frosh/tools", "3.12.0", ""),
+			release("frosh/tools", "3.11.0", ""),
+		}},
+		"swag/blocked": {Name: "swag/blocked", Versions: []repository.Version{
+			release("swag/blocked", "3.2.0", "~6.6.0"),
+		}},
+	}, nil, nil)
+
+	results := u.CheckExtensions(t.Context(), current, target, []InstalledExtension{
+		{Name: "FroshTools", Package: "frosh/tools", Version: "3.12.0", ComposerManaged: true},
+		{Name: "SwagBlocked", Package: "swag/blocked", Version: "3.2.0", ComposerManaged: true},
+	})
+	require.Len(t, results, 2)
+
+	byName := make(map[string]ExtensionResult)
+	for _, r := range results {
+		byName[r.Extension.Name] = r
+	}
+
+	unknown := byName["FroshTools"]
+	assert.Equal(t, ExtReview, unknown.Status, "missing constraints must not block")
+	assert.Contains(t, unknown.Detail, "does not declare Shopware compatibility")
+
+	blocked := byName["SwagBlocked"]
+	assert.Equal(t, ExtBlocked, blocked.Status, "known constraints excluding the target still block")
+}

--- a/internal/shop/upgrade/resolve.go
+++ b/internal/shop/upgrade/resolve.go
@@ -190,25 +190,42 @@ func ApplyResolvedVersions(results []ExtensionResult, resolve ResolveResult) {
 			continue
 		}
 
-		to := resolve.ResolvedVersion(res.Extension.Package)
-		if to != "" {
-			res.Available = to
+		change, inDiff := resolve.packageChange(res.Extension.Package)
+		if inDiff && change.To != "" {
+			res.Available = change.To
 		}
 
 		if !resolve.OK || !res.Status.BlocksUpgrade() {
 			continue
 		}
-		if to == "" || sameRelease(to, res.Extension.Version) {
+		switch {
+		case inDiff && change.Op == "remove":
+			// Transitively installed extensions can be dropped by the solver;
+			// that is not compatibility — the extension simply disappears.
+			res.Available = ""
+			res.Detail = "The Composer resolution removes this package — it would no longer be installed after the upgrade."
+		case !inDiff || sameRelease(change.To, res.Extension.Version):
 			// Absent from the lock diff means the solver kept the installed
-			// release (root requirements cannot be dropped).
+			// release.
 			res.Status = ExtOK
 			res.Available = res.Extension.Version
 			res.Detail = "Composer resolved the upgrade with the installed release; the repository's compatibility metadata was wrong or incomplete."
-		} else {
+		default:
 			res.Status = ExtNeedsUpdate
 			res.Detail = "Composer resolved the upgrade with this release; the repository's compatibility metadata was wrong or incomplete."
 		}
 	}
+}
+
+// packageChange returns the lock-diff entry for a package, if any. Composer
+// package names are case-insensitive.
+func (r ResolveResult) packageChange(pkg string) (PackageChange, bool) {
+	for _, change := range r.Changes {
+		if strings.EqualFold(change.Name, pkg) {
+			return change, true
+		}
+	}
+	return PackageChange{}, false
 }
 
 // sameRelease compares two version strings, tolerating v-prefix and segment

--- a/internal/shop/upgrade/resolve.go
+++ b/internal/shop/upgrade/resolve.go
@@ -177,15 +177,49 @@ func (r ResolveResult) VersionMap() map[string]string {
 
 // ApplyResolvedVersions overwrites each extension's Available version with
 // the exact release the resolution picked, where one was found.
+//
+// A successful resolution also overrides metadata-derived blockers: the
+// solver found an installable set that contains every root-required
+// extension, so an extension it updated — or silently kept at the installed
+// release — is proven compatible no matter what the repository metadata
+// claimed.
 func ApplyResolvedVersions(results []ExtensionResult, resolve ResolveResult) {
 	for i := range results {
-		if results[i].Extension.Package == "" {
+		res := &results[i]
+		if res.Extension.Package == "" {
 			continue
 		}
-		if to := resolve.ResolvedVersion(results[i].Extension.Package); to != "" {
-			results[i].Available = to
+
+		to := resolve.ResolvedVersion(res.Extension.Package)
+		if to != "" {
+			res.Available = to
+		}
+
+		if !resolve.OK || !res.Status.BlocksUpgrade() {
+			continue
+		}
+		if to == "" || sameRelease(to, res.Extension.Version) {
+			// Absent from the lock diff means the solver kept the installed
+			// release (root requirements cannot be dropped).
+			res.Status = ExtOK
+			res.Available = res.Extension.Version
+			res.Detail = "Composer resolved the upgrade with the installed release; the repository's compatibility metadata was wrong or incomplete."
+		} else {
+			res.Status = ExtNeedsUpdate
+			res.Detail = "Composer resolved the upgrade with this release; the repository's compatibility metadata was wrong or incomplete."
 		}
 	}
+}
+
+// sameRelease compares two version strings, tolerating v-prefix and segment
+// padding differences (v1.2.0 == 1.2.0.0).
+func sameRelease(a, b string) bool {
+	va, errA := version.NewVersion(strings.TrimPrefix(a, "v"))
+	vb, errB := version.NewVersion(strings.TrimPrefix(b, "v"))
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	return va.Equal(vb)
 }
 
 // lockNameFor maps a Composer manifest file name to its lock file name, the

--- a/internal/shop/upgrade/resolve_test.go
+++ b/internal/shop/upgrade/resolve_test.go
@@ -109,3 +109,33 @@ func TestResolveResultSecurityBlocked(t *testing.T) {
 	ok := ResolveResult{OK: true, Report: "affected by security advisories"}
 	assert.False(t, ok.SecurityBlocked(), "a successful resolution is never security-blocked")
 }
+
+func TestApplyResolvedVersionsOverridesMetadataBlockers(t *testing.T) {
+	resolve := resolvedTestResult(t)
+	require.True(t, resolve.OK)
+
+	results := []ExtensionResult{
+		// Not in the lock diff: the solver kept the installed release.
+		{Extension: InstalledExtension{Name: "FroshTools", Package: "frosh/tools", Version: "3.12.0"}, Status: ExtBlocked},
+		// In the diff: the solver picked a newer release.
+		{Extension: InstalledExtension{Name: "SwagDemo", Package: "swag/demo", Version: "2.0.0"}, Status: ExtMismatch},
+	}
+	ApplyResolvedVersions(results, resolve)
+
+	assert.Equal(t, ExtOK, results[0].Status, "a successful resolve disproves the metadata blocker")
+	assert.Equal(t, "3.12.0", results[0].Available)
+	assert.Contains(t, results[0].Detail, "installed release")
+
+	assert.Equal(t, ExtNeedsUpdate, results[1].Status)
+	assert.Equal(t, "2.1.3", results[1].Available)
+}
+
+func TestApplyResolvedVersionsKeepsBlockersOnFailedResolve(t *testing.T) {
+	results := []ExtensionResult{
+		{Extension: InstalledExtension{Name: "SwagBlocked", Package: "swag/blocked", Version: "3.2.0"}, Status: ExtBlocked, Detail: "original"},
+	}
+	ApplyResolvedVersions(results, ResolveResult{OK: false})
+
+	assert.Equal(t, ExtBlocked, results[0].Status, "a failed resolve proves nothing")
+	assert.Equal(t, "original", results[0].Detail)
+}

--- a/internal/shop/upgrade/resolve_test.go
+++ b/internal/shop/upgrade/resolve_test.go
@@ -130,6 +130,21 @@ func TestApplyResolvedVersionsOverridesMetadataBlockers(t *testing.T) {
 	assert.Equal(t, "2.1.3", results[1].Available)
 }
 
+func TestApplyResolvedVersionsRemovedPackageStaysBlocked(t *testing.T) {
+	// A transitively installed extension can be dropped by the solver; that
+	// must not read as "kept at the installed release".
+	results := []ExtensionResult{
+		{Extension: InstalledExtension{Name: "SwagGone", Package: "swag/gone", Version: "1.0.0"}, Status: ExtBlocked, Available: "x"},
+	}
+	ApplyResolvedVersions(results, ResolveResult{OK: true, Changes: []PackageChange{
+		{Name: "swag/gone", From: "1.0.0", Op: "remove"},
+	}})
+
+	assert.Equal(t, ExtBlocked, results[0].Status, "a removal is not compatibility")
+	assert.Empty(t, results[0].Available)
+	assert.Contains(t, results[0].Detail, "removes this package")
+}
+
 func TestApplyResolvedVersionsKeepsBlockersOnFailedResolve(t *testing.T) {
 	results := []ExtensionResult{
 		{Extension: InstalledExtension{Name: "SwagBlocked", Package: "swag/blocked", Version: "3.2.0"}, Status: ExtBlocked, Detail: "original"},

--- a/internal/tui/upgrade/model_test.go
+++ b/internal/tui/upgrade/model_test.go
@@ -549,10 +549,27 @@ func TestPreparePanelShowsResolvedVersions(t *testing.T) {
 	assert.Contains(t, content, "2.0.0 -> 2.1.3", "queue shows the version composer resolved to")
 }
 
-func TestPreparePanelFlaggedButResolvable(t *testing.T) {
-	// Store metadata flags an extension, but composer resolves the upgrade
-	// with extensions passed as "*": the solver's verdict wins.
+func TestPreparePanelBlockerDisprovenByResolve(t *testing.T) {
+	// Repository metadata flags an extension as blocked, but composer resolves
+	// the upgrade with extensions passed as "*": the solver's verdict wins and
+	// the stale blocker is downgraded to ok instead of scaring the user.
 	w := wizardAtPrepare(t, []backend.ExtensionResult{blockedResult(), okResult()}, true)
+
+	content := w.view(t)
+	assert.Contains(t, content, "READY")
+	assert.NotContains(t, content, "BLOCKED")
+
+	w.Send(key('c'))
+	assert.Equal(t, panelReview, w.m.panel)
+}
+
+func TestPreparePanelFlaggedButResolvable(t *testing.T) {
+	// A non-blocking flag (manual review) survives a successful resolve — the
+	// user should still look at it, it just does not block.
+	review := blockedResult()
+	review.Status = backend.ExtReview
+	review.Detail = "Local extension — review it manually."
+	w := wizardAtPrepare(t, []backend.ExtensionResult{review, okResult()}, true)
 
 	content := w.view(t)
 	assert.Contains(t, content, "REVIEW")
@@ -575,7 +592,9 @@ func TestPreparePanelComposerBlocked(t *testing.T) {
 }
 
 func TestExtensionDetailOverlay(t *testing.T) {
-	w := wizardAtPrepare(t, []backend.ExtensionResult{blockedResult(), okResult()}, true)
+	// A failed resolve keeps the metadata blocker (a successful one would
+	// disprove and downgrade it).
+	w := wizardAtPrepare(t, []backend.ExtensionResult{blockedResult(), okResult()}, false)
 
 	w.Send(specialKey(tea.KeyEnter))
 	require.True(t, w.App.OverlayOpen())

--- a/internal/tui/upgrade/panel_prepare.go
+++ b/internal/tui/upgrade/panel_prepare.go
@@ -358,9 +358,9 @@ func (m *Model) viewPrepare() (title, status, body string) {
 			message = "Dependencies are blocked by security advisories. Recheck to decide again."
 		}
 		status = m.statusStrip(tui.VariantError, "BLOCKED", message+m.reportHint())
-	case m.prepare.blockers() > 0:
+	case m.prepare.flagged() > 0:
 		status = m.statusStrip(tui.VariantWarning, "REVIEW",
-			fmt.Sprintf("Composer resolved the upgrade, but %d extensions are flagged. Review them before continuing.", m.prepare.blockers()))
+			fmt.Sprintf("Composer resolved the upgrade, but %d extensions are flagged. Review them before continuing.", m.prepare.flagged()))
 	default:
 		status = m.statusStrip(tui.VariantSuccess, "READY", "All checks passed. Continue to review the upgrade plan.")
 	}


### PR DESCRIPTION
## What changed?

`project upgrade` no longer shows an extension as **blocked** when the Composer dry run has already proven it compatible.

Before (QA report): FroshTools was flagged *"BLOCKED — No compatible Composer release exists for the selected Shopware version"* with *Store: Already compatible* — yet the upgrade resolved and ran fine. After: the queue shows the extension as **ok** with the detail *"Composer resolved the upgrade with the installed release; the repository's compatibility metadata was wrong or incomplete."*

Three changes:

- `classifyExtension` distinguishes "constraints known and excluding the target" (still **blocked**) from "no release declares a parsable Shopware constraint" — some repositories strip `require` metadata (e.g. the Store packagist serves `"require": []`). The latter is now **review** with an honest detail, since it means *unknown*, not *incompatible*.
- `ApplyResolvedVersions` reconciles the metadata scan with the authoritative dry run: a successful resolve contains every root-required extension, so it disproves metadata blockers. Kept at the installed release → **ok**; resolved to a newer release → **needs update**. A failed resolve changes nothing.
- The prepare panel's REVIEW status strip keys off flagged (review/deprecated) extensions instead of blockers, which can no longer survive a successful resolve.

## Why?

QA feedback on the upgrade wizard: *"it said Frosh was a 'blocker' because it was 'incompatible', but I could still do the upgrade."* The wizard's design makes the Composer dry run the gate (metadata is a preview), but the stale preview verdict was never corrected — contradicting labels erode trust in the readiness screens and the exported report.

Reproduced: against clean packagist, `frosh/tools` (`~6.6.0 || ~6.7.0`) classifies correctly — the false blocker only appears when the project's repository order serves the package with stripped constraint metadata.

## How was this tested?

- New unit tests: unknown-constraint classification (review, not blocked; known-incompatible still blocks), resolve reconciliation in both directions (kept → ok, updated → needs-update), failed-resolve no-op.
- Updated wizard flow tests: blocker disproven by resolve renders READY; non-blocking flags still render REVIEW; the detail overlay keeps its blocked fixture via a failed resolve.
- `go test ./...` and `golangci-lint run ./...` green.

## Related issue or discussion

Internal QA feedback on the `project upgrade` wizard (0.17.0-alpha-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HR5veromwFWWyasWLqv4QJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension compatibility checks when Shopware constraint metadata is unavailable.
  * Composer resolution can now clear outdated compatibility blockers when the resolved versions are valid.
  * Preserved blocker details when dependency resolution fails.
  * Upgrade review warnings now correctly include extensions requiring manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->