### PR TITLE
feat(project): add table row limiter to project dump

### DIFF
--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -245,5 +245,5 @@ func init() {
 	projectDatabaseDumpCmd.Flags().Bool("quick", false, "Use quick option for mysqldump")
 	projectDatabaseDumpCmd.Flags().Int("parallel", 0, "Number of tables to dump concurrently (0 = disabled)")
 	projectDatabaseDumpCmd.Flags().Int("insert-into-limit", 0, "Limit the number of rows per INSERT statement (0 = auto, takes priority over --quick when set)")
-	projectDatabaseDumpCmd.Flags().StringArray("limit", nil, "Limit the rows of a table (e.g. order=100 dumps only the 100 newest orders). Tables referencing the limited table are filtered automatically; ancestors of self-referencing rows (e.g. product variants) are kept so the dump stays importable. Can be specified multiple times")
+	projectDatabaseDumpCmd.Flags().StringArray("limit", nil, "Limit the rows of a table (e.g. order=100 dumps only the 100 newest orders). Tables referencing the limited table are filtered automatically; ancestors of self-referencing rows (e.g. product variants) are kept so the dump stays importable. Requires the CREATE and DROP privileges to freeze the kept rows into staging tables. Can be specified multiple times")
 }

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -245,5 +245,5 @@ func init() {
 	projectDatabaseDumpCmd.Flags().Bool("quick", false, "Use quick option for mysqldump")
 	projectDatabaseDumpCmd.Flags().Int("parallel", 0, "Number of tables to dump concurrently (0 = disabled)")
 	projectDatabaseDumpCmd.Flags().Int("insert-into-limit", 0, "Limit the number of rows per INSERT statement (0 = auto, takes priority over --quick when set)")
-	projectDatabaseDumpCmd.Flags().StringArray("limit", nil, "Limit the rows of a table (e.g. order=100 dumps only the 100 newest orders). Tables referencing the limited table are filtered automatically. Can be specified multiple times")
+	projectDatabaseDumpCmd.Flags().StringArray("limit", nil, "Limit the rows of a table (e.g. order=100 dumps only the 100 newest orders). Tables referencing the limited table are filtered automatically; ancestors of self-referencing rows (e.g. product variants) are kept so the dump stays importable. Can be specified multiple times")
 }

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/x/term"
@@ -48,6 +49,7 @@ var projectDatabaseDumpCmd = &cobra.Command{
 		quick, _ := cmd.Flags().GetBool("quick")
 		parallel, _ := cmd.Flags().GetInt("parallel")
 		insertIntoLimit, _ := cmd.Flags().GetInt("insert-into-limit")
+		limits, _ := cmd.Flags().GetStringArray("limit")
 
 		db, err := sql.Open("mysql", mysqlConfig.FormatDSN())
 		if err != nil {
@@ -77,12 +79,39 @@ var projectDatabaseDumpCmd = &cobra.Command{
 			projectCfg.ConfigDump.EnableAnonymization()
 		}
 
+		for _, limit := range limits {
+			table, rows, ok := strings.Cut(limit, "=")
+			if !ok {
+				return fmt.Errorf("invalid --limit %q, expected format table=rows (e.g. order=100)", limit)
+			}
+
+			rowCount, err := strconv.Atoi(rows)
+			if err != nil || rowCount < 1 {
+				return fmt.Errorf("invalid --limit %q, rows must be a positive number", limit)
+			}
+
+			if projectCfg.ConfigDump.Limit == nil {
+				projectCfg.ConfigDump.Limit = make(map[string]shop.ConfigDumpLimit)
+			}
+
+			cfgLimit := projectCfg.ConfigDump.Limit[table]
+			cfgLimit.Rows = rowCount
+			projectCfg.ConfigDump.Limit[table] = cfgLimit
+		}
+
 		projectCfg.ConfigDump.NormalizeFakerExpressions()
 
 		dumper.SelectMap = projectCfg.ConfigDump.Rewrite
 		dumper.WhereMap = projectCfg.ConfigDump.Where
 		dumper.NoData = projectCfg.ConfigDump.NoData
 		dumper.Ignore = projectCfg.ConfigDump.Ignore
+
+		if len(projectCfg.ConfigDump.Limit) > 0 {
+			dumper.LimitMap = make(map[string]mysqldump.TableLimit, len(projectCfg.ConfigDump.Limit))
+			for table, limit := range projectCfg.ConfigDump.Limit {
+				dumper.LimitMap[table] = mysqldump.TableLimit{Rows: limit.Rows, OrderBy: limit.OrderBy}
+			}
+		}
 
 		var w io.Writer
 		if output == "-" {
@@ -222,4 +251,5 @@ func init() {
 	projectDatabaseDumpCmd.Flags().Bool("quick", false, "Use quick option for mysqldump")
 	projectDatabaseDumpCmd.Flags().Int("parallel", 0, "Number of tables to dump concurrently (0 = disabled)")
 	projectDatabaseDumpCmd.Flags().Int("insert-into-limit", 0, "Limit the number of rows per INSERT statement (0 = auto, takes priority over --quick when set)")
+	projectDatabaseDumpCmd.Flags().StringArray("limit", nil, "Limit the rows of a table (e.g. order=100 dumps only the 100 newest orders). Tables referencing the limited table are filtered automatically. Can be specified multiple times")
 }

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -79,6 +79,10 @@ var projectDatabaseDumpCmd = &cobra.Command{
 			projectCfg.ConfigDump.EnableAnonymization()
 		}
 
+		if len(limits) > 0 && projectCfg.ConfigDump.Limit == nil {
+			projectCfg.ConfigDump.Limit = make(map[string]shop.ConfigDumpLimit)
+		}
+
 		for _, limit := range limits {
 			table, rows, ok := strings.Cut(limit, "=")
 			if !ok {
@@ -88,10 +92,6 @@ var projectDatabaseDumpCmd = &cobra.Command{
 			rowCount, err := strconv.Atoi(rows)
 			if err != nil || rowCount < 1 {
 				return fmt.Errorf("invalid --limit %q, rows must be a positive number", limit)
-			}
-
-			if projectCfg.ConfigDump.Limit == nil {
-				projectCfg.ConfigDump.Limit = make(map[string]shop.ConfigDumpLimit)
 			}
 
 			cfgLimit := projectCfg.ConfigDump.Limit[table]

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -80,7 +80,7 @@ var projectDatabaseDumpCmd = &cobra.Command{
 		}
 
 		if len(limits) > 0 && projectCfg.ConfigDump.Limit == nil {
-			projectCfg.ConfigDump.Limit = make(map[string]shop.ConfigDumpLimit)
+			projectCfg.ConfigDump.Limit = make(map[string]mysqldump.TableLimit)
 		}
 
 		for _, limit := range limits {
@@ -105,13 +105,7 @@ var projectDatabaseDumpCmd = &cobra.Command{
 		dumper.WhereMap = projectCfg.ConfigDump.Where
 		dumper.NoData = projectCfg.ConfigDump.NoData
 		dumper.Ignore = projectCfg.ConfigDump.Ignore
-
-		if len(projectCfg.ConfigDump.Limit) > 0 {
-			dumper.LimitMap = make(map[string]mysqldump.TableLimit, len(projectCfg.ConfigDump.Limit))
-			for table, limit := range projectCfg.ConfigDump.Limit {
-				dumper.LimitMap[table] = mysqldump.TableLimit{Rows: limit.Rows, OrderBy: limit.OrderBy}
-			}
-		}
+		dumper.LimitMap = projectCfg.ConfigDump.Limit
 
 		var w io.Writer
 		if output == "-" {

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -137,18 +137,18 @@ func (d *Dumper) finalizeLimitWhere() {
 // and a non-total ORDER BY (e.g. ties on created_at) could yield different rows
 // each time, leaving dangling foreign keys in the dump.
 //
-// It requires privileges to create tables. When that fails, it logs a warning
-// and leaves the inline-subquery filters in place, which still produce a
-// self-consistent dump on a quiescent database.
-func (d *Dumper) createLimitStagingTables(ctx context.Context) {
+// Creating the staging tables requires privileges to create tables. Because a
+// consistent kept-set cannot be guaranteed without them, --limit hard-fails when
+// the staging tables cannot be created instead of silently producing a dump that
+// may not import.
+func (d *Dumper) createLimitStagingTables(ctx context.Context) error {
 	if d.limitResolver == nil || len(d.limitResolver.limits) == 0 {
-		return
+		return nil
 	}
 
 	suffix, err := randomTableSuffix()
 	if err != nil {
-		logging.FromContext(ctx).Warnf("Cannot create staging tables for row limits, falling back to inline filters: %s", err)
-		return
+		return fmt.Errorf("cannot create staging tables for row limits: %w", err)
 	}
 
 	staging := make(map[string]string, len(d.limitResolver.limits))
@@ -158,16 +158,14 @@ func (d *Dumper) createLimitStagingTables(ctx context.Context) {
 
 		dropQuery := fmt.Sprintf("DROP TABLE IF EXISTS `%s`", stagingName)
 		if _, err := d.useTransactionOrDBExec(ctx, dropQuery); err != nil {
-			logging.FromContext(ctx).Warnf("Cannot create staging table for row limit on %s, falling back to inline filters: %s", table, err)
 			d.dropLimitStagingTables(ctx, staging)
-			return
+			return fmt.Errorf("cannot create staging table for row limit on %s (the CREATE and DROP privileges are required to use --limit): %w", table, err)
 		}
 
 		createQuery := fmt.Sprintf("CREATE TABLE `%s` AS %s", stagingName, populate)
 		if _, err := d.useTransactionOrDBExec(ctx, createQuery); err != nil {
-			logging.FromContext(ctx).Warnf("Cannot create staging table for row limit on %s, falling back to inline filters: %s", table, err)
 			d.dropLimitStagingTables(ctx, staging)
-			return
+			return fmt.Errorf("cannot create staging table for row limit on %s (the CREATE and DROP privileges are required to use --limit): %w", table, err)
 		}
 
 		staging[table] = stagingName
@@ -178,6 +176,8 @@ func (d *Dumper) createLimitStagingTables(ctx context.Context) {
 	d.finalizeLimitWhere()
 
 	logging.FromContext(ctx).Infof("Froze the kept rows of %d limited table(s) into staging tables for a consistent dump", len(staging))
+
+	return nil
 }
 
 // dropLimitStagingTables removes the given staging tables. It is safe to call

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -1,0 +1,243 @@
+package mysqldump
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/shopware/shopware-cli/logging"
+)
+
+// TableLimit restricts how many rows of a table are dumped. All tables
+// referencing the limited table via foreign keys (directly or transitively)
+// are filtered automatically so they only contain rows attached to the kept
+// rows.
+type TableLimit struct {
+	// Rows is the maximum number of rows to dump.
+	Rows int
+	// OrderBy decides which rows are kept (e.g. "`created_at` DESC" for the
+	// latest rows). When empty and the table has a created_at column,
+	// "`created_at` DESC" is used.
+	OrderBy string
+}
+
+// limitDerivedTableAlias names the derived table wrapping the LIMIT query, as
+// MySQL rejects LIMIT directly inside an IN subquery.
+const limitDerivedTableAlias = "`_sw_cli_limit`"
+
+// computeLimitFilters translates LimitMap into WHERE conditions stored in
+// limitWhere. Must run after prefetchAllSchemas, as it walks the foreign keys
+// of the cached schemas.
+func (d *Dumper) computeLimitFilters(ctx context.Context) error {
+	if len(d.LimitMap) == 0 {
+		return nil
+	}
+
+	schemas := make(map[string]*TableSchema, len(d.schemaCache))
+	for name, schema := range d.schemaCache {
+		schemas[strings.ToLower(name)] = schema
+	}
+
+	limits := make(map[string]TableLimit, len(d.LimitMap))
+	for table, limit := range d.LimitMap {
+		table = strings.ToLower(table)
+
+		schema, ok := schemas[table]
+		if !ok {
+			logging.FromContext(ctx).Warnf("Ignoring row limit for table %s: the table does not exist or is excluded from the dump", table)
+			continue
+		}
+
+		if limit.Rows <= 0 {
+			return fmt.Errorf("row limit for table %s must be greater than zero", table)
+		}
+
+		if len(schema.PrimaryKey) == 0 {
+			return fmt.Errorf("cannot limit rows of table %s: the table has no primary key", table)
+		}
+
+		if limit.OrderBy == "" && slices.ContainsFunc(schema.Columns, func(col ColumnSchema) bool { return strings.EqualFold(col.Name, "created_at") }) {
+			limit.OrderBy = "`created_at` DESC"
+			logging.FromContext(ctx).Infof("Limiting table %s to the %d newest rows by created_at", table, limit.Rows)
+		}
+
+		limits[table] = limit
+	}
+
+	if len(limits) == 0 {
+		return nil
+	}
+
+	resolver := &limitResolver{
+		whereMap:  d.WhereMap,
+		schemas:   schemas,
+		limits:    limits,
+		affected:  make(map[string]bool),
+		memo:      make(map[string]string),
+		resolving: make(map[string]bool),
+	}
+	resolver.markAffectedTables()
+
+	d.limitWhere = make(map[string]string)
+
+	for _, table := range slices.Sorted(maps.Keys(resolver.affected)) {
+		if _, isLimited := limits[table]; isLimited {
+			primaryKey := schemas[table].PrimaryKey
+			d.limitWhere[table] = fmt.Sprintf("%s IN (%s)", columnTuple(primaryKey), resolver.keptRowsQuery(table, primaryKey))
+			continue
+		}
+
+		if condition := resolver.conditionFor(table); condition != "" {
+			d.limitWhere[table] = condition
+		}
+	}
+
+	return nil
+}
+
+type limitResolver struct {
+	whereMap map[string]string
+	schemas  map[string]*TableSchema
+	limits   map[string]TableLimit
+	// affected contains all tables whose rows must be filtered: the limited
+	// tables plus every table referencing an affected table via foreign keys.
+	affected map[string]bool
+	memo     map[string]string
+	// resolving guards against foreign key cycles: edges into a table that is
+	// currently being resolved are skipped, which keeps a superset of the
+	// strictly attached rows instead of recursing forever.
+	resolving map[string]bool
+}
+
+func (r *limitResolver) markAffectedTables() {
+	for table := range r.limits {
+		r.affected[table] = true
+	}
+
+	for changed := true; changed; {
+		changed = false
+		for name, schema := range r.schemas {
+			if r.affected[name] {
+				continue
+			}
+
+			for _, fk := range schema.ForeignKeys {
+				referenced := strings.ToLower(fk.ReferencedTable)
+				if referenced != name && r.affected[referenced] {
+					r.affected[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+}
+
+// conditionFor returns the WHERE condition restricting the given non-limited
+// table to rows attached to the kept rows of its referenced affected tables.
+func (r *limitResolver) conditionFor(table string) string {
+	if condition, ok := r.memo[table]; ok {
+		return condition
+	}
+
+	r.resolving[table] = true
+	defer delete(r.resolving, table)
+
+	var parts []string
+	for _, fk := range r.schemas[table].ForeignKeys {
+		referenced := strings.ToLower(fk.ReferencedTable)
+		if !r.affected[referenced] || referenced == table || r.resolving[referenced] {
+			continue
+		}
+
+		if _, isLimited := r.limits[referenced]; !isLimited && r.conditionFor(referenced) == "" {
+			continue
+		}
+
+		condition := fmt.Sprintf("%s IN (%s)", columnTuple(fk.Columns), r.keptRowsQuery(referenced, fk.ReferencedColumns))
+
+		// Rows not referencing the parent at all are kept.
+		if nullable := r.nullableColumns(table, fk.Columns); len(nullable) != 0 {
+			nullChecks := make([]string, 0, len(nullable))
+			for _, column := range nullable {
+				nullChecks = append(nullChecks, fmt.Sprintf("`%s` IS NULL", column))
+			}
+
+			condition = fmt.Sprintf("%s OR %s", strings.Join(nullChecks, " OR "), condition)
+		}
+
+		parts = append(parts, "("+condition+")")
+	}
+
+	condition := strings.Join(parts, " AND ")
+	r.memo[table] = condition
+	return condition
+}
+
+// keptRowsQuery returns a SELECT yielding the given columns of all rows kept
+// for the given affected table.
+func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
+	quotedColumns := quoteColumns(columns)
+	tableName := r.schemas[table].Name
+
+	if limit, isLimited := r.limits[table]; isLimited {
+		query := fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, tableName)
+		if where := r.whereMap[table]; where != "" {
+			query += " WHERE " + where
+		}
+		if limit.OrderBy != "" {
+			query += " ORDER BY " + limit.OrderBy
+		}
+		query += fmt.Sprintf(" LIMIT %d", limit.Rows)
+
+		return fmt.Sprintf("SELECT %s FROM (%s) %s", quotedColumns, query, limitDerivedTableAlias)
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, tableName)
+
+	conditions := make([]string, 0, 2)
+	if where := r.whereMap[table]; where != "" {
+		conditions = append(conditions, "("+where+")")
+	}
+	if condition := r.conditionFor(table); condition != "" {
+		conditions = append(conditions, condition)
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	return query
+}
+
+func (r *limitResolver) nullableColumns(table string, columns []string) []string {
+	var nullable []string
+	for _, column := range columns {
+		for _, col := range r.schemas[table].Columns {
+			if col.Name == column && col.Nullable {
+				nullable = append(nullable, column)
+				break
+			}
+		}
+	}
+
+	return nullable
+}
+
+func columnTuple(columns []string) string {
+	if len(columns) == 1 {
+		return "`" + columns[0] + "`"
+	}
+
+	return "(" + quoteColumns(columns) + ")"
+}
+
+func quoteColumns(columns []string) string {
+	quoted := make([]string, len(columns))
+	for i, column := range columns {
+		quoted[i] = "`" + column + "`"
+	}
+
+	return strings.Join(quoted, ", ")
+}

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -14,6 +14,9 @@ import (
 // referencing the limited table via foreign keys (directly or transitively)
 // are filtered automatically so they only contain rows attached to the kept
 // rows. A second limit on a table that is already filtered this way is rejected.
+// When the limited table references itself (e.g. product.parent_id), the
+// ancestors of the kept rows are dumped too, so the export may hold slightly
+// more than Rows rows but stays importable with foreign key checks enabled.
 type TableLimit struct {
 	// Maximum amount of rows to export for this table
 	Rows int `yaml:"rows" jsonschema:"required,minimum=1"`
@@ -218,17 +221,16 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 	quotedColumns := quoteColumns(columns)
 	tableName := r.schemas[table].Name
 
-	if limit, isLimited := r.limits[table]; isLimited {
-		query := fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, tableName)
-		if where := r.whereMap[table]; where != "" {
-			query += " WHERE " + where
+	if _, isLimited := r.limits[table]; isLimited {
+		// A self-referencing limited table (e.g. product.parent_id -> product.id)
+		// must keep the ancestors of every kept row, otherwise a kept variant
+		// would reference a parent excluded by the LIMIT and break the foreign
+		// key on import. A recursive CTE seeded by the LIMIT walks the parents.
+		if selfRefs := r.selfReferences(table); len(selfRefs) != 0 {
+			return r.selfReferenceClosureQuery(table, columns, selfRefs)
 		}
-		if limit.OrderBy != "" {
-			query += " ORDER BY " + limit.OrderBy
-		}
-		query += fmt.Sprintf(" LIMIT %d", limit.Rows)
 
-		return fmt.Sprintf("SELECT %s FROM (%s) %s", quotedColumns, query, limitDerivedTableAlias)
+		return fmt.Sprintf("SELECT %s FROM (%s) %s", quotedColumns, r.limitSeedQuery(table, columns), limitDerivedTableAlias)
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, tableName)
@@ -245,6 +247,109 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 	}
 
 	return query
+}
+
+// limitSeedQuery returns the plain "SELECT columns FROM table [WHERE] [ORDER BY]
+// LIMIT n" query selecting the rows kept by the limit of the given table.
+func (r *limitResolver) limitSeedQuery(table string, columns []string) string {
+	limit := r.limits[table]
+
+	query := fmt.Sprintf("SELECT %s FROM `%s`", quoteColumns(columns), r.schemas[table].Name)
+	if where := r.whereMap[table]; where != "" {
+		query += " WHERE " + where
+	}
+	if limit.OrderBy != "" {
+		query += " ORDER BY " + limit.OrderBy
+	}
+	query += fmt.Sprintf(" LIMIT %d", limit.Rows)
+
+	return query
+}
+
+// selfReferences returns the foreign keys of the given table that point back at
+// the same table (e.g. product.parent_id -> product.id).
+func (r *limitResolver) selfReferences(table string) []ForeignKeySchema {
+	var selfRefs []ForeignKeySchema
+	for _, fk := range r.schemas[table].ForeignKeys {
+		if strings.EqualFold(fk.ReferencedTable, table) {
+			selfRefs = append(selfRefs, fk)
+		}
+	}
+
+	return selfRefs
+}
+
+// selfReferenceCTEAlias names the recursive CTE that closes a limited table over
+// its self-references.
+const selfReferenceCTEAlias = "`_sw_cli_kept`"
+
+// selfReferenceClosureQuery returns a SELECT yielding the given columns of all
+// rows kept for a limited, self-referencing table: the rows selected by the
+// LIMIT plus, recursively, the parent rows they reference through selfRefs. The
+// recursive CTE guarantees the kept set is closed under the self-references, so
+// the dump imports without dangling foreign keys.
+func (r *limitResolver) selfReferenceClosureQuery(table string, columns []string, selfRefs []ForeignKeySchema) string {
+	primaryKey := r.schemas[table].PrimaryKey
+	tableName := r.schemas[table].Name
+	pkColumns := quoteColumns(primaryKey)
+
+	// Each recursive term walks one self-reference upwards: it joins the kept
+	// rows back to the base table to recover their foreign key columns, then
+	// joins to the referenced parent rows and keeps their primary keys.
+	const childAlias, parentAlias = "`_sw_child`", "`_sw_parent`"
+	recursiveTerms := make([]string, 0, len(selfRefs))
+	for _, fk := range selfRefs {
+		keptJoin := make([]string, len(primaryKey))
+		for i, column := range primaryKey {
+			keptJoin[i] = fmt.Sprintf("%s.`%s` = %s.`%s`", childAlias, column, selfReferenceCTEAlias, column)
+		}
+
+		parentJoin := make([]string, len(fk.Columns))
+		for i, column := range fk.Columns {
+			parentJoin[i] = fmt.Sprintf("%s.`%s` = %s.`%s`", parentAlias, fk.ReferencedColumns[i], childAlias, column)
+		}
+
+		recursiveTerms = append(recursiveTerms, fmt.Sprintf(
+			"SELECT %s FROM `%s` %s JOIN %s ON %s JOIN `%s` %s ON %s",
+			prefixColumns(parentAlias, primaryKey),
+			tableName, childAlias,
+			selfReferenceCTEAlias, strings.Join(keptJoin, " AND "),
+			tableName, parentAlias, strings.Join(parentJoin, " AND "),
+		))
+	}
+
+	seed := fmt.Sprintf("SELECT %s FROM (%s) %s", pkColumns, r.limitSeedQuery(table, primaryKey), limitDerivedTableAlias)
+
+	// The CTE carries only the primary key of the kept rows. When the caller
+	// wants exactly the primary key (the common case) it is selected directly;
+	// otherwise the requested columns are fetched by joining the kept keys back
+	// to the base table, which also covers foreign keys referencing non-primary
+	// key columns.
+	projection := fmt.Sprintf("%s FROM %s", quoteColumns(columns), selfReferenceCTEAlias)
+	if !slices.Equal(columns, primaryKey) {
+		keptJoin := make([]string, len(primaryKey))
+		for i, column := range primaryKey {
+			keptJoin[i] = fmt.Sprintf("`%s`.`%s` = %s.`%s`", tableName, column, selfReferenceCTEAlias, column)
+		}
+
+		projection = fmt.Sprintf("%s FROM `%s` JOIN %s ON %s", prefixColumns("`"+tableName+"`", columns), tableName, selfReferenceCTEAlias, strings.Join(keptJoin, " AND "))
+	}
+
+	return fmt.Sprintf(
+		"WITH RECURSIVE %s (%s) AS (%s UNION %s) SELECT %s",
+		selfReferenceCTEAlias, pkColumns, seed, strings.Join(recursiveTerms, " UNION "), projection,
+	)
+}
+
+// prefixColumns quotes each column and prefixes it with the given already-quoted
+// table reference, e.g. `_sw_parent`.`id`, `_sw_parent`.`version_id`.
+func prefixColumns(tableRef string, columns []string) string {
+	prefixed := make([]string, len(columns))
+	for i, column := range columns {
+		prefixed[i] = fmt.Sprintf("%s.`%s`", tableRef, column)
+	}
+
+	return strings.Join(prefixed, ", ")
 }
 
 func (r *limitResolver) nullableColumns(table string, columns []string) []string {

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -13,14 +13,12 @@ import (
 // TableLimit restricts how many rows of a table are dumped. All tables
 // referencing the limited table via foreign keys (directly or transitively)
 // are filtered automatically so they only contain rows attached to the kept
-// rows.
+// rows. A second limit on a table that is already filtered this way is rejected.
 type TableLimit struct {
-	// Rows is the maximum number of rows to dump.
-	Rows int
-	// OrderBy decides which rows are kept (e.g. "`created_at` DESC" for the
-	// latest rows). When empty and the table has a created_at column,
-	// "`created_at` DESC" is used.
-	OrderBy string
+	// Maximum amount of rows to export for this table
+	Rows int `yaml:"rows" jsonschema:"required,minimum=1"`
+	// SQL ORDER BY clause deciding which rows are kept (e.g. "created_at DESC" for the newest rows). Defaults to "created_at DESC" when the table has a created_at column
+	OrderBy string `yaml:"order_by,omitempty"`
 }
 
 // limitDerivedTableAlias names the derived table wrapping the LIMIT query, as

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -70,6 +70,10 @@ func (d *Dumper) computeLimitFilters(ctx context.Context) error {
 		return nil
 	}
 
+	if err := rejectOverlappingLimits(schemas, limits); err != nil {
+		return err
+	}
+
 	resolver := &limitResolver{
 		whereMap:  d.WhereMap,
 		schemas:   schemas,
@@ -120,17 +124,47 @@ func (r *limitResolver) markAffectedTables() {
 		r.affected[table] = true
 	}
 
+	markReferencingTables(r.schemas, r.affected)
+}
+
+// rejectOverlappingLimits forbids independently limiting a table that is already
+// filtered by another limit (directly or transitively via foreign keys).
+// Example: --limit order=100 already keeps only order_address rows of those
+// orders, so --limit order_address=50 would pick an unrelated set and is rejected.
+func rejectOverlappingLimits(schemas map[string]*TableSchema, limits map[string]TableLimit) error {
+	if len(limits) < 2 {
+		return nil
+	}
+
+	limited := slices.Sorted(maps.Keys(limits))
+	for _, parent := range limited {
+		filtered := map[string]bool{parent: true}
+		markReferencingTables(schemas, filtered)
+
+		for _, child := range limited {
+			if child != parent && filtered[child] {
+				return fmt.Errorf("cannot limit table %s: limiting table %s already filters %s via foreign keys", child, parent, child)
+			}
+		}
+	}
+
+	return nil
+}
+
+// markReferencingTables adds every table that references a table already in
+// affected, walking foreign keys until the set stops growing.
+func markReferencingTables(schemas map[string]*TableSchema, affected map[string]bool) {
 	for changed := true; changed; {
 		changed = false
-		for name, schema := range r.schemas {
-			if r.affected[name] {
+		for name, schema := range schemas {
+			if affected[name] {
 				continue
 			}
 
 			for _, fk := range schema.ForeignKeys {
 				referenced := strings.ToLower(fk.ReferencedTable)
-				if referenced != name && r.affected[referenced] {
-					r.affected[name] = true
+				if referenced != name && affected[referenced] {
+					affected[name] = true
 					changed = true
 					break
 				}

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -2,6 +2,8 @@ package mysqldump
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"slices"
@@ -9,6 +11,17 @@ import (
 
 	"github.com/shopware/shopware-cli/logging"
 )
+
+// randomTableSuffix returns a short random hex suffix used to make staging table
+// names unique, so concurrent dumps of the same database do not collide.
+func randomTableSuffix() (string, error) {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(buf), nil
+}
 
 // TableLimit restricts how many rows of a table are dumped. All tables
 // referencing the limited table via foreign keys (directly or transitively)
@@ -76,34 +89,118 @@ func (d *Dumper) computeLimitFilters(ctx context.Context) error {
 	}
 
 	resolver := &limitResolver{
-		whereMap:  d.WhereMap,
-		schemas:   schemas,
-		limits:    limits,
-		affected:  make(map[string]bool),
-		memo:      make(map[string]string),
-		resolving: make(map[string]bool),
+		whereMap:      d.WhereMap,
+		schemas:       schemas,
+		limits:        limits,
+		affected:      make(map[string]bool),
+		memo:          make(map[string]string),
+		resolving:     make(map[string]bool),
+		stagingTables: make(map[string]string),
 	}
 	resolver.markAffectedTables()
 
-	d.limitWhere = make(map[string]string)
-
-	for _, table := range slices.Sorted(maps.Keys(resolver.affected)) {
-		if _, isLimited := limits[table]; isLimited {
-			primaryKey := schemas[table].PrimaryKey
-			d.limitWhere[table] = fmt.Sprintf("%s IN (%s)", columnTuple(primaryKey), resolver.keptRowsQuery(table, primaryKey))
-			continue
-		}
-
-		if condition := resolver.conditionFor(table); condition != "" {
-			d.limitWhere[table] = condition
-		}
-	}
+	d.limitResolver = resolver
+	d.finalizeLimitWhere()
 
 	if d.LockTables && len(d.limitWhere) > 0 {
 		logging.FromContext(ctx).Infof("Skipping table locks for %d tables filtered by row limits, as their dump queries reference other tables", len(d.limitWhere))
 	}
 
 	return nil
+}
+
+// finalizeLimitWhere (re)builds the per-table WHERE conditions from the resolver.
+// It is called once after planning and again after staging tables are created, so
+// the conditions pick up the frozen staging tables when they exist.
+func (d *Dumper) finalizeLimitWhere() {
+	r := d.limitResolver
+	r.memo = make(map[string]string)
+
+	d.limitWhere = make(map[string]string)
+	for _, table := range slices.Sorted(maps.Keys(r.affected)) {
+		if _, isLimited := r.limits[table]; isLimited {
+			primaryKey := r.schemas[table].PrimaryKey
+			d.limitWhere[table] = fmt.Sprintf("%s IN (%s)", columnTuple(primaryKey), r.keptRowsQuery(table, primaryKey))
+			continue
+		}
+
+		if condition := r.conditionFor(table); condition != "" {
+			d.limitWhere[table] = condition
+		}
+	}
+}
+
+// createLimitStagingTables freezes each limited table's kept-set into a staging
+// table, so every query that references it (the limited table itself and all
+// tables filtered against it, possibly on parallel connections) reads the exact
+// same rows. Without this, the LIMIT query is re-evaluated per referencing table
+// and a non-total ORDER BY (e.g. ties on created_at) could yield different rows
+// each time, leaving dangling foreign keys in the dump.
+//
+// It requires privileges to create tables. When that fails, it logs a warning
+// and leaves the inline-subquery filters in place, which still produce a
+// self-consistent dump on a quiescent database.
+func (d *Dumper) createLimitStagingTables(ctx context.Context) {
+	if d.limitResolver == nil || len(d.limitResolver.limits) == 0 {
+		return
+	}
+
+	suffix, err := randomTableSuffix()
+	if err != nil {
+		logging.FromContext(ctx).Warnf("Cannot create staging tables for row limits, falling back to inline filters: %s", err)
+		return
+	}
+
+	staging := make(map[string]string, len(d.limitResolver.limits))
+	for _, table := range slices.Sorted(maps.Keys(d.limitResolver.limits)) {
+		stagingName := stagingTableName(table, suffix)
+		populate := d.limitResolver.keptRowsPopulateQuery(table, d.limitResolver.schemas[table].PrimaryKey)
+
+		dropQuery := fmt.Sprintf("DROP TABLE IF EXISTS `%s`", stagingName)
+		if _, err := d.useTransactionOrDBExec(ctx, dropQuery); err != nil {
+			logging.FromContext(ctx).Warnf("Cannot create staging table for row limit on %s, falling back to inline filters: %s", table, err)
+			d.dropLimitStagingTables(ctx, staging)
+			return
+		}
+
+		createQuery := fmt.Sprintf("CREATE TABLE `%s` AS %s", stagingName, populate)
+		if _, err := d.useTransactionOrDBExec(ctx, createQuery); err != nil {
+			logging.FromContext(ctx).Warnf("Cannot create staging table for row limit on %s, falling back to inline filters: %s", table, err)
+			d.dropLimitStagingTables(ctx, staging)
+			return
+		}
+
+		staging[table] = stagingName
+	}
+
+	d.limitStagingTables = staging
+	d.limitResolver.stagingTables = staging
+	d.finalizeLimitWhere()
+
+	logging.FromContext(ctx).Infof("Froze the kept rows of %d limited table(s) into staging tables for a consistent dump", len(staging))
+}
+
+// dropLimitStagingTables removes the given staging tables. It is safe to call
+// with the tracked set (on cleanup) or a partial set (on a failed setup).
+func (d *Dumper) dropLimitStagingTables(ctx context.Context, staging map[string]string) {
+	for _, stagingName := range staging {
+		if _, err := d.useTransactionOrDBExec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", stagingName)); err != nil {
+			logging.FromContext(ctx).Warnf("Cannot drop staging table %s, please remove it manually: %s", stagingName, err)
+		}
+	}
+}
+
+// stagingTableName builds a staging table name for a limited table, keeping it
+// within MySQL's 64 character identifier limit.
+func stagingTableName(table, suffix string) string {
+	const prefix = "_sw_cli_kept_"
+
+	maxTableLen := 64 - len(prefix) - len(suffix) - 1
+	if len(table) > maxTableLen {
+		table = table[:maxTableLen]
+	}
+
+	return fmt.Sprintf("%s%s_%s", prefix, table, suffix)
 }
 
 type limitResolver struct {
@@ -118,6 +215,11 @@ type limitResolver struct {
 	// currently being resolved are skipped, which keeps a superset of the
 	// strictly attached rows instead of recursing forever.
 	resolving map[string]bool
+	// stagingTables maps a limited table to the staging table holding its frozen
+	// kept-set. When set, kept-row lookups read from the staging table instead of
+	// re-evaluating the LIMIT query, so the set stays identical across the many
+	// queries (and parallel connections) that reference it.
+	stagingTables map[string]string
 }
 
 func (r *limitResolver) markAffectedTables() {
@@ -222,15 +324,13 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 	tableName := r.schemas[table].Name
 
 	if _, isLimited := r.limits[table]; isLimited {
-		// A self-referencing limited table (e.g. product.parent_id -> product.id)
-		// must keep the ancestors of every kept row, otherwise a kept variant
-		// would reference a parent excluded by the LIMIT and break the foreign
-		// key on import. A recursive CTE seeded by the LIMIT walks the parents.
-		if selfRefs := r.selfReferences(table); len(selfRefs) != 0 {
-			return r.selfReferenceClosureQuery(table, columns, selfRefs)
+		// When the kept-set has been frozen into a staging table, read from it so
+		// every reference sees the identical rows.
+		if staging, ok := r.stagingTables[table]; ok {
+			return fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, staging)
 		}
 
-		return fmt.Sprintf("SELECT %s FROM (%s) %s", quotedColumns, r.limitSeedQuery(table, columns), limitDerivedTableAlias)
+		return r.keptRowsPopulateQuery(table, columns)
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, tableName)
@@ -247,6 +347,22 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 	}
 
 	return query
+}
+
+// keptRowsPopulateQuery returns the SELECT that computes the kept-set of a
+// limited table from the live data: the LIMIT rows, plus their ancestors when
+// the table references itself. It is used both to populate the staging table and
+// as the inline fallback when no staging table could be created.
+func (r *limitResolver) keptRowsPopulateQuery(table string, columns []string) string {
+	// A self-referencing limited table (e.g. product.parent_id -> product.id)
+	// must keep the ancestors of every kept row, otherwise a kept variant would
+	// reference a parent excluded by the LIMIT and break the foreign key on
+	// import. A recursive CTE seeded by the LIMIT walks the parents.
+	if selfRefs := r.selfReferences(table); len(selfRefs) != 0 {
+		return r.selfReferenceClosureQuery(table, columns, selfRefs)
+	}
+
+	return fmt.Sprintf("SELECT %s FROM (%s) %s", quoteColumns(columns), r.limitSeedQuery(table, columns), limitDerivedTableAlias)
 }
 
 // limitSeedQuery returns the plain "SELECT columns FROM table [WHERE] [ORDER BY]

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shopware/shopware-cli/logging"
 )
 
-// randomTableSuffix returns a short random hex suffix used to make staging table
+// randomTableSuffix returns a short random hex suffix keeping staging table
 // names unique, so concurrent dumps of the same database do not collide.
 func randomTableSuffix() (string, error) {
 	buf := make([]byte, 4)
@@ -54,6 +54,9 @@ func (d *Dumper) computeLimitFilters(ctx context.Context) error {
 		schemas[strings.ToLower(name)] = schema
 	}
 
+	// Normalized copy instead of an in-place edit of d.LimitMap: the keys are
+	// lower-cased, unknown tables are dropped and OrderBy gets a default, and
+	// d.LimitMap is the caller-owned configuration map that must stay untouched.
 	limits := make(map[string]TableLimit, len(d.LimitMap))
 	for table, limit := range d.LimitMap {
 		table = strings.ToLower(table)
@@ -131,16 +134,11 @@ func (d *Dumper) finalizeLimitWhere() {
 }
 
 // createLimitStagingTables freezes each limited table's kept-set into a staging
-// table, so every query that references it (the limited table itself and all
-// tables filtered against it, possibly on parallel connections) reads the exact
-// same rows. Without this, the LIMIT query is re-evaluated per referencing table
-// and a non-total ORDER BY (e.g. ties on created_at) could yield different rows
-// each time, leaving dangling foreign keys in the dump.
-//
-// Creating the staging tables requires privileges to create tables. Because a
-// consistent kept-set cannot be guaranteed without them, --limit hard-fails when
-// the staging tables cannot be created instead of silently producing a dump that
-// may not import.
+// table, so every query referencing it reads the same rows. Without this, the
+// LIMIT query is re-evaluated per referencing table and a non-total ORDER BY
+// (e.g. ties on created_at) leaves dangling foreign keys in the dump. As that
+// cannot be guaranteed without the CREATE privilege, a limit hard-fails here
+// instead of producing a dump that may not import.
 func (d *Dumper) createLimitStagingTables(ctx context.Context) error {
 	if d.limitResolver == nil || len(d.limitResolver.limits) == 0 {
 		return nil
@@ -180,8 +178,7 @@ func (d *Dumper) createLimitStagingTables(ctx context.Context) error {
 	return nil
 }
 
-// dropLimitStagingTables removes the given staging tables. It is safe to call
-// with the tracked set (on cleanup) or a partial set (on a failed setup).
+// dropLimitStagingTables removes the given staging tables.
 func (d *Dumper) dropLimitStagingTables(ctx context.Context, staging map[string]string) {
 	for _, stagingName := range staging {
 		if _, err := d.useTransactionOrDBExec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", stagingName)); err != nil {
@@ -216,9 +213,7 @@ type limitResolver struct {
 	// strictly attached rows instead of recursing forever.
 	resolving map[string]bool
 	// stagingTables maps a limited table to the staging table holding its frozen
-	// kept-set. When set, kept-row lookups read from the staging table instead of
-	// re-evaluating the LIMIT query, so the set stays identical across the many
-	// queries (and parallel connections) that reference it.
+	// kept-set, which kept-row lookups read instead of re-running the LIMIT query.
 	stagingTables map[string]string
 }
 
@@ -324,8 +319,6 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 	tableName := r.schemas[table].Name
 
 	if _, isLimited := r.limits[table]; isLimited {
-		// When the kept-set has been frozen into a staging table, read from it so
-		// every reference sees the identical rows.
 		if staging, ok := r.stagingTables[table]; ok {
 			return fmt.Sprintf("SELECT %s FROM `%s`", quotedColumns, staging)
 		}
@@ -351,13 +344,9 @@ func (r *limitResolver) keptRowsQuery(table string, columns []string) string {
 
 // keptRowsPopulateQuery returns the SELECT that computes the kept-set of a
 // limited table from the live data: the LIMIT rows, plus their ancestors when
-// the table references itself. It is used both to populate the staging table and
-// as the inline fallback when no staging table could be created.
+// the table references itself. It populates the staging table and is used for
+// the conditions built before the staging tables exist.
 func (r *limitResolver) keptRowsPopulateQuery(table string, columns []string) string {
-	// A self-referencing limited table (e.g. product.parent_id -> product.id)
-	// must keep the ancestors of every kept row, otherwise a kept variant would
-	// reference a parent excluded by the LIMIT and break the foreign key on
-	// import. A recursive CTE seeded by the LIMIT walks the parents.
 	if selfRefs := r.selfReferences(table); len(selfRefs) != 0 {
 		return r.selfReferenceClosureQuery(table, columns, selfRefs)
 	}
@@ -436,11 +425,8 @@ func (r *limitResolver) selfReferenceClosureQuery(table string, columns []string
 
 	seed := fmt.Sprintf("SELECT %s FROM (%s) %s", pkColumns, r.limitSeedQuery(table, primaryKey), limitDerivedTableAlias)
 
-	// The CTE carries only the primary key of the kept rows. When the caller
-	// wants exactly the primary key (the common case) it is selected directly;
-	// otherwise the requested columns are fetched by joining the kept keys back
-	// to the base table, which also covers foreign keys referencing non-primary
-	// key columns.
+	// The CTE carries only the primary key, so other columns (foreign keys
+	// referencing non-primary key columns) are joined back from the base table.
 	projection := fmt.Sprintf("%s FROM %s", quoteColumns(columns), selfReferenceCTEAlias)
 	if !slices.Equal(columns, primaryKey) {
 		keptJoin := make([]string, len(primaryKey))

--- a/internal/mysqldump/limit.go
+++ b/internal/mysqldump/limit.go
@@ -94,6 +94,10 @@ func (d *Dumper) computeLimitFilters(ctx context.Context) error {
 		}
 	}
 
+	if d.LockTables && len(d.limitWhere) > 0 {
+		logging.FromContext(ctx).Infof("Skipping table locks for %d tables filtered by row limits, as their dump queries reference other tables", len(d.limitWhere))
+	}
+
 	return nil
 }
 

--- a/internal/mysqldump/limit_test.go
+++ b/internal/mysqldump/limit_test.go
@@ -162,6 +162,94 @@ func TestLimitIncludesChildWhereInCascade(t *testing.T) {
 		dumper.limitWhere["order_delivery_position"])
 }
 
+func selfReferencingProductDumper() *Dumper {
+	return limitTestDumper(
+		&TableSchema{
+			Name:       "product",
+			PrimaryKey: []string{"id", "version_id"},
+			Columns: []ColumnSchema{
+				{Name: "id"}, {Name: "version_id"},
+				{Name: "parent_id", Nullable: true}, {Name: "parent_version_id", Nullable: true},
+				{Name: "created_at"},
+			},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.product.parent", Columns: []string{"parent_id", "parent_version_id"}, ReferencedTable: "product", ReferencedColumns: []string{"id", "version_id"}},
+			},
+		},
+		&TableSchema{
+			Name:       "order_line_item",
+			PrimaryKey: []string{"id"},
+			Columns:    []ColumnSchema{{Name: "id"}, {Name: "product_id", Nullable: true}, {Name: "product_version_id", Nullable: true}},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.oli.product", Columns: []string{"product_id", "product_version_id"}, ReferencedTable: "product", ReferencedColumns: []string{"id", "version_id"}},
+			},
+		},
+	)
+}
+
+func TestLimitClosesSelfReferencingTableOverParents(t *testing.T) {
+	dumper := selfReferencingProductDumper()
+	dumper.LimitMap = map[string]TableLimit{"product": {Rows: 500}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptProducts := "WITH RECURSIVE `_sw_cli_kept` (`id`, `version_id`) AS (" +
+		"SELECT `id`, `version_id` FROM (SELECT `id`, `version_id` FROM `product` ORDER BY `created_at` DESC LIMIT 500) `_sw_cli_limit`" +
+		" UNION " +
+		"SELECT `_sw_parent`.`id`, `_sw_parent`.`version_id` FROM `product` `_sw_child`" +
+		" JOIN `_sw_cli_kept` ON `_sw_child`.`id` = `_sw_cli_kept`.`id` AND `_sw_child`.`version_id` = `_sw_cli_kept`.`version_id`" +
+		" JOIN `product` `_sw_parent` ON `_sw_parent`.`id` = `_sw_child`.`parent_id` AND `_sw_parent`.`version_id` = `_sw_child`.`parent_version_id`" +
+		") SELECT `id`, `version_id` FROM `_sw_cli_kept`"
+
+	// The limited product table keeps the LIMIT rows plus all their ancestors.
+	assert.Equal(t, "(`id`, `version_id`) IN ("+keptProducts+")", dumper.limitWhere["product"])
+
+	// A table referencing product is filtered against the same closed set, so a
+	// kept line item always finds its product and that product finds its parent.
+	assert.Equal(t,
+		"(`product_id` IS NULL OR `product_version_id` IS NULL OR (`product_id`, `product_version_id`) IN ("+keptProducts+"))",
+		dumper.limitWhere["order_line_item"])
+}
+
+func TestLimitClosesSelfReferencingTableWithSingleColumnKey(t *testing.T) {
+	dumper := limitTestDumper(&TableSchema{
+		Name:       "category",
+		PrimaryKey: []string{"id"},
+		Columns: []ColumnSchema{
+			{Name: "id"}, {Name: "parent_id", Nullable: true}, {Name: "created_at"},
+		},
+		ForeignKeys: []ForeignKeySchema{
+			{Name: "fk.category.parent", Columns: []string{"parent_id"}, ReferencedTable: "category", ReferencedColumns: []string{"id"}},
+		},
+	})
+	dumper.LimitMap = map[string]TableLimit{"category": {Rows: 20}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptCategories := "WITH RECURSIVE `_sw_cli_kept` (`id`) AS (" +
+		"SELECT `id` FROM (SELECT `id` FROM `category` ORDER BY `created_at` DESC LIMIT 20) `_sw_cli_limit`" +
+		" UNION " +
+		"SELECT `_sw_parent`.`id` FROM `category` `_sw_child`" +
+		" JOIN `_sw_cli_kept` ON `_sw_child`.`id` = `_sw_cli_kept`.`id`" +
+		" JOIN `category` `_sw_parent` ON `_sw_parent`.`id` = `_sw_child`.`parent_id`" +
+		") SELECT `id` FROM `_sw_cli_kept`"
+
+	assert.Equal(t, "`id` IN ("+keptCategories+")", dumper.limitWhere["category"])
+}
+
+func TestLimitClosureRespectsWhereMap(t *testing.T) {
+	dumper := selfReferencingProductDumper()
+	dumper.WhereMap = map[string]string{"product": "active = 1"}
+	dumper.LimitMap = map[string]TableLimit{"product": {Rows: 10}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	// The user WHERE only constrains the LIMIT seed; ancestors are still pulled
+	// in unconditionally so the kept set stays closed under the self-reference.
+	assert.Contains(t, dumper.limitWhere["product"],
+		"SELECT `id`, `version_id` FROM `product` WHERE active = 1 ORDER BY `created_at` DESC LIMIT 10")
+}
+
 func TestLimitTerminatesOnForeignKeyCycles(t *testing.T) {
 	dumper := limitTestDumper(
 		&TableSchema{

--- a/internal/mysqldump/limit_test.go
+++ b/internal/mysqldump/limit_test.go
@@ -1,0 +1,236 @@
+package mysqldump
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func notNullColumns(names ...string) []ColumnSchema {
+	cols := make([]ColumnSchema, 0, len(names))
+	for _, name := range names {
+		cols = append(cols, ColumnSchema{Name: name})
+	}
+	return cols
+}
+
+func limitTestDumper(schemas ...*TableSchema) *Dumper {
+	dumper := NewMySQLDumper(nil)
+	dumper.schemaCache = make(map[string]*TableSchema, len(schemas))
+	for _, schema := range schemas {
+		dumper.schemaCache[schema.Name] = schema
+	}
+	return dumper
+}
+
+func orderGraphDumper() *Dumper {
+	return limitTestDumper(
+		&TableSchema{
+			Name:       "order",
+			PrimaryKey: []string{"id", "version_id"},
+			Columns:    notNullColumns("id", "version_id", "created_at"),
+		},
+		&TableSchema{
+			Name:       "order_line_item",
+			PrimaryKey: []string{"id", "version_id"},
+			Columns: []ColumnSchema{
+				{Name: "id"}, {Name: "version_id"}, {Name: "order_id"}, {Name: "order_version_id"},
+				{Name: "parent_id", Nullable: true}, {Name: "product_id", Nullable: true},
+			},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.order_line_item.order_id", Columns: []string{"order_id", "order_version_id"}, ReferencedTable: "order", ReferencedColumns: []string{"id", "version_id"}},
+				{Name: "fk.order_line_item.parent_id", Columns: []string{"parent_id"}, ReferencedTable: "order_line_item", ReferencedColumns: []string{"id"}},
+				{Name: "fk.order_line_item.product_id", Columns: []string{"product_id"}, ReferencedTable: "product", ReferencedColumns: []string{"id"}},
+			},
+		},
+		&TableSchema{
+			Name:       "order_delivery",
+			PrimaryKey: []string{"id", "version_id"},
+			Columns:    notNullColumns("id", "version_id", "order_id", "order_version_id"),
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.order_delivery.order_id", Columns: []string{"order_id", "order_version_id"}, ReferencedTable: "order", ReferencedColumns: []string{"id", "version_id"}},
+			},
+		},
+		&TableSchema{
+			Name:       "order_delivery_position",
+			PrimaryKey: []string{"id", "version_id"},
+			Columns:    notNullColumns("id", "version_id", "order_delivery_id", "order_delivery_version_id"),
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.order_delivery_position.order_delivery_id", Columns: []string{"order_delivery_id", "order_delivery_version_id"}, ReferencedTable: "order_delivery", ReferencedColumns: []string{"id", "version_id"}},
+			},
+		},
+		&TableSchema{
+			Name:       "product",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id", "created_at"),
+		},
+	)
+}
+
+func TestLimitCascadesOverForeignKeys(t *testing.T) {
+	dumper := orderGraphDumper()
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 100}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptOrders := "SELECT `id`, `version_id` FROM (SELECT `id`, `version_id` FROM `order` ORDER BY `created_at` DESC LIMIT 100) `_sw_cli_limit`"
+
+	assert.Equal(t, "(`id`, `version_id`) IN ("+keptOrders+")", dumper.limitWhere["order"])
+	assert.Equal(t, "((`order_id`, `order_version_id`) IN ("+keptOrders+"))", dumper.limitWhere["order_line_item"])
+	assert.Equal(t, "((`order_id`, `order_version_id`) IN ("+keptOrders+"))", dumper.limitWhere["order_delivery"])
+	assert.Equal(t,
+		"((`order_delivery_id`, `order_delivery_version_id`) IN (SELECT `id`, `version_id` FROM `order_delivery` WHERE ((`order_id`, `order_version_id`) IN ("+keptOrders+"))))",
+		dumper.limitWhere["order_delivery_position"])
+
+	// product is only referenced by order_line_item, not referencing it, so it stays complete
+	assert.NotContains(t, dumper.limitWhere, "product")
+}
+
+func TestLimitKeepsRowsWithNullableForeignKey(t *testing.T) {
+	dumper := limitTestDumper(
+		&TableSchema{
+			Name:       "order",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id", "created_at"),
+		},
+		&TableSchema{
+			Name:       "document",
+			PrimaryKey: []string{"id"},
+			Columns:    []ColumnSchema{{Name: "id"}, {Name: "order_id", Nullable: true}},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.document.order_id", Columns: []string{"order_id"}, ReferencedTable: "order", ReferencedColumns: []string{"id"}},
+			},
+		},
+	)
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 10}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptOrders := "SELECT `id` FROM (SELECT `id` FROM `order` ORDER BY `created_at` DESC LIMIT 10) `_sw_cli_limit`"
+	assert.Equal(t, "(`order_id` IS NULL OR `order_id` IN ("+keptOrders+"))", dumper.limitWhere["document"])
+}
+
+func TestLimitRespectsWhereMapAndCustomOrderBy(t *testing.T) {
+	dumper := limitTestDumper(
+		&TableSchema{
+			Name:       "order",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id", "order_number"),
+		},
+		&TableSchema{
+			Name:       "order_tag",
+			PrimaryKey: []string{"order_id", "tag_id"},
+			Columns:    notNullColumns("order_id", "tag_id"),
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.order_tag.order_id", Columns: []string{"order_id"}, ReferencedTable: "order", ReferencedColumns: []string{"id"}},
+			},
+		},
+	)
+	dumper.WhereMap = map[string]string{"order": "version_id = 0x1"}
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 5, OrderBy: "`order_number` DESC"}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptOrders := "SELECT `id` FROM (SELECT `id` FROM `order` WHERE version_id = 0x1 ORDER BY `order_number` DESC LIMIT 5) `_sw_cli_limit`"
+	assert.Equal(t, "`id` IN ("+keptOrders+")", dumper.limitWhere["order"])
+	assert.Equal(t, "(`order_id` IN ("+keptOrders+"))", dumper.limitWhere["order_tag"])
+}
+
+func TestLimitWithoutCreatedAtHasNoOrderBy(t *testing.T) {
+	dumper := limitTestDumper(&TableSchema{
+		Name:       "queue",
+		PrimaryKey: []string{"id"},
+		Columns:    notNullColumns("id"),
+	})
+	dumper.LimitMap = map[string]TableLimit{"queue": {Rows: 3}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	assert.Equal(t, "`id` IN (SELECT `id` FROM (SELECT `id` FROM `queue` LIMIT 3) `_sw_cli_limit`)", dumper.limitWhere["queue"])
+}
+
+func TestLimitIncludesChildWhereInCascade(t *testing.T) {
+	dumper := orderGraphDumper()
+	dumper.WhereMap = map[string]string{"order_delivery": "custom_fields IS NULL"}
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 100}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptOrders := "SELECT `id`, `version_id` FROM (SELECT `id`, `version_id` FROM `order` ORDER BY `created_at` DESC LIMIT 100) `_sw_cli_limit`"
+	assert.Equal(t,
+		"((`order_delivery_id`, `order_delivery_version_id`) IN (SELECT `id`, `version_id` FROM `order_delivery` WHERE (custom_fields IS NULL) AND ((`order_id`, `order_version_id`) IN ("+keptOrders+"))))",
+		dumper.limitWhere["order_delivery_position"])
+}
+
+func TestLimitTerminatesOnForeignKeyCycles(t *testing.T) {
+	dumper := limitTestDumper(
+		&TableSchema{
+			Name:       "s",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id"),
+		},
+		&TableSchema{
+			Name:       "a",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id", "b_id"),
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.a.b_id", Columns: []string{"b_id"}, ReferencedTable: "b", ReferencedColumns: []string{"id"}},
+			},
+		},
+		&TableSchema{
+			Name:       "b",
+			PrimaryKey: []string{"id"},
+			Columns:    []ColumnSchema{{Name: "id"}, {Name: "a_id", Nullable: true}, {Name: "s_id"}},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.b.a_id", Columns: []string{"a_id"}, ReferencedTable: "a", ReferencedColumns: []string{"id"}},
+				{Name: "fk.b.s_id", Columns: []string{"s_id"}, ReferencedTable: "s", ReferencedColumns: []string{"id"}},
+			},
+		},
+	)
+	dumper.LimitMap = map[string]TableLimit{"s": {Rows: 5}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	keptS := "SELECT `id` FROM (SELECT `id` FROM `s` LIMIT 5) `_sw_cli_limit`"
+	assert.Contains(t, dumper.limitWhere["b"], "(`s_id` IN ("+keptS+"))")
+	assert.Contains(t, dumper.limitWhere["a"], "`b_id` IN (SELECT `id` FROM `b` WHERE")
+}
+
+func TestLimitUnknownTableIsIgnored(t *testing.T) {
+	dumper := limitTestDumper(&TableSchema{
+		Name:       "order",
+		PrimaryKey: []string{"id"},
+		Columns:    notNullColumns("id"),
+	})
+	dumper.LimitMap = map[string]TableLimit{"missing": {Rows: 5}}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+	assert.Empty(t, dumper.limitWhere)
+}
+
+func TestLimitValidation(t *testing.T) {
+	dumper := limitTestDumper(&TableSchema{
+		Name:       "order",
+		PrimaryKey: []string{"id"},
+		Columns:    notNullColumns("id"),
+	})
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 0}}
+	assert.ErrorContains(t, dumper.computeLimitFilters(t.Context()), "must be greater than zero")
+
+	dumper = limitTestDumper(&TableSchema{
+		Name:    "order",
+		Columns: notNullColumns("id"),
+	})
+	dumper.LimitMap = map[string]TableLimit{"order": {Rows: 5}}
+	assert.ErrorContains(t, dumper.computeLimitFilters(t.Context()), "no primary key")
+}
+
+func TestEffectiveWhereCombinesUserAndLimitConditions(t *testing.T) {
+	dumper := NewMySQLDumper(nil)
+	dumper.WhereMap = map[string]string{"t": "a = 1"}
+	dumper.limitWhere = map[string]string{"t": "`b` IN (SELECT 1)", "u": "`c` IN (SELECT 2)"}
+
+	assert.Equal(t, "(a = 1) AND `b` IN (SELECT 1)", dumper.effectiveWhere("T"))
+	assert.Equal(t, "`c` IN (SELECT 2)", dumper.effectiveWhere("u"))
+	assert.Equal(t, "", dumper.effectiveWhere("other"))
+}

--- a/internal/mysqldump/limit_test.go
+++ b/internal/mysqldump/limit_test.go
@@ -208,6 +208,99 @@ func TestLimitUnknownTableIsIgnored(t *testing.T) {
 	assert.Empty(t, dumper.limitWhere)
 }
 
+func TestLimitRejectsOverlappingTables(t *testing.T) {
+	t.Run("child of a limited table", func(t *testing.T) {
+		dumper := orderGraphDumper()
+		dumper.LimitMap = map[string]TableLimit{
+			"order":           {Rows: 100},
+			"order_line_item": {Rows: 50},
+		}
+
+		err := dumper.computeLimitFilters(t.Context())
+		assert.ErrorContains(t, err, "cannot limit table order_line_item")
+		assert.ErrorContains(t, err, "limiting table order already filters order_line_item")
+	})
+
+	t.Run("transitive child of a limited table", func(t *testing.T) {
+		dumper := orderGraphDumper()
+		dumper.LimitMap = map[string]TableLimit{
+			"order":                   {Rows: 100},
+			"order_delivery_position": {Rows: 10},
+		}
+
+		err := dumper.computeLimitFilters(t.Context())
+		assert.ErrorContains(t, err, "cannot limit table order_delivery_position")
+		assert.ErrorContains(t, err, "limiting table order already filters order_delivery_position")
+	})
+
+	t.Run("parent and child limited independently", func(t *testing.T) {
+		dumper := limitTestDumper(
+			&TableSchema{
+				Name:       "customer",
+				PrimaryKey: []string{"id"},
+				Columns:    notNullColumns("id", "created_at"),
+			},
+			&TableSchema{
+				Name:       "order",
+				PrimaryKey: []string{"id"},
+				Columns:    notNullColumns("id", "customer_id", "created_at"),
+				ForeignKeys: []ForeignKeySchema{
+					{Name: "fk.order.customer_id", Columns: []string{"customer_id"}, ReferencedTable: "customer", ReferencedColumns: []string{"id"}},
+				},
+			},
+		)
+		dumper.LimitMap = map[string]TableLimit{
+			"order":    {Rows: 100},
+			"customer": {Rows: 50},
+		}
+
+		err := dumper.computeLimitFilters(t.Context())
+		assert.ErrorContains(t, err, "cannot limit table order")
+		assert.ErrorContains(t, err, "limiting table customer already filters order")
+	})
+
+	t.Run("foreign key cycle", func(t *testing.T) {
+		dumper := limitTestDumper(
+			&TableSchema{
+				Name:       "a",
+				PrimaryKey: []string{"id"},
+				Columns:    notNullColumns("id", "b_id"),
+				ForeignKeys: []ForeignKeySchema{
+					{Name: "fk.a.b_id", Columns: []string{"b_id"}, ReferencedTable: "b", ReferencedColumns: []string{"id"}},
+				},
+			},
+			&TableSchema{
+				Name:       "b",
+				PrimaryKey: []string{"id"},
+				Columns:    notNullColumns("id", "a_id"),
+				ForeignKeys: []ForeignKeySchema{
+					{Name: "fk.b.a_id", Columns: []string{"a_id"}, ReferencedTable: "a", ReferencedColumns: []string{"id"}},
+				},
+			},
+		)
+		dumper.LimitMap = map[string]TableLimit{
+			"a": {Rows: 10},
+			"b": {Rows: 10},
+		}
+
+		err := dumper.computeLimitFilters(t.Context())
+		assert.ErrorContains(t, err, "cannot limit table b")
+		assert.ErrorContains(t, err, "limiting table a already filters b")
+	})
+}
+
+func TestLimitAllowsUnrelatedTables(t *testing.T) {
+	dumper := orderGraphDumper()
+	dumper.LimitMap = map[string]TableLimit{
+		"order":   {Rows: 100},
+		"product": {Rows: 50},
+	}
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+	assert.Contains(t, dumper.limitWhere, "order")
+	assert.Contains(t, dumper.limitWhere, "product")
+}
+
 func TestLimitValidation(t *testing.T) {
 	dumper := limitTestDumper(&TableSchema{
 		Name:       "order",

--- a/internal/mysqldump/limit_test.go
+++ b/internal/mysqldump/limit_test.go
@@ -323,7 +323,7 @@ func TestEffectiveWhereCombinesUserAndLimitConditions(t *testing.T) {
 	dumper.WhereMap = map[string]string{"t": "a = 1"}
 	dumper.limitWhere = map[string]string{"t": "`b` IN (SELECT 1)", "u": "`c` IN (SELECT 2)"}
 
-	assert.Equal(t, "(a = 1) AND `b` IN (SELECT 1)", dumper.effectiveWhere("T"))
+	assert.Equal(t, "(a = 1) AND (`b` IN (SELECT 1))", dumper.effectiveWhere("T"))
 	assert.Equal(t, "`c` IN (SELECT 2)", dumper.effectiveWhere("u"))
 	assert.Equal(t, "", dumper.effectiveWhere("other"))
 }

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -36,7 +36,7 @@ type Dumper struct {
 	// and the staging table setup.
 	limitResolver *limitResolver
 	// limitStagingTables maps a limited table to the staging table holding its
-	// frozen kept-set, so the set stays identical across all referencing queries.
+	// frozen kept-set
 	limitStagingTables map[string]string
 	filterMap          map[string]string
 	// LockTables controls whether to lock tables during dump (default: true)
@@ -113,9 +113,7 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 		return err
 	}
 	defer func() {
-		if len(d.limitStagingTables) > 0 {
-			d.dropLimitStagingTables(context.WithoutCancel(ctx), d.limitStagingTables)
-		}
+		d.dropLimitStagingTables(context.WithoutCancel(ctx), d.limitStagingTables)
 	}()
 
 	if _, err = fmt.Fprintln(w, dump); err != nil {
@@ -365,8 +363,7 @@ func (d *Dumper) dumpTableDataDirect(ctx context.Context, w io.Writer, table str
 	return nil
 }
 
-// hasLimitFilter reports whether the data queries of the table carry a
-// row-limit condition computed from LimitMap.
+// hasLimitFilter reports whether the queries of the table carry a row-limit condition.
 func (d *Dumper) hasLimitFilter(table string) bool {
 	_, ok := d.limitWhere[strings.ToLower(table)]
 	return ok
@@ -680,26 +677,19 @@ func (d *Dumper) getSelectQueryFor(ctx context.Context, table string) (cols []st
 func (d *Dumper) effectiveWhere(table string) string {
 	table = strings.ToLower(table)
 
-	var conditions []string
-	if userWhere := d.WhereMap[table]; userWhere != "" {
-		conditions = append(conditions, userWhere)
-	}
-	if limitWhere := d.limitWhere[table]; limitWhere != "" {
-		conditions = append(conditions, limitWhere)
+	conditions := make([]string, 0, 2)
+	for _, condition := range []string{d.WhereMap[table], d.limitWhere[table]} {
+		if condition != "" {
+			conditions = append(conditions, condition)
+		}
 	}
 
-	switch len(conditions) {
-	case 0:
-		return ""
-	case 1:
-		return conditions[0]
-	default:
-		quoted := make([]string, len(conditions))
-		for i, condition := range conditions {
-			quoted[i] = "(" + condition + ")"
-		}
-		return strings.Join(quoted, " AND ")
+	// Only a combination needs parentheses to keep the precedence of each part.
+	if len(conditions) < 2 {
+		return strings.Join(conditions, " AND ")
 	}
+
+	return "(" + strings.Join(conditions, ") AND (") + ")"
 }
 
 func (d *Dumper) getLockTableWriteStatement(table string) string {

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -664,16 +664,26 @@ func (d *Dumper) getSelectQueryFor(ctx context.Context, table string) (cols []st
 // computed from the row limits for the given table.
 func (d *Dumper) effectiveWhere(table string) string {
 	table = strings.ToLower(table)
-	userWhere := d.WhereMap[table]
-	limitWhere := d.limitWhere[table]
 
-	switch {
-	case userWhere != "" && limitWhere != "":
-		return fmt.Sprintf("(%s) AND %s", userWhere, limitWhere)
-	case userWhere != "":
-		return userWhere
+	var conditions []string
+	if userWhere := d.WhereMap[table]; userWhere != "" {
+		conditions = append(conditions, userWhere)
+	}
+	if limitWhere := d.limitWhere[table]; limitWhere != "" {
+		conditions = append(conditions, limitWhere)
+	}
+
+	switch len(conditions) {
+	case 0:
+		return ""
+	case 1:
+		return conditions[0]
 	default:
-		return limitWhere
+		quoted := make([]string, len(conditions))
+		for i, condition := range conditions {
+			quoted[i] = "(" + condition + ")"
+		}
+		return strings.Join(quoted, " AND ")
 	}
 }
 

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -26,8 +26,13 @@ type Dumper struct {
 	// NoData contains list of tables to dump structure only (no data), supports glob wildcards (e.g. "cart*")
 	NoData []string
 	// Ignore contains list of tables to skip entirely, supports glob wildcards (e.g. "cart*")
-	Ignore    []string
-	filterMap map[string]string
+	Ignore []string
+	// LimitMap contains row limits per table (table -> limit). Tables referencing
+	// a limited table via foreign keys are filtered automatically.
+	LimitMap map[string]TableLimit
+	// limitWhere contains the WHERE conditions computed from LimitMap
+	limitWhere map[string]string
+	filterMap  map[string]string
 	// LockTables controls whether to lock tables during dump (default: true)
 	LockTables bool
 	// Quick enables quick mode for mysqldump (default: false)
@@ -91,6 +96,10 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 	}
 
 	if err := d.prefetchAllSchemas(ctx, tablesToDump); err != nil {
+		return err
+	}
+
+	if err := d.computeLimitFilters(ctx); err != nil {
 		return err
 	}
 
@@ -633,10 +642,27 @@ func (d *Dumper) getSelectQueryFor(ctx context.Context, table string) (cols []st
 		return cols, "", err
 	}
 	query = fmt.Sprintf("SELECT %s FROM `%s`", strings.Join(cols, ", "), table)
-	if where, ok := d.WhereMap[strings.ToLower(table)]; ok {
+	if where := d.effectiveWhere(table); where != "" {
 		query = fmt.Sprintf("%s WHERE %s", query, where)
 	}
 	return
+}
+
+// effectiveWhere combines the user-configured WHERE clause with the condition
+// computed from the row limits for the given table.
+func (d *Dumper) effectiveWhere(table string) string {
+	table = strings.ToLower(table)
+	userWhere := d.WhereMap[table]
+	limitWhere := d.limitWhere[table]
+
+	switch {
+	case userWhere != "" && limitWhere != "":
+		return fmt.Sprintf("(%s) AND %s", userWhere, limitWhere)
+	case userWhere != "":
+		return userWhere
+	default:
+		return limitWhere
+	}
 }
 
 func (d *Dumper) getLockTableWriteStatement(table string) string {
@@ -686,7 +712,7 @@ func (d *Dumper) getColumnsForSelect(ctx context.Context, table string, consider
 
 func (d *Dumper) rowCount(ctx context.Context, table string) (count uint64, err error) {
 	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`", table)
-	if where, ok := d.WhereMap[strings.ToLower(table)]; ok {
+	if where := d.effectiveWhere(table); where != "" {
 		query = fmt.Sprintf("%s WHERE %s", query, where)
 	}
 	row := d.useTransactionOrDBQueryRow(ctx, query)

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -109,7 +109,9 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
-	d.createLimitStagingTables(ctx)
+	if err := d.createLimitStagingTables(ctx); err != nil {
+		return err
+	}
 	defer func() {
 		if len(d.limitStagingTables) > 0 {
 			d.dropLimitStagingTables(context.WithoutCancel(ctx), d.limitStagingTables)

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -32,7 +32,13 @@ type Dumper struct {
 	LimitMap map[string]TableLimit
 	// limitWhere contains the WHERE conditions computed from LimitMap
 	limitWhere map[string]string
-	filterMap  map[string]string
+	// limitResolver holds the planned row-limit filters between computeLimitFilters
+	// and the staging table setup.
+	limitResolver *limitResolver
+	// limitStagingTables maps a limited table to the staging table holding its
+	// frozen kept-set, so the set stays identical across all referencing queries.
+	limitStagingTables map[string]string
+	filterMap          map[string]string
 	// LockTables controls whether to lock tables during dump (default: true)
 	LockTables bool
 	// Quick enables quick mode for mysqldump (default: false)
@@ -102,6 +108,13 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 	if err := d.computeLimitFilters(ctx); err != nil {
 		return err
 	}
+
+	d.createLimitStagingTables(ctx)
+	defer func() {
+		if len(d.limitStagingTables) > 0 {
+			d.dropLimitStagingTables(context.WithoutCancel(ctx), d.limitStagingTables)
+		}
+	}()
 
 	if _, err = fmt.Fprintln(w, dump); err != nil {
 		return err

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -304,7 +304,12 @@ func (d *Dumper) dumpTableDataDirect(ctx context.Context, w io.Writer, table str
 	var tmp string
 	var err error
 
-	if d.LockTables {
+	// Row-limit conditions contain subqueries on other tables (or the table
+	// itself), which MySQL rejects with ER_TABLE_NOT_LOCKED while the table
+	// is locked via FLUSH TABLES ... WITH READ LOCK.
+	lockTable := d.LockTables && !d.hasLimitFilter(table)
+
+	if lockTable {
 		_, err = d.mysqlFlushTable(ctx, table)
 		if err != nil {
 			return err
@@ -336,13 +341,20 @@ func (d *Dumper) dumpTableDataDirect(ctx context.Context, w io.Writer, table str
 		}
 	}
 
-	if d.LockTables {
+	if lockTable {
 		if _, dErr := d.mysqlUnlockTables(ctx); dErr != nil {
 			return dErr
 		}
 	}
 
 	return nil
+}
+
+// hasLimitFilter reports whether the data queries of the table carry a
+// row-limit condition computed from LimitMap.
+func (d *Dumper) hasLimitFilter(table string) bool {
+	_, ok := d.limitWhere[strings.ToLower(table)]
+	return ok
 }
 
 func (d *Dumper) dumpTableDataToWriter(ctx context.Context, w io.Writer, table string) error {

--- a/internal/mysqldump/mysql_test.go
+++ b/internal/mysqldump/mysql_test.go
@@ -63,6 +63,22 @@ func TestMySQLFlushTable(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDumpTableDataDirectSkipsLockingForLimitFilteredTables(t *testing.T) {
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db)
+	dumper.LockTables = true
+	dumper.limitWhere = map[string]string{"table": "`id` IN (SELECT 1)"}
+
+	// No FLUSH TABLES expectation: the limit condition contains a subquery,
+	// so locking must be skipped and the count query is the first statement.
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM `table` WHERE `id` IN \\(SELECT 1\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	var buf bytes.Buffer
+	assert.NoError(t, dumper.dumpTableDataDirect(t.Context(), &buf, "table"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestMySQLUnlockTables(t *testing.T) {
 	db, mock := getDB(t)
 	dumper := getInternalMySQLInstance(db)

--- a/internal/mysqldump/mysql_test.go
+++ b/internal/mysqldump/mysql_test.go
@@ -1257,7 +1257,7 @@ func TestLimitStagingTableFreezesKeptRows(t *testing.T) {
 	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS SELECT `id` FROM \\(SELECT `id` FROM `product` ORDER BY `created_at` DESC LIMIT 100\\)").
 		WillReturnResult(sqlmock.NewResult(0, 100))
 
-	dumper.createLimitStagingTables(t.Context())
+	assert.NoError(t, dumper.createLimitStagingTables(t.Context()))
 	assert.NoError(t, mock.ExpectationsWereMet())
 
 	staging := dumper.limitStagingTables["product"]
@@ -1274,30 +1274,27 @@ func TestLimitStagingTableDropRemovesTable(t *testing.T) {
 
 	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS ").WillReturnResult(sqlmock.NewResult(0, 100))
-	dumper.createLimitStagingTables(t.Context())
+	assert.NoError(t, dumper.createLimitStagingTables(t.Context()))
 
 	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
 	dumper.dropLimitStagingTables(t.Context(), dumper.limitStagingTables)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestLimitStagingFallsBackToInlineWhenCreateFails(t *testing.T) {
+func TestLimitStagingFailsHardWhenCreateDenied(t *testing.T) {
 	dumper, mock := stagingDumper(t)
 	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
-
-	inlineProduct := dumper.limitWhere["product"]
-	inlineChild := dumper.limitWhere["order_line_item"]
 
 	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS ").WillReturnError(errors.New("CREATE command denied"))
 
-	dumper.createLimitStagingTables(t.Context())
+	err := dumper.createLimitStagingTables(t.Context())
+	assert.ErrorContains(t, err, "cannot create staging table for row limit on product")
+	assert.ErrorContains(t, err, "CREATE and DROP privileges are required to use --limit")
 	assert.NoError(t, mock.ExpectationsWereMet())
 
-	// No staging tables tracked, filters unchanged from the inline planning.
+	// No staging tables are left tracked when setup fails.
 	assert.Empty(t, dumper.limitStagingTables)
-	assert.Equal(t, inlineProduct, dumper.limitWhere["product"])
-	assert.Equal(t, inlineChild, dumper.limitWhere["order_line_item"])
 }
 
 func TestStagingTableNameStaysWithinIdentifierLimit(t *testing.T) {

--- a/internal/mysqldump/mysql_test.go
+++ b/internal/mysqldump/mysql_test.go
@@ -1224,3 +1224,86 @@ func Test_mySQL_parallelCanBeEnabled(t *testing.T) {
 
 	assert.Equal(t, 4, dumper.Parallel, "Parallel should be configurable")
 }
+
+func stagingDumper(t *testing.T) (*Dumper, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock := getDB(t)
+	dumper := NewMySQLDumper(db)
+	dumper.schemaCache = map[string]*TableSchema{
+		"product": {
+			Name:       "product",
+			PrimaryKey: []string{"id"},
+			Columns:    notNullColumns("id", "created_at"),
+		},
+		"order_line_item": {
+			Name:       "order_line_item",
+			PrimaryKey: []string{"id"},
+			Columns:    []ColumnSchema{{Name: "id"}, {Name: "product_id", Nullable: true}},
+			ForeignKeys: []ForeignKeySchema{
+				{Name: "fk.oli.product", Columns: []string{"product_id"}, ReferencedTable: "product", ReferencedColumns: []string{"id"}},
+			},
+		},
+	}
+	dumper.LimitMap = map[string]TableLimit{"product": {Rows: 100}}
+	return dumper, mock
+}
+
+func TestLimitStagingTableFreezesKeptRows(t *testing.T) {
+	dumper, mock := stagingDumper(t)
+
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS SELECT `id` FROM \\(SELECT `id` FROM `product` ORDER BY `created_at` DESC LIMIT 100\\)").
+		WillReturnResult(sqlmock.NewResult(0, 100))
+
+	dumper.createLimitStagingTables(t.Context())
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	staging := dumper.limitStagingTables["product"]
+	assert.NotEmpty(t, staging)
+
+	// Every filter now reads the frozen staging table instead of re-running LIMIT.
+	assert.Equal(t, "`id` IN (SELECT `id` FROM `"+staging+"`)", dumper.limitWhere["product"])
+	assert.Equal(t, "(`product_id` IS NULL OR `product_id` IN (SELECT `id` FROM `"+staging+"`))", dumper.limitWhere["order_line_item"])
+}
+
+func TestLimitStagingTableDropRemovesTable(t *testing.T) {
+	dumper, mock := stagingDumper(t)
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS ").WillReturnResult(sqlmock.NewResult(0, 100))
+	dumper.createLimitStagingTables(t.Context())
+
+	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
+	dumper.dropLimitStagingTables(t.Context(), dumper.limitStagingTables)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLimitStagingFallsBackToInlineWhenCreateFails(t *testing.T) {
+	dumper, mock := stagingDumper(t)
+	assert.NoError(t, dumper.computeLimitFilters(t.Context()))
+
+	inlineProduct := dumper.limitWhere["product"]
+	inlineChild := dumper.limitWhere["order_line_item"]
+
+	mock.ExpectExec("DROP TABLE IF EXISTS `_sw_cli_kept_product_[0-9a-f]+`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE `_sw_cli_kept_product_[0-9a-f]+` AS ").WillReturnError(errors.New("CREATE command denied"))
+
+	dumper.createLimitStagingTables(t.Context())
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	// No staging tables tracked, filters unchanged from the inline planning.
+	assert.Empty(t, dumper.limitStagingTables)
+	assert.Equal(t, inlineProduct, dumper.limitWhere["product"])
+	assert.Equal(t, inlineChild, dumper.limitWhere["order_line_item"])
+}
+
+func TestStagingTableNameStaysWithinIdentifierLimit(t *testing.T) {
+	longTable := strings.Repeat("a", 100)
+	name := stagingTableName(longTable, "deadbeef")
+	assert.LessOrEqual(t, len(name), 64)
+	assert.True(t, strings.HasPrefix(name, "_sw_cli_kept_"))
+	assert.True(t, strings.HasSuffix(name, "_deadbeef"))
+}

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -249,7 +249,7 @@ type ConfigDump struct {
 	Ignore []string `yaml:"ignore,omitempty"`
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`
-	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected
+	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable
 	Limit map[string]mysqldump.TableLimit `yaml:"limit,omitempty"`
 }
 

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/shopware/shopware-cli/internal/compatibility"
+	"github.com/shopware/shopware-cli/internal/mysqldump"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/logging"
 )
@@ -249,15 +250,7 @@ type ConfigDump struct {
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`
 	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected
-	Limit map[string]ConfigDumpLimit `yaml:"limit,omitempty"`
-}
-
-// ConfigDumpLimit restricts how many rows of a table are exported.
-type ConfigDumpLimit struct {
-	// Maximum amount of rows to export for this table
-	Rows int `yaml:"rows" jsonschema:"required,minimum=1"`
-	// SQL ORDER BY clause deciding which rows are kept (e.g. "created_at DESC" for the newest rows). Defaults to "created_at DESC" when the table has a created_at column
-	OrderBy string `yaml:"order_by,omitempty"`
+	Limit map[string]mysqldump.TableLimit `yaml:"limit,omitempty"`
 }
 
 // EnableClean adds default tables that should be excluded from data dump in clean mode

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -248,6 +248,16 @@ type ConfigDump struct {
 	Ignore []string `yaml:"ignore,omitempty"`
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`
+	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows
+	Limit map[string]ConfigDumpLimit `yaml:"limit,omitempty"`
+}
+
+// ConfigDumpLimit restricts how many rows of a table are exported.
+type ConfigDumpLimit struct {
+	// Maximum amount of rows to export for this table
+	Rows int `yaml:"rows" jsonschema:"required,minimum=1"`
+	// SQL ORDER BY clause deciding which rows are kept (e.g. "created_at DESC" for the newest rows). Defaults to "created_at DESC" when the table has a created_at column
+	OrderBy string `yaml:"order_by,omitempty"`
 }
 
 // EnableClean adds default tables that should be excluded from data dump in clean mode

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -249,7 +249,7 @@ type ConfigDump struct {
 	Ignore []string `yaml:"ignore,omitempty"`
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`
-	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable
+	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable. Requires the CREATE and DROP privileges to freeze the kept rows into staging tables
 	Limit map[string]mysqldump.TableLimit `yaml:"limit,omitempty"`
 }
 

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -248,7 +248,7 @@ type ConfigDump struct {
 	Ignore []string `yaml:"ignore,omitempty"`
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`
-	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows
+	// Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected
 	Limit map[string]ConfigDumpLimit `yaml:"limit,omitempty"`
 }
 

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -559,7 +559,7 @@
         },
         "limit": {
           "additionalProperties": {
-            "$ref": "#/$defs/ConfigDumpLimit"
+            "$ref": "#/$defs/TableLimit"
           },
           "type": "object",
           "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected"
@@ -567,25 +567,6 @@
       },
       "additionalProperties": false,
       "type": "object"
-    },
-    "ConfigDumpLimit": {
-      "properties": {
-        "rows": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum amount of rows to export for this table"
-        },
-        "order_by": {
-          "type": "string",
-          "description": "SQL ORDER BY clause deciding which rows are kept (e.g. \"created_at DESC\" for the newest rows). Defaults to \"created_at DESC\" when the table has a created_at column"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "rows"
-      ],
-      "description": "ConfigDumpLimit restricts how many rows of a table are exported."
     },
     "ConfigImageProxy": {
       "properties": {
@@ -686,6 +667,25 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "TableLimit": {
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum amount of rows to export for this table"
+        },
+        "order_by": {
+          "type": "string",
+          "description": "SQL ORDER BY clause deciding which rows are kept (e.g. \"created_at DESC\" for the newest rows). Defaults to \"created_at DESC\" when the table has a created_at column"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rows"
+      ],
+      "description": "TableLimit restricts how many rows of a table are dumped."
     }
   }
 }

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -562,7 +562,7 @@
             "$ref": "#/$defs/TableLimit"
           },
           "type": "object",
-          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected"
+          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable"
         }
       },
       "additionalProperties": false,

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -562,7 +562,7 @@
             "$ref": "#/$defs/ConfigDumpLimit"
           },
           "type": "object",
-          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows"
+          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected"
         }
       },
       "additionalProperties": false,

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -562,7 +562,7 @@
             "$ref": "#/$defs/TableLimit"
           },
           "type": "object",
-          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable"
+          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows. A second limit on a table that is already filtered this way is rejected. When the limited table references itself (e.g. product.parent_id), the ancestors of the kept rows are exported too, so the dump stays importable. Requires the CREATE and DROP privileges to freeze the kept rows into staging tables"
         }
       },
       "additionalProperties": false,

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -556,10 +556,36 @@
           },
           "type": "object",
           "description": "Add an where condition to that table, schema is table name as key, and where statement as value"
+        },
+        "limit": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ConfigDumpLimit"
+          },
+          "type": "object",
+          "description": "Limit the amount of exported rows of a table, schema is table name as key. All tables referencing the limited table via foreign keys (also transitively) are filtered automatically, so they only contain rows belonging to the kept rows"
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "ConfigDumpLimit": {
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum amount of rows to export for this table"
+        },
+        "order_by": {
+          "type": "string",
+          "description": "SQL ORDER BY clause deciding which rows are kept (e.g. \"created_at DESC\" for the newest rows). Defaults to \"created_at DESC\" when the table has a created_at column"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rows"
+      ],
+      "description": "ConfigDumpLimit restricts how many rows of a table are exported."
     },
     "ConfigImageProxy": {
       "properties": {

--- a/scripts/schema.go
+++ b/scripts/schema.go
@@ -44,6 +44,10 @@ func generateProjectSchema() error {
 		return err
 	}
 
+	if err := r.AddGoComments("github.com/shopware/shopware-cli", "./internal/mysqldump"); err != nil {
+		return err
+	}
+
 	schema := r.Reflect(&shop.Config{})
 
 	bytes, err := json.MarshalIndent(schema, "", "  ")


### PR DESCRIPTION
## What changed?

Adds a table row limiter to `project dump`, so large tables can be reduced to a fixed number of rows while keeping the dump referentially consistent.

New CLI flag (repeatable):

```bash
shopware-cli project dump --limit order=100 --limit product=500
```

New `.shopware-project.yml` section:

```yaml
dump:
  limit:
    order:
      rows: 100
      order_by: "order_number DESC" # optional, defaults to created_at DESC
```

How it works: the dumper walks the foreign-key graph of the cached table schemas and automatically filters every table that references a limited table — directly or transitively — with `WHERE ... IN (SELECT ...)` conditions, so e.g. limiting `order` also limits `order_line_item`, `order_delivery`, and `order_delivery_position` to rows belonging to the kept orders.

Details:

- Composite primary/foreign keys are supported via tuple `IN` (Shopware's `(id, version_id)` pairs).
- Nullable foreign keys keep their unrelated rows (`order_id IS NULL OR order_id IN (...)`).
- Tables that are only *referenced* (like `product` from `order_line_item`) are not filtered.
- Foreign-key cycles terminate safely by keeping a superset of the attached rows.
- Existing `where:` config entries are combined with the limit conditions (`(user where) AND (limit condition)`).
- A limit on an unknown table logs a warning and is skipped; `rows < 1` or a table without a primary key is an error.

## Why?

Dumping a production database for local development is painful when a handful of tables (orders, logs) hold millions of rows. A plain `LIMIT` per table would break foreign keys on import; this feature keeps only rows that belong together, producing small dumps that still import cleanly with `FOREIGN_KEY_CHECKS` enabled.

## How was this tested?

- New unit tests in `internal/mysqldump/limit_test.go` covering: FK cascade over multiple levels, nullable FK handling, custom `order_by`, `where` composition, FK cycles, unknown tables, and validation errors.
- `go test ./...` and `golangci-lint run` pass.

## Related issue or discussion

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)
