### PR TITLE
chore: validate and advertise Agent Skills

### DIFF
--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -1,0 +1,35 @@
+name: Agent Skills
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "docs/AGENT_SKILLS.md"
+      - "README.md"
+      - ".github/workflows/agent-skills.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+      - ".github/workflows/agent-skills.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate shopware-cli skill
+        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli
+
+      - name: Validate shopware-cli-docker skill
+        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli-docker
+
+      - name: Verify skills discovery
+        run: npx --yes skills@1.5.18 add . --list

--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
       - name: Validate shopware-cli skill
         run: pipx run --spec "git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli

--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate shopware-cli skill
-        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli
+        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli
 
       - name: Validate shopware-cli-docker skill
-        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli-docker
+        run: pipx run --spec "git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref" skills-ref validate ./skills/shopware-cli-docker
 
       - name: Verify skills discovery
         run: npx --yes skills@1.5.18 add . --list

--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - "skills/**"
       - "docs/AGENT_SKILLS.md"
-      - "README.md"
-      - ".github/workflows/agent-skills.yml"
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shopware CLI
 
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.com)
+[![skills.sh](https://skills.sh/b/shopware/shopware-cli)](https://skills.sh/shopware/shopware-cli)
 
 Shopware CLI is a command line companion for common Shopware account, project, and extension workflows.
 

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -131,15 +131,9 @@ They are distributed through the Agent Skills ecosystem directly from the
 copies of the skills.
 
 After merging changes to the default branch, verify public discovery:
-After merging changes to the default branch, verify public discovery:
-
-
-Install specific skills with:
 
 ```bash
-npx skills add shopware/shopware-cli \
-  --skill shopware-cli \
-  --skill shopware-cli-docker
+npx skills add shopware/shopware-cli --list
 ```
 
 The `skills` CLI is responsible for installing the canonical skills for


### PR DESCRIPTION
## What changed?
Part II of fulfilling the acceptance criteria of #1198. Applies the skills.sh badge, checked that both skills conform to the Agent Skills standard, adds github workflow, fixes an error in the docs.

## Why?

## How was this tested?

## Related issue or discussion

Closes #1198.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a badge linking to the repository’s Agent Skills listing.
  * Updated Agent Skills documentation with the public discovery command.
  * Removed the outdated individual-skill installation example.
  * Improved guidance for finding and accessing available skills.

* **Quality Assurance**
  * Added automated validation for skills when relevant changes are submitted.
  * Added checks to confirm skills are valid and discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->