### PR TITLE
chore: adds skills and related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ shopware-cli --no-interaction <command>
 - `scripts/`: repository helper scripts
 - `env-bridge/`: environment bridge helper entrypoint
 
+## Official Agent Skills
+
+Shopware CLI maintainers provide official Agent Skills in this repository's `skills/` folder. These skills teach compatible AI coding agents how to use Shopware CLI workflows safely and correctly. 
+
+Install them with:
+
+```bash
+npx skills add shopware/shopware-cli
+```
+
+Available skills are `shopware-cli` and `shopware-cli-docker`.
+
 ## Documentation
 
 - Official docs: <https://developer.shopware.com/docs/products/cli/>

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -1,0 +1,224 @@
+# Agent Skills
+
+Shopware CLI publishes Agent Skills for AI coding tools.
+
+The canonical skills live in this repository so that changes to Shopware CLI and
+changes to its agent guidance can be reviewed and released together.
+
+## Repository structure
+
+```text
+shopware-cli/
+├── AGENTS.md
+├── docs/
+│   └── AGENT_SKILLS.md
+└── skills/
+    ├── shopware-cli/
+    │   └── SKILL.md
+    └── shopware-cli-docker/
+        └── SKILL.md
+```
+
+Each skill is intentionally self-contained in a single `SKILL.md`.
+
+Do not maintain separate Claude, Cursor, Codex, Copilot, or other
+client-specific copies in this repository.
+
+## Available skills
+
+### `shopware-cli`
+
+General Shopware CLI guidance.
+
+It teaches agents how to:
+
+- discover the current CLI command surface;
+- prefer Shopware CLI abstractions over lower-level tooling;
+- distinguish project, extension, and account workflows;
+- reason about command safety and side effects;
+- work non-interactively;
+- troubleshoot CLI failures.
+
+### `shopware-cli-docker`
+
+Guidance for Shopware CLI projects using Docker.
+
+It teaches agents to let Shopware CLI resolve the project environment instead
+of defaulting to raw Docker commands.
+
+In particular, Symfony Console commands should normally go through:
+
+```bash
+shopware-cli project console <command>
+```
+
+and development environment lifecycle through:
+
+```bash
+shopware-cli project dev
+shopware-cli project dev start
+shopware-cli project dev status
+shopware-cli project dev stop
+```
+
+## Source of truth
+
+The files under `skills/` are the canonical source.
+
+Do not duplicate their content in generated client-specific files.
+
+The skills should contain durable workflow knowledge rather than an exhaustive
+copy of the command reference. Agents are instructed to inspect the current
+CLI with `--help`, which reduces the amount of guidance that needs updating
+when commands or flags are added.
+
+## Pull request checklist
+
+For user-facing Shopware CLI changes:
+
+1. Implement the CLI change.
+2. Check whether `skills/shopware-cli/SKILL.md` is affected.
+3. Check whether `skills/shopware-cli-docker/SKILL.md` is affected.
+4. Update the skill in the same PR when required.
+5. Validate the skills.
+6. Verify that the skills can still be discovered by the skills CLI.
+
+Consider adding the following item to the repository PR template:
+
+```text
+- [ ] I reviewed `skills/` for user-facing CLI changes.
+```
+
+## Validation
+
+Validate each skill against the Agent Skills format:
+
+```bash
+skills-ref validate ./skills/shopware-cli
+skills-ref validate ./skills/shopware-cli-docker
+```
+
+Verify repository discovery:
+
+```bash
+npx skills add . --list
+```
+
+CI should run these checks so an invalid skill cannot be merged.
+
+Where practical, CI should also test commands explicitly referenced by the
+skills, such as:
+
+```text
+project console
+project dev
+project dev start
+project dev status
+project dev stop
+project dump
+```
+
+This catches obvious drift when commands are renamed or removed.
+
+Semantic changes still require human review.
+
+## Distribution
+
+The canonical Agent Skills are maintained under `skills/` in this repository.
+
+They are distributed through the Agent Skills ecosystem directly from the
+`shopware/shopware-cli` GitHub repository. Do not maintain client-specific
+copies of the skills.
+
+After merging changes to the default branch, verify public discovery:
+
+```bash
+npx skills add shopware/shopware-cli --list
+
+### Installation
+
+Install the official Shopware CLI skills with:
+
+```bash
+npx skills add shopware/shopware-cli
+```
+
+Install specific skills with:
+
+```bash
+npx skills add shopware/shopware-cli \
+  --skill shopware-cli \
+  --skill shopware-cli-docker
+```
+
+The `skills` CLI is responsible for installing the canonical skills for
+supported AI clients. Shopware CLI does not maintain client-specific copies.
+
+## Updating installed skills
+
+The canonical source changes whenever `skills/` changes on the default branch.
+
+Users can check installed skills for available updates with:
+
+```bash
+npx skills check
+```
+
+Update the Shopware skills with:
+
+```bash
+npx skills update shopware-cli shopware-cli-docker
+```
+
+or update all installed project skills with:
+
+```bash
+npx skills update -y
+```
+
+Updating the Shopware CLI binary does not automatically modify skills installed
+by external Agent Skills tooling.
+
+## Keeping the skills current
+
+Agent Skills are part of the user-facing Shopware CLI contract.
+
+Every pull request that changes user-facing CLI behavior must review `skills/`
+for impact.
+
+Review the skills when changing:
+
+- command names or hierarchy;
+- important execution modes;
+- environment or Docker behavior;
+- recommended workflows;
+- destructive or state-changing behavior;
+- commands explicitly referenced in a skill.
+
+Do not turn the skills into a duplicate command reference. The running CLI and
+its `--help` output remain authoritative for exact commands, flags, and
+version-specific behavior.
+
+Where possible, CI should verify that commands explicitly referenced by the
+skills continue to exist.
+
+## Versioning
+
+Skills do not have an independent Shopware version.
+
+Because their canonical source lives in the Shopware CLI repository, every Git
+tag and Shopware CLI release records the exact skill source that existed for
+that release.
+
+The default branch contains the latest maintained guidance.
+
+## Future signed distribution
+
+If Shopware later requires cryptographically verified, pinned, or offline skill
+distribution, the canonical `skills/` directory may additionally be published
+as a signed OCI artifact.
+
+This must remain a second distribution of the same canonical source, not a
+separate copy of the skills.
+
+Until such a requirement exists, the `skills` CLI and skills.sh ecosystem are the preferred cross-client distribution and update mechanism.

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -131,18 +131,8 @@ They are distributed through the Agent Skills ecosystem directly from the
 copies of the skills.
 
 After merging changes to the default branch, verify public discovery:
+After merging changes to the default branch, verify public discovery:
 
-```bash
-npx skills add shopware/shopware-cli --list
-```
-
-### Installation
-
-Install the official Shopware CLI skills with:
-
-```bash
-npx skills add shopware/shopware-cli
-```
 
 Install specific skills with:
 

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -134,6 +134,7 @@ After merging changes to the default branch, verify public discovery:
 
 ```bash
 npx skills add shopware/shopware-cli --list
