### PR TITLE
fix: report PHP linter issues with line numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/shyim/go-composer/sbom v0.1.1
 	github.com/shyim/go-endoflife-api v0.0.0-20260630085844-dc60358f29eb
 	github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c
-	github.com/shyim/go-phplint v0.2.2
+	github.com/shyim/go-phplint v0.2.3
 	github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1
 	github.com/shyim/go-version v0.0.0-20250828113848-97ec77491b32
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/shyim/go-htmlprinter v0.0.0-20250417052954-e3e325d9ba3f h1:b7RObIj6Tn
 github.com/shyim/go-htmlprinter v0.0.0-20250417052954-e3e325d9ba3f/go.mod h1:UZ9KS4PRWtcsdL8IqdeXQK+L+L1tDqe6+lfmq9b12eo=
 github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c h1:4u/ATdQ4wCgIpQ2KJVC+iJXeB92kP6dI30CDZMSRJJI=
 github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c/go.mod h1:AGw/+zOkH6mNkBiTO4+2zCZvdMgd3oFyRLmxIMXQPGw=
-github.com/shyim/go-phplint v0.2.2 h1:o14unCWk7zY6NCcMeLyeYOEq0vvSHblGNJRK/aoDKME=
-github.com/shyim/go-phplint v0.2.2/go.mod h1:EFbIzL9UZ0DKJwt9SbYUr2thlbK1BHiiaLGyue5XjcM=
+github.com/shyim/go-phplint v0.2.3 h1:GX+edJpc0grmXKnJ2hHoqTeSkEpg5a7FTiG7+qNz3YI=
+github.com/shyim/go-phplint v0.2.3/go.mod h1:EFbIzL9UZ0DKJwt9SbYUr2thlbK1BHiiaLGyue5XjcM=
 github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1 h1:oD4MMCeWHSuvvLv2iXOKVMZRvJyn+r3xwIMU2BFttDo=
 github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1/go.mod h1:G8YfjnnIrntUnXjmOlbkLn9HuEA5if+XvxIxuWq7tUg=
 github.com/shyim/go-version v0.0.0-20250828113848-97ec77491b32 h1:LEMavffuqxLwefNTQYlTNj/d9yAg5zVPCKvQrtt1/l4=

--- a/internal/extension/platform.go
+++ b/internal/extension/platform.go
@@ -494,7 +494,8 @@ func validatePHPFiles(c context.Context, ext Extension, check validation.Check) 
 				check.AddResult(validation.CheckResult{
 					Path:       relPath,
 					Identifier: "php.linter",
-					Message:    fmt.Sprintf("%s: %s", relPath, diag.Message),
+					Message:    diag.Message,
+					Line:       diag.Start.Line,
 					Severity:   validation.SeverityError,
 				})
 			}


### PR DESCRIPTION
## What changed?

Bump `github.com/shyim/go-phplint` from v0.2.2 to v0.2.3.

PHP linter validation results now set `Line` from the diagnostic start position and stop prefixing the message with the file path. Reporters already print path and line separately (`summary`, GitHub annotations, GitLab, markdown, JUnit).

Before:

```text
src/Foo.php
  0  error    [php.linter]  src/Foo.php: syntax error, unexpected token
```

After:

```text
src/Foo.php
  12  error    [php.linter]  syntax error, unexpected token
```

v0.2.3 also includes two false-positive fixes from go-phplint:

- allow constructor arguments in `new` default values / constant expressions
- do not treat `Builder::new()->qux()` as unparenthesized new-expression dereferencing

## Why?

Validation output was missing line numbers, so GitHub annotations and the summary reporter could not point at the failing line. The path was also duplicated in the message.

## How was this tested?

- `go mod tidy` after the version bump
- Change is limited to result mapping in `validatePHPFiles`; existing reporters already consume `Line`

## Related issue or discussion

- [go-phplint v0.2.3](https://github.com/shyim/go-phplint/releases/tag/v0.2.3)
- Follow-up to #1393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PHP lint diagnostics by displaying line numbers separately for easier navigation.
  * Simplified lint messages to show only the relevant diagnostic text, without extra file path information.
  * Updated linting behavior to provide more consistent and readable error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->