### PR TITLE
docs: adds project dump restore adr

### DIFF
--- a/docs/adr/0001-ai-command.md
+++ b/docs/adr/0001-ai-command.md
@@ -1,7 +1,6 @@
-# 1. Shopware AI integrations in `shopware-cli`
-
-- Status: Proposed
-- Date: 2026-08-06
+title: Handling Shopware AI integrations
+date: 2026-08-06
+tags: [ai, MCP Server, Agent Skill, integration]
 
 ## Context
 

--- a/docs/adr/0002-project-dump-restore.md
+++ b/docs/adr/0002-project-dump-restore.md
@@ -55,6 +55,16 @@ Public and private files are optional tar archives of the corresponding Shopware
 
 `--anonymize` and `ConfigDump` rules apply only to the SQL dumper. They do not sanitize public or private files. File components are transferred as stored. Private files can include invoices, documents, and other sensitive shop data; that is expected and must be documented.
 
+### Import safety
+
+Import replaces the selected target components. That includes shop credentials in the database, such as the admin password. It must not do this quietly.
+
+Before any write, `project import` prints what it is about to apply: the archive, `source`, and each selected component. `--dry-run` does that inspection and print, then exits without writing.
+
+If the target is not empty, import refuses unless `--force` is set. A target is not empty when a selected database already has Shopware tables, or a selected filesystem already has objects. `--force` is required for both interactive and non-interactive use; a confirmation prompt is not a substitute.
+
+Import only writes the selected package components. Follow-up work on the running shop is out of scope and must be triggered by the user: Elasticsearch or OpenSearch indexing, cache warmup, message queue catch-up, theme compile, and similar.
+
 ### metadata.json
 
 `metadata.json` describes the package, not the file layout. Required fields for `format_version` 1:
@@ -96,6 +106,8 @@ The first implementation writes and reads that tar on the local filesystem. Wher
 
 - `project dump` remains the database-only SQL command. Existing scripts keep working.
 - `project export` / `project import` are the portable shop-data commands.
+- Import prints the planned apply, supports `--dry-run`, and refuses a non-empty target unless `--force` is set.
+- Post-import shop tasks such as search indexing stay with the user.
 - Public and private files travel with the database in one archive, using the project's Flysystem config (`local` and `amazon-s3` only).
 - Hosted MySQL Shell dumps can be imported when they arrive in this package layout, without replacing the CLI SQL dumper.
 - SQL-only restore of a raw `dump.sql` is not `project import`. That remains a separate concern.

--- a/docs/adr/0002-project-dump-restore.md
+++ b/docs/adr/0002-project-dump-restore.md
@@ -37,3 +37,67 @@ This workflow is for transferring shop data. Production backup, disaster recover
 - The transfer format should remain compatible with future PaaS import and export workflows where practical.
 - Partial transfers, optional compression, and non-local storage can be added without introducing a separate data model.
 - Work to define the migration path from/into Shopware PaaS/SaaS hosting is ongoing and supported by this ADR.
+
+## Possible archive and manifest formats
+
+The following examples are illustrative and subject to validation against PaaS/SaaS interoperability requirements.
+
+Potential archive structure:
+
+```
+manifest.json
+database.sql          # database.backup_type = "sql"
+database/             # database.backup_type = "mysql-shell"
+  ...                 # complete, opaque MySQL Shell dump
+public.tar.gz          # optional
+private.tar.gz         # optional
+```
+
+Potential manifest structure:
+
+```
+{
+  "format_version": 1,
+  "created_at": "2026-08-11T12:00:00Z",
+  "tool": {
+    "name": "shopware-cli",
+    "version": "0.9.0"
+  },
+  "source": {
+    "shopware_version": "6.7.1.0",
+    "database": {
+      "vendor": "mysql",
+      "version": "8.4.6"
+    }
+  },
+  "database": {
+    "backup_type": "sql",
+    "path": "database.sql"
+  },
+  "filesystems": {
+    "public": {
+      "path": "public.tar.gz"
+    },
+    "private": {
+      "path": "private.tar.gz"
+    }
+  },
+  "files": [
+    {
+      "path": "database.sql",
+      "size": 123456789,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    {
+      "path": "public.tar.gz",
+      "size": 23456789,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "private.tar.gz",
+      "size": 3456789,
+      "sha256": "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
+    }
+  ]
+}
+```

--- a/docs/adr/0002-project-dump-restore.md
+++ b/docs/adr/0002-project-dump-restore.md
@@ -1,68 +1,72 @@
-title: Align project dump and restore with portable shop data
+title: Project import and export
 date: 2026-08-11