+```
 
 ### Installation
 

--- a/skills/shopware-cli-docker/SKILL.md
+++ b/skills/shopware-cli-docker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopware-cli-docker
-description: Use Shopware CLI correctly in Docker-backed Shopware projects. Use when running Symfony commands, working with project services or databases, starting or stopping the development environment, troubleshooting Docker execution, or deciding whether a command belongs on the host or inside the project environment.
+description: Use when working on Docker-backed Shopware projects and needing to run Shopware or Symfony CLI commands, interact with project services or databases, start or stop the development environment, troubleshoot Docker execution, or determine whether a command should run on the host or inside the project container.
 ---
 
 # Shopware CLI with Docker

--- a/skills/shopware-cli-docker/SKILL.md
+++ b/skills/shopware-cli-docker/SKILL.md
@@ -133,7 +133,7 @@ First check whether Shopware CLI already exposes the intended workflow.
 
 If no CLI abstraction exists:
 
-1. confirm this using `shopware-cli ... --help`;
+1. confirm this using the relevant command group's `--help`;
 2. determine the configured Docker service and working directory;
 3. run the low-level tool in the correct project environment;
 4. avoid hard-coding paths and service names when they can be discovered.

--- a/skills/shopware-cli-docker/SKILL.md
+++ b/skills/shopware-cli-docker/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: shopware-cli-docker
+description: Use Shopware CLI correctly in Docker-backed Shopware projects. Use when running Symfony commands, working with project services or databases, starting or stopping the development environment, troubleshooting Docker execution, or deciding whether a command belongs on the host or inside the project environment.
+---
+
+# Shopware CLI with Docker
+
+In a Shopware CLI-managed Docker project, prefer asking Shopware CLI to perform the operation instead of manually deciding how to enter containers.
+
+Shopware CLI knows the project configuration and selected execution environment and can route supported operations through the correct executor.
+
+## Core rule
+
+Do not default to:
+
+```bash
+docker compose exec ...
+```
+
+when Shopware CLI already exposes the operation.
+
+Prefer:
+
+```bash
+shopware-cli project ...
+```
+
+The CLI should decide when Docker is required.
+
+## Symfony and Shopware Console commands
+
+When a task requires `bin/console`, use:
+
+```bash
+shopware-cli project console <command> [arguments]
+```
+
+Instead of manually doing something like:
+
+```bash
+docker compose exec web php bin/console <command>
+```
+
+prefer:
+
+```bash
+shopware-cli project console <command>
+```
+
+`project console` resolves the current Shopware project and its configured executor. In a Docker-backed environment, the CLI routes the Symfony command through the project container.
+
+This applies to Shopware and Symfony Console workflows such as:
+
+- cache commands;
+- plugin and app lifecycle;
+- indexing;
+- migrations;
+- scheduled tasks;
+- system configuration;
+- other commands exposed by `bin/console`.
+
+Before executing an unfamiliar or state-changing command:
+
+```bash
+shopware-cli project console <command> --help
+```
+
+Do not assume a Symfony command is safe merely because it exists.
+
+## Development environment
+
+Use Shopware CLI to manage the development environment:
+
+```bash
+shopware-cli project dev
+shopware-cli project dev start
+shopware-cli project dev status
+shopware-cli project dev stop
+```
+
+Do not replace these with `docker compose up` or `docker compose down` unless there is a specific reason to bypass the CLI.
+
+The CLI knows the configured environment and can prepare and manage the Docker setup required by the project.
+
+## Other project operations
+
+Prefer the corresponding Shopware CLI command for supported tasks such as builds, watchers, logs, validation, upgrades, project maintenance, and extension management.
+
+Do not manually wrap a Shopware CLI command in `docker compose exec`.
+
+If Shopware CLI already exposes the operation, let the CLI handle Docker.
+
+## Database work
+
+First determine what kind of database operation the user actually needs.
+
+For database exports, inspect:
+
+```bash
+shopware-cli project dump --help
+```
+
+For database-related operations exposed through Symfony or Shopware Console, prefer:
+
+```bash
+shopware-cli project console <command>
+```
+
+For arbitrary SQL, first inspect the available Shopware CLI and Symfony commands. Do not invent a CLI command.
+
+If no suitable Shopware CLI abstraction exists, direct database access may be necessary. Before doing that:
+
+1. identify the configured database service and target environment;
+2. prefer discovered configuration over hard-coded container names or credentials;
+3. use read-only queries where possible;
+4. treat writes, deletes, schema changes, imports, and bulk updates as destructive operations.
+
+Never execute database-changing commands against an ambiguous environment.
+
+## Composer, PHP, and npm
+
+Prefer a higher-level Shopware CLI operation when one exists.
+
+Do not immediately run:
+
+```bash
+docker compose exec web composer ...
+docker compose exec web php ...
+docker compose exec web npm ...
+```
+
+First check whether Shopware CLI already exposes the intended workflow.
+
+If no CLI abstraction exists:
+
+1. confirm this using `shopware-cli ... --help`;
+2. determine the configured Docker service and working directory;
+3. run the low-level tool in the correct project environment;
+4. avoid hard-coding paths and service names when they can be discovered.
+
+Direct Docker execution is the fallback, not the default.
+
+## Environment selection
+
+Do not assume that an environment named `local`, `dev`, `staging`, or similar is Docker-backed or safe to modify.
+
+Inspect `.shopware-project.yml` and use the CLI's environment selection mechanisms.
+
+Before destructive commands, establish exactly which environment will be affected.
+
+## Starting from a user request
+
+When a user asks for something like:
+
+- "clear the Shopware cache";
+- "run this Symfony command";
+- "update the plugin";
+- "run migrations";
+- "check the database";
+- "start the shop";
+- "show me the logs";
+
+do not translate the request directly into raw Docker commands.
+
+First ask: **Does Shopware CLI already know how to do this?**
+
+For Symfony commands, the answer should usually begin with:
+
+```bash
+shopware-cli project console ...
+```
+
+For development environment lifecycle, begin with:
+
+```bash
+shopware-cli project dev ...
+```
+
+For other workflows, inspect:
+
+```bash
+shopware-cli project --help
+```
+
+## Troubleshooting
+
+When Docker-backed execution fails:
+
+1. Run `shopware-cli project dev status`.
+2. Inspect the relevant Shopware CLI command's `--help`.
+3. Retry with `--verbose` when useful.
+4. Verify the selected environment in project configuration.
+5. Inspect Docker directly only after establishing how Shopware CLI attempted to execute the operation.
+
+Do not move a command from the container to the host just to make it work unless the project is explicitly configured for local execution.
+
+## Safety
+
+Docker does not make a command safe.
+
+Commands executed through `project console`, Composer, the database, or project-management commands can still modify files, dependencies, application state, or data.
+
+Before a destructive action:
+
+- identify the environment;
+- inspect the command;
+- understand the expected changes;
+- prefer previews or read-only checks when available;
+- preserve unrelated user work.

--- a/skills/shopware-cli-docker/SKILL.md
+++ b/skills/shopware-cli-docker/SKILL.md
@@ -188,7 +188,7 @@ When Docker-backed execution fails:
 
 1. Run `shopware-cli project dev status`.
 2. Inspect the relevant Shopware CLI command's `--help`.
-3. Retry with `--verbose` when useful.
+3. For Shopware CLI debug output, place `--verbose` before the command group, for example `shopware-cli --verbose project console <command>`.
 4. Verify the selected environment in project configuration.
 5. Inspect Docker directly only after establishing how Shopware CLI attempted to execute the operation.
 

--- a/skills/shopware-cli/SKILL.md
+++ b/skills/shopware-cli/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: shopware-cli
+description: Use Shopware CLI safely and effectively for Shopware project, extension, account, development, build, validation, upgrade, and troubleshooting workflows. Also use when contributing to shopware/shopware-cli and reasoning about the CLI's user-facing behavior.
+---
+
+# Shopware CLI
+
+Use Shopware CLI as the preferred interface for supported Shopware project, extension, and account workflows.
+
+When contributing to `shopware/shopware-cli`, use this skill to reason from the user's perspective: what the CLI can do, which command a user should choose, how commands should behave, and where safety boundaries belong. Use the repository's `AGENTS.md` for implementation conventions, architecture, testing, and Go-specific contributor guidance.
+
+## Start with the current CLI
+
+Treat the current CLI as authoritative for commands and flags.
+
+```bash
+shopware-cli --version
+shopware-cli --help
+shopware-cli project --help
+shopware-cli extension --help
+shopware-cli account --help
+```
+
+For a specific command:
+
+```bash
+shopware-cli <group> <command> --help
+```
+
+When working on unreleased functionality in the `shopware/shopware-cli` repository, inspect or run the checked-out code instead of assuming the installed release behaves the same way.
+
+Do not invent commands, flags, configuration fields, or behavior from memory.
+
+## Command areas
+
+The CLI has three primary user-facing areas:
+
+- `project`: create, configure, develop, inspect, build, maintain, and upgrade Shopware projects.
+- `extension`: build, validate, format, package, and maintain Shopware extensions.
+- `account`: authenticated Shopware Account and extension producer workflows.
+
+This is orientation, not a complete command catalog. Use `--help` for the current command surface.
+
+## Prefer Shopware CLI abstractions
+
+When Shopware CLI provides a command for a task, prefer it over manually reconstructing the workflow with Composer, `bin/console`, Docker, npm, PHP, or direct filesystem changes.
+
+The CLI may already understand:
+
+- the current Shopware project;
+- project and extension configuration;
+- the selected environment;
+- Docker versus local execution;
+- extension structure and type;
+- supported build, validation, maintenance, and upgrade workflows.
+
+Use lower-level tools only when:
+
+1. Shopware CLI does not expose the required operation; or
+2. troubleshooting requires inspecting the underlying operation.
+
+If the task involves a Docker-backed project or deciding where a command should execute, use the `shopware-cli-docker` skill when available.
+
+## Understand command risk
+
+Before executing a command, understand what it can change.
+
+### Usually low risk
+
+Inspection-oriented actions such as help, version checks, status, diagnostics, schema inspection, validation, and reading logs are normally appropriate while investigating a task.
+
+Still inspect command help when behavior is unclear.
+
+### Local file changes
+
+Commands that create, generate, format, fix, upgrade, package, install dependencies, or rewrite configuration may change files.
+
+Before running them:
+
+- inspect `--help`;
+- understand which files may change;
+- use a preview or dry-run when the command actually supports one;
+- preserve unrelated user changes;
+- review the resulting diff.
+
+Do not assume every command supports `--dry-run`.
+
+### Database and application-state changes
+
+Treat commands that can change the database, Shopware application state, installed extensions, caches, indexes, migrations, or configuration as higher risk.
+
+`shopware-cli project console` is an execution bridge to Symfony Console. Its safety depends on the command passed to it.
+
+Before running an unfamiliar or state-changing Symfony command:
+
+```bash
+shopware-cli project console <command> --help
+```
+
+Know which environment will be affected before proceeding.
+
+### Remote changes
+
+Treat account operations that authenticate, log out, upload, push, publish, or otherwise modify remote Shopware Account state as external side effects.
+
+Do not infer permission or user intent simply because credentials are available.
+
+## Inspect the project before deciding
+
+Relevant files can include:
+
+- `.shopware-project.yml`
+- `.shopware-extension.yml`
+- `composer.json`
+- `composer.lock`
+- `manifest.xml`
+
+Do not infer the project type, extension type, target environment, or Shopware version solely from the user's wording.
+
+Prefer CLI-provided configuration schemas over remembered configuration fields.
+
+## Non-interactive and agent execution
+
+For unattended or agent-driven execution, prefer:
+
+```bash
+shopware-cli --no-interaction <command>
+```
+
+or:
+
+```bash
+shopware-cli -n <command>
+```
+
+If required values are missing, inspect `--help` and provide them explicitly rather than guessing answers to prompts.
+
+Prefer machine-readable output when the command explicitly supports it.
+
+## Credentials and sensitive data
+
+Never expose access tokens, passwords, client secrets, database credentials, or other secret values in responses, logs, examples, or committed files.
+
+Prefer Shopware CLI's supported authentication and configuration mechanisms instead of manipulating credential storage directly.
+
+Database dumps and other exports may contain sensitive customer or shop data. Treat their creation, storage, and sharing accordingly.
+
+## Generated files
+
+Distinguish source files from generated files before editing them.
+
+When Shopware CLI owns generation of an artifact, prefer regenerating it through the appropriate CLI command instead of manually editing generated output.
+
+Inspect command help before regenerating anything that may overwrite existing files.
+
+## Troubleshooting
+
+When a Shopware CLI command fails:
+
+1. Capture the exact command and error.
+2. Check `shopware-cli --version`.
+3. Inspect the command's `--help`.
+4. Verify the working directory and relevant project or extension configuration.
+5. Retry with `--verbose` when useful.
+6. Check whether the correct project environment is selected and available.
+7. Inspect the underlying Composer, Symfony, Docker, npm, PHP, or API operation only after establishing what Shopware CLI attempted to do.
+
+Do not work around a failing Shopware CLI command with lower-level tooling until you understand what CLI behavior or configuration would be bypassed.
+
+## Information priority
+
+When behavior is unclear, use this order:
+
+1. the current CLI and its `--help`;
+2. project configuration and CLI-provided schemas;
+3. official Shopware CLI documentation;
+4. the `shopware/shopware-cli` source code when implementation details are required.
+
+Prefer version-correct facts over remembered Shopware behavior.


### PR DESCRIPTION
## What changed?
Adds two Agent Skills to the repo:
- Shopware CLI
- Shopware CLI + Docker

## Why?

Adding official Agent Skills aligned with skills.sh practices, so that AI coding tools can use Shopware CLI with accurate, maintained workflow guidance instead of guessing from generic model knowledge. 

## How was this tested?

Will validate against the public repository and complete skills.sh discovery loop after the PR is merged.

## Related issue or discussion

Closes #1198.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official agent skill resources for Shopware CLI and Docker-based Shopware workflows.
  * Added guidance for project and extension operations, environment management, database tasks, troubleshooting, and safer command execution.

* **Documentation**
  * Documented skill discovery, installation, validation, updates, distribution, maintenance, and versioning.
  * Added guidance on risk assessment, credential handling, generated files, command discovery, and non-interactive execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->