### PR TITLE
feat: enhance extension changelog handling with Store links

### DIFF
--- a/internal/shop/upgrade/changelog.go
+++ b/internal/shop/upgrade/changelog.go
@@ -20,6 +20,9 @@ type ExtensionChangelog struct {
 	// From is the installed version, To the update's target version.
 	From string
 	To   string
+	// StoreLink is the Shopware Store listing URL when the Store knows the
+	// extension, "" otherwise.
+	StoreLink string
 	// Entries are ordered newest first.
 	Entries []ChangelogEntry
 }
@@ -74,6 +77,7 @@ func (u *ProjectUpgrader) LoadExtensionChangelogs(ctx context.Context, target st
 			Extension: plugin.Name,
 			From:      win.from.String(),
 			To:        win.to.String(),
+			StoreLink: plugin.StoreLink,
 		}
 		for _, entry := range plugin.Changelogs {
 			v, err := version.NewVersion(entry.Version)
@@ -102,7 +106,27 @@ func (u *ProjectUpgrader) LoadExtensionChangelogs(ctx context.Context, target st
 	}
 
 	sort.Slice(changelogs, func(i, j int) bool { return changelogs[i].Extension < changelogs[j].Extension })
+	ApplyStoreLinks(results, changelogs)
 	return changelogs
+}
+
+// ApplyStoreLinks overwrites each matching extension's changelog URL with the
+// Store listing when the Store returned one, replacing the Packagist fallback.
+func ApplyStoreLinks(results []ExtensionResult, changelogs []ExtensionChangelog) {
+	links := make(map[string]string, len(changelogs))
+	for _, cl := range changelogs {
+		if cl.StoreLink != "" {
+			links[cl.Extension] = cl.StoreLink
+		}
+	}
+	if len(links) == 0 {
+		return
+	}
+	for i := range results {
+		if link := links[results[i].Extension.Name]; link != "" {
+			results[i].ChangelogURL = link
+		}
+	}
 }
 
 // changelogDate reduces the Store's timestamp ("2026-01-15 00:00:00.000000")

