### PR TITLE
feat(project): add --remove-data flag to project dev stop

### DIFF
--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -90,7 +90,9 @@ var projectDevStopCmd = &cobra.Command{
 			return err
 		}
 
-		return env.stop(cmd)
+		removeVolumes, _ := cmd.Flags().GetBool("remove-data")
+
+		return env.stop(cmd, executor.StopOptions{RemoveVolumes: removeVolumes})
 	},
 }
 
@@ -249,14 +251,19 @@ func (e *devEnvironment) start(cmd *cobra.Command) error {
 	return nil
 }
 
-func (e *devEnvironment) stop(cmd *cobra.Command) error {
+func (e *devEnvironment) stop(cmd *cobra.Command, opts executor.StopOptions) error {
 	start := time.Now()
 
+	title := "Stopping development environment..."
+	if opts.RemoveVolumes {
+		title = "Stopping development environment and removing data..."
+	}
+
 	err := spinner.New().
-		Title("Stopping development environment...").
+		Title(title).
 		Context(cmd.Context()).
 		ActionWithErr(func(ctx context.Context) error {
-			return e.executor.StopEnvironment(ctx)
+			return e.executor.StopEnvironment(ctx, opts)
 		}).
 		Run()
 
@@ -305,4 +312,6 @@ func init() {
 	projectDevCmd.AddCommand(projectDevStartCmd)
 	projectDevCmd.AddCommand(projectDevStopCmd)
 	projectDevCmd.AddCommand(projectDevStatusCmd)
+
+	projectDevStopCmd.Flags().Bool("remove-data", false, "Also remove the named volumes declared in the compose file, deleting all data stored in them")
 }

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -244,8 +244,13 @@ func (d *DockerExecutor) StartEnvironment(ctx context.Context) error {
 	return nil
 }
 
-func (d *DockerExecutor) StopEnvironment(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "docker", d.composeArgs("down")...)
+func (d *DockerExecutor) StopEnvironment(ctx context.Context, opts StopOptions) error {
+	downArgs := d.composeArgs("down")
+	if opts.RemoveVolumes {
+		downArgs = append(downArgs, "--volumes")
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", downArgs...)
 	cmd.Dir = d.projectRoot
 
 	output, err := cmd.CombinedOutput()

--- a/internal/executor/docker_test.go
+++ b/internal/executor/docker_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeRecordingDocker installs a docker stub on PATH that records every
+// argument it is invoked with, one per line, into argsFile.
+func writeRecordingDocker(t *testing.T, argsFile string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker binary requires a POSIX shell")
+	}
+
+	shPath, err := exec.LookPath("sh")
+	require.NoError(t, err)
+
+	script := fmt.Sprintf("#!%s\nprintf '%%s\\n' \"$@\" > %q\n", shPath, argsFile)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "docker"), []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+}
+
+// recordedArgs reads the arguments captured by writeRecordingDocker.
+func recordedArgs(t *testing.T, argsFile string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+
+	var args []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+
+	return args
+}
+
+func TestDockerStopEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        StopOptions
+		projectName string
+		want        []string
+	}{
+		{
+			name: "plain down",
+			opts: StopOptions{},
+			want: []string{"compose", "down"},
+		},
+		{
+			name: "down removes volumes",
+			opts: StopOptions{RemoveVolumes: true},
+			want: []string{"compose", "down", "--volumes"},
+		},
+		{
+			name:        "pinned project keeps -p before down",
+			projectName: "sw-shop-abc123",
+			opts:        StopOptions{},
+			want:        []string{"compose", "-p", "sw-shop-abc123", "down"},
+		},
+		{
+			name:        "pinned project with volumes",
+			projectName: "sw-shop-abc123",
+			opts:        StopOptions{RemoveVolumes: true},
+			want:        []string{"compose", "-p", "sw-shop-abc123", "down", "--volumes"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			argsFile := filepath.Join(t.TempDir(), "args.txt")
+			writeRecordingDocker(t, argsFile)
+
+			dockerExec := &DockerExecutor{projectRoot: t.TempDir(), composeProjectName: tc.projectName}
+
+			require.NoError(t, dockerExec.StopEnvironment(t.Context(), tc.opts))
+
+			assert.Equal(t, tc.want, recordedArgs(t, argsFile))
+		})
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -22,6 +22,13 @@ const (
 	TypeSymfonyCLI = "symfony-cli"
 )
 
+// StopOptions configures how the development environment is stopped.
+type StopOptions struct {
+	// RemoveVolumes also removes the named volumes declared in the compose
+	// file, deleting all data stored in them.
+	RemoveVolumes bool
+}
+
 type Executor interface {
 	ConsoleCommand(ctx context.Context, args ...string) *Process
 	ComposerCommand(ctx context.Context, args ...string) *Process
@@ -32,7 +39,7 @@ type Executor interface {
 	WithEnv(env map[string]string) Executor
 	WithRelDir(relDir string) Executor
 	StartEnvironment(ctx context.Context) error
-	StopEnvironment(ctx context.Context) error
+	StopEnvironment(ctx context.Context, opts StopOptions) error
 	EnvironmentStatus(ctx context.Context) (bool, error)
 	AdminAPIClient(ctx context.Context) (*adminSdk.Client, error)
 	// DatabaseConnection returns credentials to reach the project database

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -147,7 +147,7 @@ func (l *LocalExecutor) StartEnvironment(_ context.Context) error {
 	return ErrNotSupported
 }
 
-func (l *LocalExecutor) StopEnvironment(_ context.Context) error {
+func (l *LocalExecutor) StopEnvironment(_ context.Context, _ StopOptions) error {
 	return ErrNotSupported
 }
 

--- a/internal/executor/symfony_cli.go
+++ b/internal/executor/symfony_cli.go
@@ -83,7 +83,7 @@ func (s *SymfonyCLIExecutor) StartEnvironment(_ context.Context) error {
 	return ErrNotSupported
 }
 
-func (s *SymfonyCLIExecutor) StopEnvironment(_ context.Context) error {
+func (s *SymfonyCLIExecutor) StopEnvironment(_ context.Context, _ StopOptions) error {
 	return ErrNotSupported
 }
 

--- a/internal/shop/pluginmigrate/pluginmigrate_test.go
+++ b/internal/shop/pluginmigrate/pluginmigrate_test.go
@@ -54,8 +54,8 @@ func (f *fakeExecutor) StartEnvironment(context.Context) error      { return nil
 func (f *fakeExecutor) DatabaseConnection(context.Context) (*executor.DatabaseConnection, error) {
 	return nil, executor.ErrNotSupported
 }
-func (f *fakeExecutor) StopEnvironment(context.Context) error           { return nil }
-func (f *fakeExecutor) EnvironmentStatus(context.Context) (bool, error) { return true, nil }
+func (f *fakeExecutor) StopEnvironment(context.Context, executor.StopOptions) error { return nil }
+func (f *fakeExecutor) EnvironmentStatus(context.Context) (bool, error)             { return true, nil }
 func (f *fakeExecutor) AdminAPIClient(context.Context) (*adminSdk.Client, error) {
 	return nil, executor.ErrNotSupported
 }

--- a/internal/shop/upgrade/run_test.go
+++ b/internal/shop/upgrade/run_test.go
@@ -57,8 +57,8 @@ func (f *fakeExecutor) StartEnvironment(context.Context) error { return nil }
 func (f *fakeExecutor) DatabaseConnection(context.Context) (*executor.DatabaseConnection, error) {
 	return nil, executor.ErrNotSupported
 }
-func (f *fakeExecutor) StopEnvironment(context.Context) error           { return nil }
-func (f *fakeExecutor) EnvironmentStatus(context.Context) (bool, error) { return true, nil }
+func (f *fakeExecutor) StopEnvironment(context.Context, executor.StopOptions) error { return nil }
+func (f *fakeExecutor) EnvironmentStatus(context.Context) (bool, error)             { return true, nil }
 func (f *fakeExecutor) AdminAPIClient(context.Context) (*adminSdk.Client, error) {
 	return nil, executor.ErrNotSupported
 }


### PR DESCRIPTION
## What changed?
Adds a new `--remove-data` flag to `shopware-cli project dev stop`:

```
shopware-cli project dev stop --remove-data
```

When set, the CLI passes `--volumes` to `docker compose down`, so the named volumes declared in the compose file are removed together with the environment (deleting all data stored in them).

```
Flags:
  -h, --help          help for stop
      --remove-data   Also remove the named volumes declared in the compose file, deleting all data stored in them
```

Internally `Executor.StopEnvironment` now takes an `executor.StopOptions` struct (`RemoveVolumes`), which only the Docker executor acts on; local and symfony-cli executors ignore it.

## Why?
There was no way to reset the development environment fully — database contents and other data stored in compose volumes survived a `dev stop`/`dev start` cycle.

## How was this tested?
- New unit tests (`internal/executor/docker_test.go`) assert the exact `docker compose down` invocation with/without `--remove-data` and with/without a pinned compose project name.
- `go test ./...` and `golangci-lint run` pass.

## Related issue or discussion
None
