### PR TITLE
fix: fix storefront asset validation conditions

### DIFF
--- a/internal/extension/validator_assets.go
+++ b/internal/extension/validator_assets.go
@@ -47,7 +47,7 @@ func validateAssetByResourceDir(check validation.Check, resourceDir string) {
 		})
 	}
 
-	if foundStorefrontDistFiles != nil && foundStorefrontEntrypoint {
+	if foundStorefrontDistFiles == nil && !foundStorefrontEntrypoint {
 		check.AddResult(validation.CheckResult{
 			Path:       resourceDir,
 			Identifier: "assets.storefront.sources_missing",
@@ -56,7 +56,7 @@ func validateAssetByResourceDir(check validation.Check, resourceDir string) {
 		})
 	}
 
-	if foundStorefrontDistFiles == nil && !foundStorefrontEntrypoint {
+	if foundStorefrontDistFiles != nil && foundStorefrontEntrypoint {
 		check.AddResult(validation.CheckResult{
 			Path:       resourceDir,
 			Identifier: "assets.storefront.build_missing",

--- a/internal/extension/validator_assets_test.go
+++ b/internal/extension/validator_assets_test.go
@@ -1,0 +1,67 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAssetByResourceDirStorefront(t *testing.T) {
+	tests := []struct {
+		name            string
+		buildPresent    bool
+		sourcePresent   bool
+		expectedID      string
+		expectedMessage string
+	}{
+		{
+			name:          "build and source present",
+			buildPresent:  true,
+			sourcePresent: true,
+		},
+		{
+			name:            "build present and source missing",
+			buildPresent:    true,
+			expectedID:      "assets.storefront.sources_missing",
+			expectedMessage: "Found storefront build files",
+		},
+		{
+			name:            "build missing and source present",
+			sourcePresent:   true,
+			expectedID:      "assets.storefront.build_missing",
+			expectedMessage: "Found storefront source files",
+		},
+		{
+			name: "build and source missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceDir := t.TempDir()
+			if tt.buildPresent {
+				assert.NoError(t, os.MkdirAll(filepath.Join(resourceDir, "app", "storefront", "dist"), 0o755))
+			}
+			if tt.sourcePresent {
+				sourceDir := filepath.Join(resourceDir, "app", "storefront", "src")
+				assert.NoError(t, os.MkdirAll(sourceDir, 0o755))
+				assert.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.js"), []byte(""), 0o644))
+			}
+
+			check := &testCheck{}
+			validateAssetByResourceDir(check, resourceDir)
+
+			if tt.expectedID == "" {
+				assert.Empty(t, check.Results)
+				return
+			}
+
+			if assert.Len(t, check.Results, 1) {
+				assert.Equal(t, tt.expectedID, check.Results[0].Identifier)
+				assert.Contains(t, check.Results[0].Message, tt.expectedMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed?

  - Fixed inverted storefront asset validation conditions.
  - Added tests covering all build/source combinations.
  - No TUI or CLI output changes.

  ## Why?

  Storefront validation reported incorrect identifiers and messages when build files or source entrypoints were missing.

  ## How was this tested?

  - go test ./internal/extension passes.
  - go test ./... passes except the unrelated DNS container integration test, which failed because the DNS container refused the connection.
  - git diff --check passes.

  ## Related issue or discussion

  #1339 