--- a/internal/shop/upgrade/changelog_test.go
+++ b/internal/shop/upgrade/changelog_test.go
@@ -34,7 +34,8 @@ func TestLoadExtensionChangelogs(t *testing.T) {
 		gotVersion = shopwareVersion
 		gotNames = names
 		return []account_api.StorePlugin{{
-			Name: "SwagDemo",
+			Name:      "SwagDemo",
+			StoreLink: "https://store.shopware.com/swag-demo.html",
 			Changelogs: []account_api.StoreChangelog{
 				storeChangelog("2.5.0", "2026-06-01 00:00:00.000000", "too new"),
 				storeChangelog("2.1.0", "2026-03-01 00:00:00.000000", "<p>Adds <b>things</b></p><ul><li>one</li><li>two &amp; three</li></ul>"),
@@ -60,6 +61,9 @@ func TestLoadExtensionChangelogs(t *testing.T) {
 	assert.Equal(t, "SwagDemo", cl.Extension)
 	assert.Equal(t, "1.0.0", cl.From)
 	assert.Equal(t, "2.1.0", cl.To)
+	assert.Equal(t, "https://store.shopware.com/swag-demo.html", cl.StoreLink)
+	assert.Equal(t, "https://store.shopware.com/swag-demo.html", results[0].ChangelogURL,
+		"Store listing replaces the Packagist fallback when the Store has the extension")
 
 	require.Len(t, cl.Entries, 2, "entries outside (installed, available] are dropped")
 	assert.Equal(t, "2.1.0", cl.Entries[0].Version, "newest first")
@@ -102,13 +106,14 @@ func TestReportIncludesChangelogs(t *testing.T) {
 			Extension: "SwagDemo",
 			From:      "1.0.0",
 			To:        "2.0.0",
+			StoreLink: "https://store.shopware.com/swag-demo.html",
 			Entries: []ChangelogEntry{
 				{Version: "2.0.0", Date: "2026-01-15", Text: "Major rework"},
 			},
 		}},
 	})
 	assert.Contains(t, report, "## Extension update changelogs")
-	assert.Contains(t, report, "### SwagDemo (1.0.0 → 2.0.0)")
+	assert.Contains(t, report, "### [SwagDemo](https://store.shopware.com/swag-demo.html) (1.0.0 → 2.0.0)")
 	assert.Contains(t, report, "**2.0.0 — 2026-01-15**")
 	assert.Contains(t, report, "Major rework")
 }

--- a/internal/shop/upgrade/compat.go
+++ b/internal/shop/upgrade/compat.go
@@ -24,6 +24,7 @@ var shopwareConstraintPackages = []string{"shopware/core", "shopware/storefront"
 // ordered most severe first.
 func (u *ProjectUpgrader) CheckExtensions(ctx context.Context, current, target *version.Version, extensions []InstalledExtension) []ExtensionResult {
 	storeStatus := u.loadStoreStatus(ctx, current, target, extensions)
+	storePlugins := u.loadStorePlugins(ctx, target, extensions)
 	repos := u.projectRepositories(ctx)
 
 	results := make([]ExtensionResult, 0, len(extensions))
@@ -34,6 +35,9 @@ func (u *ProjectUpgrader) CheckExtensions(ctx context.Context, current, target *
 			applyStoreStatus(&res, store)
 		} else if ext.ComposerManaged {
 			res.StoreLabel = "Not available in Store"
+		}
+		if plugin, ok := storePlugins[ext.Name]; ok && plugin.StoreLink != "" {
+			res.ChangelogURL = plugin.StoreLink
 		}
 		results = append(results, res)
 	}
@@ -79,6 +83,36 @@ func (u *ProjectUpgrader) loadStoreStatus(ctx context.Context, current, target *
 	byName := make(map[string]account_api.UpdateCheckExtensionCompatibility, len(updates))
 	for _, u := range updates {
 		byName[u.Name] = u
+	}
+	return byName
+}
+
+// loadStorePlugins fetches Store listings (including the storefront URL) for
+// Composer-managed extensions. Failures degrade to an empty map.
+func (u *ProjectUpgrader) loadStorePlugins(ctx context.Context, target *version.Version, extensions []InstalledExtension) map[string]account_api.StorePlugin {
+	if target == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(extensions))
+	for _, ext := range extensions {
+		if ext.ComposerManaged {
+			names = append(names, ext.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+
+	plugins, err := u.storePlugins(ctx, "en_GB", target.String(), names)
+	if err != nil {
+		logging.FromContext(ctx).Debugf("store plugin lookup failed: %v", err)
+		return nil
+	}
+
+	byName := make(map[string]account_api.StorePlugin, len(plugins))
+	for _, plugin := range plugins {
+		byName[plugin.Name] = plugin
 	}
 	return byName
 }
@@ -235,7 +269,7 @@ func (u *ProjectUpgrader) TargetPHPRequirement(ctx context.Context, target *vers
 }
 
 // changelogURL points at the package page of the repository that provides the
-// extension, where its release notes live.
+// extension. Prefer the Shopware Store listing when CheckExtensions has one.
 func changelogURL(repoURL, pkg string) string {
 	if strings.Contains(repoURL, "packagist.org") {
 		return "https://packagist.org/packages/" + pkg

--- a/internal/shop/upgrade/compat_test.go
+++ b/internal/shop/upgrade/compat_test.go
@@ -45,6 +45,9 @@ func compatUpgrader(t *testing.T, dir string, provider fakeProvider, store []acc
 	u.extensionUpdates = func(context.Context, string, string, []account_api.UpdateCheckExtension) ([]account_api.UpdateCheckExtensionCompatibility, error) {
 		return store, storeErr
 	}
+	u.storePlugins = func(context.Context, string, string, []string) ([]account_api.StorePlugin, error) {
+		return nil, nil
+	}
 	return u
 }
 
@@ -198,6 +201,43 @@ func TestTargetPHPRequirement(t *testing.T) {
 
 	assert.Equal(t, ">=8.2", u.TargetPHPRequirement(t.Context(), target))
 	assert.Empty(t, u.TargetPHPRequirement(t.Context(), version.Must(version.NewVersion("6.9.0.0"))))
+}
+
+func TestCheckExtensionsPrefersStoreListingOverPackagist(t *testing.T) {
+	dir := setupProject(t)
+	current, target := compatVersions(t)
+
+	u := compatUpgrader(t, dir, fakeProvider{
+		"swag/demo": {Name: "swag/demo", Versions: []repository.Version{
+			release("swag/demo", "2.0.0", "~6.6.0 || ~6.7.0"),
+		}},
+		"vendor/private": {Name: "vendor/private", Versions: []repository.Version{
+			release("vendor/private", "1.0.0", "~6.6.0 || ~6.7.0"),
+		}},
+	}, nil, nil)
+	u.storePlugins = func(_ context.Context, locale, shopwareVersion string, names []string) ([]account_api.StorePlugin, error) {
+		assert.Equal(t, "en_GB", locale)
+		assert.Equal(t, "6.7.11.0", shopwareVersion)
+		assert.ElementsMatch(t, []string{"SwagDemo", "PrivateExt"}, names)
+		return []account_api.StorePlugin{{
+			Name:      "SwagDemo",
+			StoreLink: "https://store.shopware.com/swag-demo.html",
+		}}, nil
+	}
+
+	results := u.CheckExtensions(t.Context(), current, target, []InstalledExtension{
+		{Name: "SwagDemo", Package: "swag/demo", Version: "2.0.0", ComposerManaged: true},
+		{Name: "PrivateExt", Package: "vendor/private", Version: "1.0.0", ComposerManaged: true},
+	})
+	require.Len(t, results, 2)
+
+	byName := make(map[string]ExtensionResult)
+	for _, r := range results {
+		byName[r.Extension.Name] = r
+	}
+
+	assert.Equal(t, "https://store.shopware.com/swag-demo.html", byName["SwagDemo"].ChangelogURL)
+	assert.Empty(t, byName["PrivateExt"].ChangelogURL, "extensions unknown to the Store keep the repository fallback")
 }
 
 func TestClassifyExtensionWithoutConstraintMetadataIsReviewNotBlocked(t *testing.T) {

--- a/internal/shop/upgrade/report.go
+++ b/internal/shop/upgrade/report.go
@@ -106,7 +106,10 @@ func renderReport(data ReportData) string {
 		return s.BlocksUpgrade()
 	})
 	writeExtensionGroup(&b, "Needs review", data.Extensions, func(s ExtStatus) bool {
-		return !s.BlocksUpgrade() && s != ExtOK
+		return s.NeedsAttention() && !s.BlocksUpgrade()
+	})
+	writeExtensionGroup(&b, "Needs update", data.Extensions, func(s ExtStatus) bool {
+		return s == ExtNeedsUpdate
 	})
 	writeExtensionGroup(&b, "OK", data.Extensions, func(s ExtStatus) bool {
 		return s == ExtOK
@@ -177,7 +180,11 @@ func writeChangelogs(b *strings.Builder, changelogs []ExtensionChangelog) {
 
 	b.WriteString("## Extension update changelogs\n\n")
 	for _, cl := range changelogs {
-		fmt.Fprintf(b, "### %s (%s → %s)\n\n", cl.Extension, cl.From, cl.To)
+		if cl.StoreLink != "" {
+			fmt.Fprintf(b, "### [%s](%s) (%s → %s)\n\n", cl.Extension, cl.StoreLink, cl.From, cl.To)
+		} else {
+			fmt.Fprintf(b, "### %s (%s → %s)\n\n", cl.Extension, cl.From, cl.To)
+		}
 		for _, entry := range cl.Entries {
 			heading := entry.Version
 			if entry.Date != "" {

--- a/internal/shop/upgrade/report_test.go
+++ b/internal/shop/upgrade/report_test.go
@@ -27,6 +27,7 @@ func TestWriteReport(t *testing.T) {
 		Extensions: []ExtensionResult{
 			{Extension: InstalledExtension{Name: "SwagOk", Package: "swag/ok", Version: "2.0.0"}, Status: ExtOK, Available: "2.0.0"},
 			{Extension: InstalledExtension{Name: "LocalPlugin", Version: "1.0.0"}, Status: ExtReview, Detail: "Local extension"},
+			{Extension: InstalledExtension{Name: "SwagUpdate", Package: "swag/update", Version: "1.0.0"}, Status: ExtNeedsUpdate, Available: "1.2.0", Detail: "Composer resolution determined the final compatibility result."},
 			{Extension: InstalledExtension{Name: "AcmeBlocked", Package: "acme/blocked", Version: "3.0.0"}, Status: ExtBlocked, Detail: "No compatible release"},
 		},
 		ComposerReport: "Your requirements could not be resolved.",
@@ -50,8 +51,11 @@ func TestWriteReport(t *testing.T) {
 
 	assert.Contains(t, report, "## Extensions: Blocked (1)")
 	assert.Contains(t, report, "## Extensions: Needs review (1)")
+	assert.Contains(t, report, "## Extensions: Needs update (1)")
 	assert.Contains(t, report, "## Extensions: OK (1)")
+	assert.Contains(t, report, "| SwagUpdate | swag/update | 1.0.0 | 1.2.0 | needs update | Composer resolution determined the final compatibility result. |")
 	assert.Less(t, indexOf(report, "AcmeBlocked"), indexOf(report, "LocalPlugin"), "blocked group is listed first")
+	assert.Less(t, indexOf(report, "LocalPlugin"), indexOf(report, "SwagUpdate"), "review group is listed before automatic updates")
 
 	assert.Contains(t, report, "Your requirements could not be resolved.")
 
@@ -85,5 +89,7 @@ func TestWriteReportSkipsEmptyGroups(t *testing.T) {
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.NotContains(t, string(content), "Blocked")
+	assert.NotContains(t, string(content), "Needs review")
+	assert.NotContains(t, string(content), "Needs update")
 	assert.NotContains(t, string(content), "Composer resolution report")
 }

--- a/internal/shop/upgrade/resolve.go
+++ b/internal/shop/upgrade/resolve.go
@@ -209,10 +209,10 @@ func ApplyResolvedVersions(results []ExtensionResult, resolve ResolveResult) {
 			// release.
 			res.Status = ExtOK
 			res.Available = res.Extension.Version
-			res.Detail = "Composer resolved the upgrade with the installed release; the repository's compatibility metadata was wrong or incomplete."
+			res.Detail = "Composer resolution determined the final compatibility result; the installed release stays."
 		default:
 			res.Status = ExtNeedsUpdate
-			res.Detail = "Composer resolved the upgrade with this release; the repository's compatibility metadata was wrong or incomplete."
+			res.Detail = "Composer resolution determined the final compatibility result."
 		}
 	}
 }

--- a/internal/shop/upgrade/resolve_test.go
+++ b/internal/shop/upgrade/resolve_test.go
@@ -125,9 +125,12 @@ func TestApplyResolvedVersionsOverridesMetadataBlockers(t *testing.T) {
 	assert.Equal(t, ExtOK, results[0].Status, "a successful resolve disproves the metadata blocker")
 	assert.Equal(t, "3.12.0", results[0].Available)
 	assert.Contains(t, results[0].Detail, "installed release")
+	assert.Contains(t, results[0].Detail, "Composer resolution determined the final compatibility result")
+	assert.NotContains(t, results[0].Detail, "wrong or incomplete")
 
 	assert.Equal(t, ExtNeedsUpdate, results[1].Status)
 	assert.Equal(t, "2.1.3", results[1].Available)
+	assert.Equal(t, "Composer resolution determined the final compatibility result.", results[1].Detail)
 }
 
 func TestApplyResolvedVersionsRemovedPackageStaysBlocked(t *testing.T) {

--- a/internal/shop/upgrade/types.go
+++ b/internal/shop/upgrade/types.go
@@ -180,7 +180,8 @@ type ExtensionResult struct {
 	StoreLabel string
 	// Replacement names a successor extension when Status is ExtDeprecated.
 	Replacement string
-	// ChangelogURL points at the release notes of the providing repository.
+	// ChangelogURL points at the Shopware Store listing when the extension
+	// is known there, otherwise at the providing Composer repository page.
 	ChangelogURL string
 	// Detail is a one-line explanation shown in the detail overlay.
 	Detail string

--- a/internal/tui/upgrade/model_test.go
+++ b/internal/tui/upgrade/model_test.go
@@ -632,6 +632,23 @@ func TestExtensionDetailVariants(t *testing.T) {
 	}
 }
 
+func TestExtensionDetailPrefersStoreListingLink(t *testing.T) {
+	result := okResult()
+	result.ChangelogURL = "https://store.shopware.com/swag-demo.html"
+	store := newExtensionDetail(result, "Target 6.7.11.0")
+	content := ansi.Strip(store.View(110, 34))
+	assert.Contains(t, content, "View in Store")
+	assert.Contains(t, content, "Open the Shopware Store listing")
+	assert.NotContains(t, content, "View changelog")
+
+	result.ChangelogURL = "https://packagist.org/packages/swag/demo"
+	packagist := newExtensionDetail(result, "Target 6.7.11.0")
+	content = ansi.Strip(packagist.View(110, 34))
+	assert.Contains(t, content, "View changelog")
+	assert.Contains(t, content, "Open release notes in browser")
+	assert.NotContains(t, content, "View in Store")
+}
+
 func TestReviewPanel(t *testing.T) {
 	w := wizardAtPrepare(t, []backend.ExtensionResult{okResult()}, true)
 	w.Send(key('c'))
@@ -660,11 +677,13 @@ func TestPrepareLoadsChangelogsIntoReport(t *testing.T) {
 
 	changelogs := []backend.ExtensionChangelog{{
 		Extension: "SwagDemo", From: "2.0.0", To: "2.1.0",
-		Entries: []backend.ChangelogEntry{{Version: "2.1.0", Date: "2026-03-01", Text: "Fixes"}},
+		StoreLink: "https://store.shopware.com/swag-demo.html",
+		Entries:   []backend.ChangelogEntry{{Version: "2.1.0", Date: "2026-03-01", Text: "Fixes"}},
 	}}
 	w.Send(changelogsMsg{gen: w.m.prepareGen, changelogs: changelogs})
 
 	assert.Equal(t, changelogs, w.m.reportData().Changelogs)
+	assert.Equal(t, "https://store.shopware.com/swag-demo.html", w.m.prepare.results[0].ChangelogURL)
 }
 
 func TestPrepareDropsStaleChangelogs(t *testing.T) {

--- a/internal/tui/upgrade/overlay_extension_detail.go
+++ b/internal/tui/upgrade/overlay_extension_detail.go
@@ -181,9 +181,13 @@ func (d *extensionDetail) viewRight() string {
 	}
 
 	if r.ChangelogURL != "" {
-		b.WriteString(tui.StyledLink(r.ChangelogURL, "View changelog →", tui.LinkStyle))
+		label, hint := "View changelog →", "Open release notes in browser"
+		if strings.Contains(r.ChangelogURL, "store.shopware.com") {
+			label, hint = "View in Store →", "Open the Shopware Store listing"
+		}
+		b.WriteString(tui.StyledLink(r.ChangelogURL, label, tui.LinkStyle))
 		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Open release notes in browser"))
+		b.WriteString(tui.DimStyle.Render(hint))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/upgrade/panel_prepare.go
+++ b/internal/tui/upgrade/panel_prepare.go
@@ -226,6 +226,7 @@ func (m *Model) updatePrepare(msg tea.Msg) (app.Content, tea.Cmd) {
 			return m, nil
 		}
 		m.prepare.changelogs = msg.changelogs
+		backend.ApplyStoreLinks(m.prepare.results, msg.changelogs)
 		return m, nil
 
 	case tea.KeyPressMsg:


### PR DESCRIPTION
## What changed?

Upgrade wizard report and extension-detail links now match what the Prepare panel already shows.

**`report.md` grouping and wording**

Automatically resolved extension updates are no longer listed under **Needs review**. They get their own **Needs update** section (same label as the TUI), and the note no longer says repository metadata was “wrong or incomplete”.

Before:

```markdown
## Extensions: Needs review (4)

| Extension | … | Result | Note |
| SwagFoo | … | needs update | Composer resolved the upgrade with this release; the repository's compatibility metadata was wrong or incomplete. |
```

After:

```markdown
## Extensions: Needs update (4)

| Extension | … | Result | Note |
| SwagFoo | … | needs update | Composer resolution determined the final compatibility result. |
```

**Needs review** stays for items that actually need attention (local / deprecated).

**Store listing instead of Packagist**

When `api.shopware.com` knows the extension, changelog links go to the Store listing (`StoreLink`) instead of Packagist.

- Extension detail overlay: **View in Store →** (Packagist fallback stays **View changelog →**)
- `report.md` changelog heading: `[SwagDemo](https://store.shopware.com/…)` when a Store URL exists

## Why?

The Prepare panel already treated Composer-resolved updates as **needs update** with no manual action. The exported report called the same rows **Needs review** and blamed incomplete metadata, which made a finished automatic upgrade look like it needed human follow-up.

Packagist is also the wrong place to read Store extension notes. The changelog endpoint already returns a storefront URL, so the wizard should use that when it has one.

## How was this tested?

- Unit tests for report grouping, the neutral Composer-resolution note, Store-link preference over Packagist, overlay copy, and applying Store links when changelogs arrive
- `go test ./internal/shop/upgrade/ ./internal/tui/upgrade/`

## Related issue or discussion

Closes #1361