### PR TITLE
chore: update go-phplint to v0.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/shyim/go-composer/sbom v0.1.1
 	github.com/shyim/go-endoflife-api v0.0.0-20260630085844-dc60358f29eb
 	github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c
-	github.com/shyim/go-phplint v0.2.3
+	github.com/shyim/go-phplint v0.2.4
 	github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1
 	github.com/shyim/go-version v0.0.0-20250828113848-97ec77491b32
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/shyim/go-htmlprinter v0.0.0-20250417052954-e3e325d9ba3f h1:b7RObIj6Tn
 github.com/shyim/go-htmlprinter v0.0.0-20250417052954-e3e325d9ba3f/go.mod h1:UZ9KS4PRWtcsdL8IqdeXQK+L+L1tDqe6+lfmq9b12eo=
 github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c h1:4u/ATdQ4wCgIpQ2KJVC+iJXeB92kP6dI30CDZMSRJJI=
 github.com/shyim/go-php-discover v0.0.0-20260802092855-da3bc85f491c/go.mod h1:AGw/+zOkH6mNkBiTO4+2zCZvdMgd3oFyRLmxIMXQPGw=
-github.com/shyim/go-phplint v0.2.3 h1:GX+edJpc0grmXKnJ2hHoqTeSkEpg5a7FTiG7+qNz3YI=
-github.com/shyim/go-phplint v0.2.3/go.mod h1:EFbIzL9UZ0DKJwt9SbYUr2thlbK1BHiiaLGyue5XjcM=
+github.com/shyim/go-phplint v0.2.4 h1:T6toipCAU0NSD/OaMF9R41+X/EI6mjtiUWFUFXI3AgQ=
+github.com/shyim/go-phplint v0.2.4/go.mod h1:EFbIzL9UZ0DKJwt9SbYUr2thlbK1BHiiaLGyue5XjcM=
 github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1 h1:oD4MMCeWHSuvvLv2iXOKVMZRvJyn+r3xwIMU2BFttDo=
 github.com/shyim/go-spdx v0.0.0-20260602055701-a935a2772ac1/go.mod h1:G8YfjnnIrntUnXjmOlbkLn9HuEA5if+XvxIxuWq7tUg=
 github.com/shyim/go-version v0.0.0-20250828113848-97ec77491b32 h1:LEMavffuqxLwefNTQYlTNj/d9yAg5zVPCKvQrtt1/l4=


### PR DESCRIPTION
## What changed?

Bump `github.com/shyim/go-phplint` from v0.2.3 to v0.2.4.

## Why?

v0.2.4 stops treating `null` and `false` as standalone types when they appear as union members. Those are valid since PHP 8.0; only truly standalone usages (e.g. `function f(): null` or `?false`) require PHP 8.2. Unions that consist solely of `null` and `false` are still reported, matching PHP's compile-time behavior.

See [shyim/go-phplint#6](https://github.com/shyim/go-phplint/pull/6).

## How was this tested?

- `go.mod` / `go.sum` only; no shopware-cli source changes.
- `go mod tidy` after the version bump.
- Verified the v0.2.4 release notes match the intended `null`/`false` union false-positive fix.

## Related issue or discussion

- [go-phplint v0.2.4](https://github.com/shyim/go-phplint/releases/tag/v0.2.4)
- Follow-up to #1393 and #1394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PHP linting component to a newer version, incorporating the latest maintenance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->