### PR TITLE
chore: add bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dist/
 /completions
 /local
+/bin
 /.shopware-cli
 /.shopware-project.yml
 /.shopware-project.yaml


### PR DESCRIPTION
## What changed?
adds `/bin` directory to gitignore

## Why?

[Readme mentions](https://github.com/shopware/shopware-cli#build-locally-from-this-repository) to build the project like this locally:

```bash
go build -o bin/shopware-cli .
```

But then you end up with the binary being picked up by git, which you have to ignore / make sure to not commit.

## How was this tested?

Read readme, run the above command, then `git status` shows that untracked file.
Having the executable in the `bin` directory is still beneficial, e.g. I can add that to my system `PATH` to run and test it on shopware projects.

## Related issue or discussion

None, just my first small / minor annoyance I ran into while setting up my local dev environment :)

<!--
Before opening this PR:
- Small fixes (typos, docs) can go straight to a PR.
- Larger changes (new features/commands/subcommands, changes to existing
  command behavior) should be discussed in an issue first.
- Run `go test ./...` and `golangci-lint run ./...` locally.
- Add or update tests for bug fixes and new behavior.
- Keep the PR focused — smaller PRs are easier to review and merge.
-->