-tags: [project dump, project restore, mysql, database]
+tags: [project import, project export, mysql, database]
 
 ## Context
 
-`project dump` currently creates a SQL database dump, with optional gzip or zstd compression and support for Shopware-specific cleaning and anonymization.
+`project dump` creates a SQL database dump, with optional gzip or zstd compression and support for Shopware-specific cleaning and anonymization.
 
-[#1243](https://github.com/shopware/shopware-cli/issues/1243) proposed the corresponding `project restore` workflow. Work in [#1326](https://github.com/shopware/shopware-cli/pull/1326) added shared database connection handling and SQL execution infrastructure needed for that workflow, but `project restore` was held back while we aligned with Shopware PaaS and SaaS teams.
+Transferable shop data can include three components: the database, public files, and private files. Shopware CLI should interoperate with Shopware hosting: data produced by the CLI should be restorable in hosted environments, and data exported from hosted environments should be restorable elsewhere.
 
-The resulting conversation established that transferable shop data can include three distinct components: the database, public files, and private files. It also surfaced two interoperability goals: first, making data produced by Shopware CLI suitable for a future migration into Shopware hosting; and second, allowing data exported from hosted environments to be restored elsewhere.
+A SQL dump is not enough for that. Files and a declared package layout are also required.
 
 ## Decision
 
-We will proceed with `project restore` and keep the existing database-only `project dump` and its SQL format supported.
+`project dump` stays as it is: a database-only SQL stream to `dump.sql` or stdout, with optional gzip or zstd wrapping.
 
-To ensure compatibility with other Shopware hosting models, dump and restore will also evolve around the same three independently selectable components: database, public files, and private files.
+Portable shop-data packages are a new pair of commands:
 
-Whole-shop transfers will use a versioned manifest describing the included components and their formats. The portable structure should match the format expected by Shopware hosting where applicable and practical, so that data produced by Shopware CLI can be accepted by a future PaaS restore flow without conversion.
+- `project export` writes a tar archive.
+- `project import` reads that tar archive.
 
-These compatibility requirements define the interchange contract; they do not require Shopware CLI to adopt hosting-specific implementation details that are unnecessary for interoperability. We commit to frictionless interchange, not to cloning PaaS/SaaS internals.
+Export and import operate on independently selectable components: database, public files, and private files. Public and private file data is optional on both sides: an archive does not have to include them, and `project import` does not have to apply them even when they are present.
 
-The database component will continue to support Shopware CLI's existing SQL dumps and will also support reading mysql-shell dumps.
+The archive is the interchange unit. Its layout should match the format expected by Shopware hosting where applicable and practical, so a CLI export can be accepted by a future hosted import without conversion, and a hosted export can be imported by the CLI.
 
-Dump and restore will support partial operation on individual components and optional compression.
-
-The first implementation may read from and write to the local filesystem, but the design must not hard-code local paths as the only source or destination. The dump/restore model must support the storage setup used by Shopware PaaS and SaaS, including S3, while remaining extensible to additional user-controlled storage backends.
+These compatibility requirements define the interchange contract. They do not require Shopware CLI to clone PaaS/SaaS internals.
 
 This workflow is for transferring shop data. Production backup, disaster recovery, and platform snapshot lifecycle remain separate concerns.
 
-## Consequences
+### Archive
 
-- The pending `project restore` work can proceed for existing Shopware CLI SQL dumps.
-- Existing `project dump` behavior remains compatible.
-- Public and private files can be added to the same transfer model.
-- mysql-shell dumps can be consumed without replacing Shopware CLI's existing database dumper.
-- The transfer format should remain compatible with future PaaS import and export workflows where practical.
-- Partial transfers, optional compression, and non-local storage can be added without introducing a separate data model.
-- Work to define the migration path from/into Shopware PaaS/SaaS hosting is ongoing and supported by this ADR.
+`project export` writes one tar (optionally wrapped with gzip or zstd). Inside:
 
-## Possible archive and manifest formats
-
-The following examples are illustrative and subject to validation against PaaS/SaaS interoperability requirements.
-
-Potential archive structure:
-
-```
+```text
 manifest.json
 database.sql          # database.backup_type = "sql"
 database/             # database.backup_type = "mysql-shell"
   ...                 # complete, opaque MySQL Shell dump
-public.tar.gz          # optional
-private.tar.gz         # optional
+public.tar.gz         # optional
+private.tar.gz        # optional
 ```
 
-Potential manifest structure:
+A package includes only the selected components. `database.sql` and `database/` are alternatives, not both present.
 
-```
+The first CLI export writes `database.sql` using the existing SQL dumper, including `--clean` / `--anonymize` and `ConfigDump` rewrite, where, ignore, and no-data rules. The CLI will not produce MySQL Shell dumps in the first implementation.
+
+`project import` consumes the tar. For the database component it accepts either `backup_type`:
+
+- `"sql"` — the SQL file is applied to the project database.
+- `"mysql-shell"` — the directory is loaded as MySQL Shell left it. Any directory that MySQL Shell's load utility can consume (`util.dumpInstance` or `util.dumpSchemas` output) is accepted. The CLI does not re-encode MySQL Shell internals.
+
+Public and private files are optional tar archives of the corresponding Shopware filesystems, not of the project source tree. Export includes a filesystem only when that component is selected. Import applies a filesystem only when that component is selected and present in the archive; a missing `public.tar.gz` or `private.tar.gz` is valid. When they are applied, export reads them and import writes them through the project's existing Flysystem configuration in `config/packages` (`shopware.filesystem.public` and `shopware.filesystem.private`). Only the `local` and `amazon-s3` adapters are supported. Any other adapter is rejected with a clear error.
+
+`--anonymize` and `ConfigDump` rules apply only to the SQL dumper. They do not sanitize public or private files. File components are transferred as stored. Private files can include invoices, documents, and other sensitive shop data; that is expected and must be documented.
+
+### Manifest
+
+`manifest.json` describes the package. Required fields for `format_version` 1:
+
+- `format_version` (integer, currently `1`)
+- `created_at` (RFC 3339 timestamp)
+- `source` (`shopware_version`, and `database.vendor` / `database.version` when a database component is present)
+- at least one of `database` or `filesystems`
+- `files`: array of `{path, size, sha256}` for every payload file except the manifest itself
+
+```json
 {
   "format_version": 1,
   "created_at": "2026-08-11T12:00:00Z",
-  "tool": {
-    "name": "shopware-cli",
-    "version": "0.9.0"
-  },
   "source": {
     "shopware_version": "6.7.1.0",
     "database": {
@@ -101,3 +105,29 @@ Potential manifest structure:
   ]
 }
 ```
+
+Validation rules:
+
+- Import rejects an unknown `format_version` with a clear error. It does not attempt partial interpretation.
+- Import ignores unknown fields (forward compatible).
+- `files[].path` must match the component paths declared in `database` / `filesystems`.
+- Import verifies each `files[]` entry's size and SHA-256 before applying that component.
+- A missing `filesystems.public` or `filesystems.private` key means that component is not in the package.
+- `database.backup_type` is `"sql"` or `"mysql-shell"`.
+
+Field names and additional hosting-specific metadata may still be aligned with PaaS/SaaS before the first implementation. Adding fields is allowed; removing or renaming a required `format_version` 1 field requires a new `format_version`.
+
+### Compression and storage
+
+Inner payloads may be compressed on their own (`public.tar.gz`, `private.tar.gz`, `database.sql.gz`). The outer file is the tar that export writes and import reads; gzip or zstd wrapping of that tar is optional.
+
+The first implementation writes and reads that tar on the local filesystem. Where the shop's public and private files themselves live is determined only by the Flysystem adapters above.
+
+## Consequences
+
+- `project dump` remains the database-only SQL command. Existing scripts keep working.
+- `project export` / `project import` are the portable shop-data commands.
+- Public and private files travel with the database in one archive, using the project's Flysystem config (`local` and `amazon-s3` only).
+- Hosted MySQL Shell dumps can be imported when they arrive in this package layout, without replacing the CLI SQL dumper.
+- SQL-only restore of a raw `dump.sql` is not `project import`. That remains a separate concern.
+- Work to align the package with Shopware PaaS/SaaS hosting is ongoing and supported by this ADR.

--- a/docs/adr/0002-project-dump-restore.md
+++ b/docs/adr/0002-project-dump-restore.md
@@ -1,0 +1,39 @@
+title: Align project dump and restore with portable shop data
+date: 2026-08-11
+tags: [project dump, project restore, mysql, database]
+
+## Context
+
+`project dump` currently creates a SQL database dump, with optional gzip or zstd compression and support for Shopware-specific cleaning and anonymization.
+
+[#1243](https://github.com/shopware/shopware-cli/issues/1243) proposed the corresponding `project restore` workflow. Work in [#1326](https://github.com/shopware/shopware-cli/pull/1326) added shared database connection handling and SQL execution infrastructure needed for that workflow, but `project restore` was held back while we aligned with Shopware PaaS and SaaS teams.
+
+The resulting conversation established that transferable shop data can include three distinct components: the database, public files, and private files. It also surfaced two interoperability goals: first, making data produced by Shopware CLI suitable for a future migration into Shopware hosting; and second, allowing data exported from hosted environments to be restored elsewhere.
+
+## Decision
+
+We will proceed with `project restore` and keep the existing database-only `project dump` and its SQL format supported.
+
+To ensure compatibility with other Shopware hosting models, dump and restore will also evolve around the same three independently selectable components: database, public files, and private files.
+
+Whole-shop transfers will use a versioned manifest describing the included components and their formats. The portable structure should match the format expected by Shopware hosting where applicable and practical, so that data produced by Shopware CLI can be accepted by a future PaaS restore flow without conversion.
+
+These compatibility requirements define the interchange contract; they do not require Shopware CLI to adopt hosting-specific implementation details that are unnecessary for interoperability. We commit to frictionless interchange, not to cloning PaaS/SaaS internals.
+
+The database component will continue to support Shopware CLI's existing SQL dumps and will also support reading mysql-shell dumps.
+
+Dump and restore will support partial operation on individual components and optional compression.
+
+The first implementation may read from and write to the local filesystem, but the design must not hard-code local paths as the only source or destination. The dump/restore model must support the storage setup used by Shopware PaaS and SaaS, including S3, while remaining extensible to additional user-controlled storage backends.
+
+This workflow is for transferring shop data. Production backup, disaster recovery, and platform snapshot lifecycle remain separate concerns.
+
+## Consequences
+
+- The pending `project restore` work can proceed for existing Shopware CLI SQL dumps.
+- Existing `project dump` behavior remains compatible.
+- Public and private files can be added to the same transfer model.
+- mysql-shell dumps can be consumed without replacing Shopware CLI's existing database dumper.
+- The transfer format should remain compatible with future PaaS import and export workflows where practical.
+- Partial transfers, optional compression, and non-local storage can be added without introducing a separate data model.
+- Work to define the migration path from/into Shopware PaaS/SaaS hosting is ongoing and supported by this ADR.

--- a/docs/adr/0002-project-dump-restore.md
+++ b/docs/adr/0002-project-dump-restore.md
@@ -19,7 +19,7 @@ Portable shop-data packages are a new pair of commands:
 - `project export` writes a tar archive.
 - `project import` reads that tar archive.
 
-Export and import operate on independently selectable components: database, public files, and private files. Public and private file data is optional on both sides: an archive does not have to include them, and `project import` does not have to apply them even when they are present.
+Export and import operate on independently selectable components: database, public files, and private files. An archive does not have to include public or private files. `project import` applies every component that is present. Skipping public or private files is opt-out (`--skip-public`, `--skip-private`).
 
 The archive is the interchange unit. Its layout should match the format expected by Shopware hosting where applicable and practical, so a CLI export can be accepted by a future hosted import without conversion, and a hosted export can be imported by the CLI.
 
@@ -32,36 +32,36 @@ This workflow is for transferring shop data. Production backup, disaster recover
 `project export` writes one tar (optionally wrapped with gzip or zstd). Inside:
 
 ```text
-manifest.json
-database.sql          # database.backup_type = "sql"
-database/             # database.backup_type = "mysql-shell"
-  ...                 # complete, opaque MySQL Shell dump
+metadata.json
+database.sql          # SQL dump
+database/             # complete, opaque MySQL Shell dump
+  ...
 public.tar.gz         # optional
 private.tar.gz        # optional
 ```
 
-A package includes only the selected components. `database.sql` and `database/` are alternatives, not both present.
+Components are detected from those fixed names. `metadata.json` does not repeat paths or backup types.
+
+`database.sql` and `database/` are alternatives. If both are present, import fails. A missing `public.tar.gz` or `private.tar.gz` means that filesystem is not in the package.
 
 The first CLI export writes `database.sql` using the existing SQL dumper, including `--clean` / `--anonymize` and `ConfigDump` rewrite, where, ignore, and no-data rules. The CLI will not produce MySQL Shell dumps in the first implementation.
 
-`project import` consumes the tar. For the database component it accepts either `backup_type`:
+`project import` consumes the tar and picks the database payload from the layout:
 
-- `"sql"` — the SQL file is applied to the project database.
-- `"mysql-shell"` — the directory is loaded as MySQL Shell left it. Any directory that MySQL Shell's load utility can consume (`util.dumpInstance` or `util.dumpSchemas` output) is accepted. The CLI does not re-encode MySQL Shell internals.
+- `database.sql` — applied to the project database.
+- `database/` — loaded as MySQL Shell left it. Any directory that MySQL Shell's load utility can consume (`util.dumpInstance` or `util.dumpSchemas` output) is accepted. The CLI does not re-encode MySQL Shell internals.
 
-Public and private files are optional tar archives of the corresponding Shopware filesystems, not of the project source tree. Export includes a filesystem only when that component is selected. Import applies a filesystem only when that component is selected and present in the archive; a missing `public.tar.gz` or `private.tar.gz` is valid. When they are applied, export reads them and import writes them through the project's existing Flysystem configuration in `config/packages` (`shopware.filesystem.public` and `shopware.filesystem.private`). Only the `local` and `amazon-s3` adapters are supported. Any other adapter is rejected with a clear error.
+Public and private files are optional tar archives of the corresponding Shopware filesystems, not of the project source tree. Export includes a filesystem only when that component is selected. Import applies `public.tar.gz` and `private.tar.gz` when they are present, unless the matching `--skip-public` or `--skip-private` flag is set. A missing file is valid and is not an error. When they are applied, export reads them and import writes them through the project's existing Flysystem configuration in `config/packages` (`shopware.filesystem.public` and `shopware.filesystem.private`). Only the `local` and `amazon-s3` adapters are supported. Any other adapter is rejected with a clear error.
 
 `--anonymize` and `ConfigDump` rules apply only to the SQL dumper. They do not sanitize public or private files. File components are transferred as stored. Private files can include invoices, documents, and other sensitive shop data; that is expected and must be documented.
 
-### Manifest
+### metadata.json
 
-`manifest.json` describes the package. Required fields for `format_version` 1:
+`metadata.json` describes the package, not the file layout. Required fields for `format_version` 1:
 
 - `format_version` (integer, currently `1`)
 - `created_at` (RFC 3339 timestamp)
 - `source` (`shopware_version`, and `database.vendor` / `database.version` when a database component is present)
-- at least one of `database` or `filesystems`
-- `files`: array of `{path, size, sha256}` for every payload file except the manifest itself
 
 ```json
 {
@@ -73,47 +73,16 @@ Public and private files are optional tar archives of the corresponding Shopware
       "vendor": "mysql",
       "version": "8.4.6"
     }
-  },
-  "database": {
-    "backup_type": "sql",
-    "path": "database.sql"
-  },
-  "filesystems": {
-    "public": {
-      "path": "public.tar.gz"
-    },
-    "private": {
-      "path": "private.tar.gz"
-    }
-  },
-  "files": [
-    {
-      "path": "database.sql",
-      "size": 123456789,
-      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-    },
-    {
-      "path": "public.tar.gz",
-      "size": 23456789,
-      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
-    },
-    {
-      "path": "private.tar.gz",
-      "size": 3456789,
-      "sha256": "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
-    }
-  ]
+  }
 }
 ```
 
 Validation rules:
 
-- Import rejects an unknown `format_version` with a clear error. It does not attempt partial interpretation.
+- Import rejects a missing `metadata.json` or an unknown `format_version` with a clear error. It does not attempt partial interpretation.
 - Import ignores unknown fields (forward compatible).
-- `files[].path` must match the component paths declared in `database` / `filesystems`.
-- Import verifies each `files[]` entry's size and SHA-256 before applying that component.
-- A missing `filesystems.public` or `filesystems.private` key means that component is not in the package.
-- `database.backup_type` is `"sql"` or `"mysql-shell"`.
+- The archive must contain at least one of `database.sql`, `database/`, `public.tar.gz`, or `private.tar.gz`.
+- If both `database.sql` and `database/` are present, import fails.
 
 Field names and additional hosting-specific metadata may still be aligned with PaaS/SaaS before the first implementation. Adding fields is allowed; removing or renaming a required `format_version` 1 field requires a new `format_version`.
 


### PR DESCRIPTION
## What changed?

ADR to document decisions with PaaS+SaaS regarding proposed `project restore` workflow behavior. 

Also standardizes the headings to more closely match what's used in shopware/shopware, updating the first ADR. 

## Why?

Get buy-in and alignment from stakeholders, drive interoperability across and support hosting models without hard-coding the CLI into corners.

## How was this tested?

It's a docs change.

## Related issue or discussion

Relates to https://github.com/shopware/shopware-cli/pull/1326 and would unblock https://github.com/shopware/shopware-cli/issues/1243.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the AI command architecture decision record with clearer title, date, and tags.
  - Added guidance for portable project export and import workflows using versioned tar archives.
  - Documented database, public-file, and private-file packages, including partial operations, compression, manifests, and supported storage options.
  - Clarified SQL and MySQL Shell formats, validation rules, dry runs, safety checks, and the separation between project transfers and production backup or disaster-recovery practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->