### PR TITLE
ci: isolate macOS test sandbox to loopback only

### DIFF
--- a/sandbox-no-network.sb
+++ b/sandbox-no-network.sb
@@ -1,5 +1,9 @@
 (version 1)
 (allow default)
-(allow network*)
-(deny network-outbound (remote tcp "*:80"))
-(deny network-outbound (remote tcp "*:443"))
+
+; Seatbelt stand-in for Linux `unshare --net` (loopback only):
+; httptest and other 127.0.0.1 servers keep working, but nothing can
+; reach the outside. Unix sockets are left denied so mDNSResponder
+; cannot resolve external names on the process's behalf.
+(deny network-outbound)
+(allow network-outbound (remote ip "localhost:*"))


### PR DESCRIPTION
## What changed?

Tighten `sandbox-no-network.sb` so the macOS `sandbox-exec` test runner only allows loopback outbound traffic.

Before, the profile allowed all networking and only denied TCP 80/443. DNS still worked through mDNSResponder, and any other port could leave the machine.

Now it denies all outbound connections except `localhost`, matching Linux `unshare --net` (loopback only). Unix sockets stay denied so mDNSResponder cannot resolve external names on the process's behalf. `httptest.NewServer` and other `127.0.0.1` servers keep working.

## Why?

`./scripts/run-tests.sh` is meant to match the Nix/CI no-network sandbox. On macOS it did not: tests that needed real Docker or external DNS could still pass locally and fail in CI.

## How was this tested?

- Confirmed external connect is `Operation not permitted` and DNS lookups fail with `no such host` under `sandbox-exec`.
- Confirmed `127.0.0.1` bind/connect still works.
- Ran `./scripts/run-tests.sh -count=1` on macOS; the suite passed. Docker integration tests skip because they cannot reach the daemon socket.

## Related issue or discussion
