### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "shopware-cli",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the shopware-cli Go project.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+# Pinned to match CONTRIBUTING.md / mise.toml. Keep the Go version aligned with go.mod.
+GO_VERSION="go1.26.4"
+GOLANGCI_LINT_VERSION="v2.12.0"
+
+# Warm the module cache and download the Go toolchain declared in go.mod
+# (the base image ships an older Go, so GOTOOLCHAIN=auto fetches ${GO_VERSION}).
+go mod download
+
+# Build the CLI to verify the toolchain works and to warm the build cache.
+go build -o shopware-cli .
+
+# Install golangci-lint into GOPATH/bin (already on PATH). It must be built with
+# the same Go toolchain the project targets, otherwise it refuses to lint code
+# that declares a newer language version than the one it was compiled with.
+GOBIN_DIR="$(go env GOPATH)/bin"
+if ! "${GOBIN_DIR}/golangci-lint" --version 2>/dev/null \
+    | grep -q "has version ${GOLANGCI_LINT_VERSION#v} built with ${GO_VERSION}"; then
+    GOTOOLCHAIN="${GO_VERSION}" go install \
+        "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+fi
+
+echo "shopware-cli environment ready:"
+go version
+"${GOBIN_DIR}/golangci-lint" --version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a Cloud Agent environment for the `shopware-cli` Go project:

- `.cursor/environment.json` — uses Cursor's default base image and runs an install script (no long-running services needed for a CLI project).
- `.cursor/install.sh` — idempotent bootstrap that:
  - warms the Go module cache and downloads the `go1.26.4` toolchain declared in `go.mod` (the base image ships an older Go, so `GOTOOLCHAIN=auto` fetches it);
  - builds the `shopware-cli` binary to verify the toolchain and warm the build cache;
  - installs `golangci-lint` `v2.12.0` into `GOPATH/bin` (already on `PATH`), built with the `go1.26.4` toolchain. This is required because a `golangci-lint` compiled with an older Go refuses to lint code that targets a newer language version.

## Why

There was no `.cursor/environment.json`, so Cloud Agents booted a just-in-time environment. This pins the tooling used by `CONTRIBUTING.md`/`mise.toml` so future agents can build, test, vet, and lint out of the box.

## How it was tested

On the VM, from a clean checkout state:

- `./.cursor/install.sh` runs to completion and is idempotent (second run skips the `golangci-lint` reinstall).
- `go build -o shopware-cli .` — OK
- `go vet ./...` — OK
- `golangci-lint run ./... --timeout 4m` — 0 issues
- `./scripts/run-tests.sh ./...` (network-isolated full suite) — all packages pass
- CLI end-to-end: `extension get-name` → `TestPlugin`, `extension get-version` → `1.0.0`, `project config-schema` emits the JSON schema.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a2cb840-8f3c-4629-83ec-e3b87ead5ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a2cb840-8f3c-4629-83ec-e3b87ead5ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

