### PR TITLE
fix: resolve golangci-lint perfsprint findings

### DIFF
--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -2,7 +2,7 @@ package project
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -57,7 +57,7 @@ queue. The count per queue is optional and defaults to 1.`,
 		}
 
 		if workerSpec != "" && queuesToConsume != "" {
-			return fmt.Errorf("--queue cannot be combined with a queue spec argument")
+			return errors.New("--queue cannot be combined with a queue spec argument")
 		}
 
 		if memoryLimit == "" {
@@ -97,7 +97,7 @@ queue. The count per queue is optional and defaults to 1.`,
 			p := cmdExecutor.ConsoleCommand(ctx, consumeConfig.ConsumeArgs(job.Queues)...)
 			p.Cmd.Stdout = os.Stdout
 			p.Cmd.Stderr = os.Stderr
-			p.Cmd.Env = append(os.Environ(), fmt.Sprintf("MESSENGER_CONSUMER_NAME=%s", job.ConsumerName))
+			p.Cmd.Env = append(os.Environ(), "MESSENGER_CONSUMER_NAME="+job.ConsumerName)
 			p.Cmd.WaitDelay = time.Second
 			p.Cmd.Cancel = func() error {
 				return gracefulStop(p.Cmd, gracefulStopLimit)

--- a/internal/account-api/producer_store_pull_test.go
+++ b/internal/account-api/producer_store_pull_test.go
@@ -3,6 +3,7 @@ package account_api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -279,5 +280,5 @@ type errorNameExtension struct {
 }
 
 func (e *errorNameExtension) GetName() (string, error) {
-	return "", fmt.Errorf("name missing")
+	return "", errors.New("name missing")
 }

--- a/internal/account-api/producer_store_upload_test.go
+++ b/internal/account-api/producer_store_upload_test.go
@@ -2,7 +2,7 @@ package account_api
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -318,7 +318,7 @@ func TestUploadExtensionSkipsPublishedBinary(t *testing.T) {
 			return nil
 		},
 		updateExtensionBinaryFileFn: func(_ context.Context, _, _, _ int, _ string) error {
-			return fmt.Errorf("BinariesException-40: already published")
+			return errors.New("BinariesException-40: already published")
 		},
 	}
 

--- a/internal/shop/worker.go
+++ b/internal/shop/worker.go
@@ -104,8 +104,8 @@ func DefaultWorkerQueues(projectRoot string) []string {
 func (c WorkerConfig) ConsumeArgs(queues []string) []string {
 	args := []string{
 		"messenger:consume",
-		fmt.Sprintf("--memory-limit=%s", c.MemoryLimit),
-		fmt.Sprintf("--time-limit=%s", c.TimeLimit),
+		"--memory-limit=" + c.MemoryLimit,
+		"--time-limit=" + c.TimeLimit,
 		fmt.Sprintf("--failure-limit=%d", c.FailureLimit),
 	}
 
@@ -129,7 +129,7 @@ func PlanWorkers(spec string, amount int, defaultQueues []string) ([]WorkerJob, 
 
 	if spec == "" {
 		if amount < 1 {
-			return nil, fmt.Errorf("worker amount must be at least 1")
+			return nil, errors.New("worker amount must be at least 1")
 		}
 
 		jobs := make([]WorkerJob, 0, amount)

--- a/internal/shop/worker_test.go
+++ b/internal/shop/worker_test.go
@@ -2,6 +2,7 @@ package shop
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -205,7 +206,7 @@ func TestRunWorkers(t *testing.T) {
 			attempts++
 			mu.Unlock()
 
-			return nil, fmt.Errorf("boom")
+			return nil, errors.New("boom")
 		}
 
 		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)


### PR DESCRIPTION
## Summary
- Replace constant-format `fmt.Errorf` with `errors.New` where the message has no format verbs
- Replace simple `fmt.Sprintf("%s", …)` string builds with concatenation

This clears the current `golangci-lint` `perfsprint` failures.

## Test plan
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go test ./cmd/project/ ./internal/shop/ ./internal/account-api/`