### PR TITLE
Deprecate `project generate-jwt` and `extension prepare` for October 2026

### DIFF
--- a/cmd/extension/extension_prepare.go
+++ b/cmd/extension/extension_prepare.go
@@ -10,9 +10,10 @@ import (
 )
 
 var extensionPrepareCmd = &cobra.Command{
-	Use:   "prepare [path]",
-	Short: "Install Composer dependencies of an extension and delete unnecessary files for zipping",
-	Args:  cobra.MinimumNArgs(1),
+	Use:        "prepare [path]",
+	Short:      "Install Composer dependencies of an extension and delete unnecessary files for zipping",
+	Deprecated: "will be removed in October 2026. Use `extension package` instead.",
+	Args:       cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/extension/extension_prepare.go
+++ b/cmd/extension/extension_prepare.go
@@ -12,7 +12,7 @@ import (
 var extensionPrepareCmd = &cobra.Command{
 	Use:        "prepare [path]",
 	Short:      "Install Composer dependencies of an extension and delete unnecessary files for zipping",
-	Deprecated: "will be removed in October 2026. Use `extension package` instead.",
+	Deprecated: "Will be removed in October 2026. Use `extension package` instead.",
 	Args:       cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])

--- a/cmd/extension/extension_prepare_test.go
+++ b/cmd/extension/extension_prepare_test.go
@@ -34,14 +34,14 @@ func TestExtensionPreparePrintsDeprecationNotice(t *testing.T) {
 	out := new(bytes.Buffer)
 	extensionPrepareCmd.SetOut(out)
 	extensionPrepareCmd.SetErr(out)
-	extensionPrepareCmd.SetArgs([]string{"--help"})
+	extensionRootCmd.SetArgs([]string{"prepare", "--help"})
 	t.Cleanup(func() {
-		extensionPrepareCmd.SetArgs(nil)
+		extensionRootCmd.SetArgs(nil)
 		extensionPrepareCmd.SetOut(nil)
 		extensionPrepareCmd.SetErr(nil)
 	})
 
-	require.NoError(t, extensionPrepareCmd.Execute())
+	require.NoError(t, extensionRootCmd.Execute())
 
 	output := out.String()
 	assert.Contains(t, output, "deprecated")
@@ -55,15 +55,15 @@ func TestExtensionPrepareStillExecutes(t *testing.T) {
 	out := new(bytes.Buffer)
 	extensionPrepareCmd.SetOut(out)
 	extensionPrepareCmd.SetErr(out)
-	extensionPrepareCmd.SetArgs([]string{dir})
 	extensionPrepareCmd.SetContext(t.Context())
+	extensionRootCmd.SetArgs([]string{"prepare", dir})
 	t.Cleanup(func() {
-		extensionPrepareCmd.SetArgs(nil)
+		extensionRootCmd.SetArgs(nil)
 		extensionPrepareCmd.SetOut(nil)
 		extensionPrepareCmd.SetErr(nil)
 	})
 
-	require.NoError(t, extensionPrepareCmd.Execute())
+	require.NoError(t, extensionRootCmd.Execute())
 	assert.Contains(t, out.String(), "deprecated")
 	assert.Contains(t, out.String(), "October 2026")
 }

--- a/cmd/extension/extension_prepare_test.go
+++ b/cmd/extension/extension_prepare_test.go
@@ -1,0 +1,69 @@
+package extension
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testPrepareAppManifest = `<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+	<meta>
+		<name>MyExampleApp</name>
+		<label>Label</label>
+		<description>A description</description>
+		<author>Your Company Ltd.</author>
+		<copyright>(c) by Your Company Ltd.</copyright>
+		<version>1.0.0</version>
+		<license>MIT</license>
+	</meta>
+</manifest>`
+
+func TestExtensionPrepareCommandDeprecated(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, extensionPrepareCmd.Deprecated, "October 2026")
+	assert.Contains(t, extensionPrepareCmd.Deprecated, "extension package")
+}
+
+func TestExtensionPreparePrintsDeprecationNotice(t *testing.T) {
+	out := new(bytes.Buffer)
+	extensionPrepareCmd.SetOut(out)
+	extensionPrepareCmd.SetErr(out)
+	extensionPrepareCmd.SetArgs([]string{"--help"})
+	t.Cleanup(func() {
+		extensionPrepareCmd.SetArgs(nil)
+		extensionPrepareCmd.SetOut(nil)
+		extensionPrepareCmd.SetErr(nil)
+	})
+
+	require.NoError(t, extensionPrepareCmd.Execute())
+
+	output := out.String()
+	assert.Contains(t, output, "deprecated")
+	assert.Contains(t, output, "October 2026")
+}
+
+func TestExtensionPrepareStillExecutes(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.xml"), []byte(testPrepareAppManifest), 0o644))
+
+	out := new(bytes.Buffer)
+	extensionPrepareCmd.SetOut(out)
+	extensionPrepareCmd.SetErr(out)
+	extensionPrepareCmd.SetArgs([]string{dir})
+	extensionPrepareCmd.SetContext(t.Context())
+	t.Cleanup(func() {
+		extensionPrepareCmd.SetArgs(nil)
+		extensionPrepareCmd.SetOut(nil)
+		extensionPrepareCmd.SetErr(nil)
+	})
+
+	require.NoError(t, extensionPrepareCmd.Execute())
+	assert.Contains(t, out.String(), "deprecated")
+	assert.Contains(t, out.String(), "October 2026")
+}

--- a/cmd/project/project_generate_jwt.go
+++ b/cmd/project/project_generate_jwt.go
@@ -19,8 +19,9 @@ import (
 )
 
 var projectNewJWTCmd = &cobra.Command{
-	Use:   "generate-jwt",
-	Short: "Generate a new JWT secret key",
+	Use:        "generate-jwt",
+	Short:      "Generate a new JWT secret key",
+	Deprecated: "will be removed in October 2026",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		publicKey, privateKey, err := generatePrivatePublicKey(2048)
 		if err != nil {
@@ -64,6 +65,8 @@ var projectNewJWTCmd = &cobra.Command{
 func init() {
 	projectRootCmd.AddCommand(projectNewJWTCmd)
 	projectNewJWTCmd.PersistentFlags().Bool("env", false, "Provide secrets as environment variables")
+	// Cobra prints Deprecated via Out; keep --env key output on stdout parseable.
+	projectNewJWTCmd.SetOut(os.Stderr)
 }
 
 func generatePrivatePublicKey(keyLength int) ([]byte, []byte, error) {

--- a/cmd/project/project_generate_jwt.go
+++ b/cmd/project/project_generate_jwt.go
@@ -21,7 +21,7 @@ import (
 var projectNewJWTCmd = &cobra.Command{
 	Use:        "generate-jwt",
 	Short:      "Generate a new JWT secret key",
-	Deprecated: "will be removed in October 2026",
+	Deprecated: "Will be removed in October 2026",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		publicKey, privateKey, err := generatePrivatePublicKey(2048)
 		if err != nil {

--- a/cmd/project/project_generate_jwt_test.go
+++ b/cmd/project/project_generate_jwt_test.go
@@ -1,0 +1,61 @@
+package project
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateJWTCommandDeprecated(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, projectNewJWTCmd.Deprecated, "October 2026")
+}
+
+func TestGenerateJWTPrintsDeprecationNotice(t *testing.T) {
+	out := new(bytes.Buffer)
+	projectNewJWTCmd.SetOut(out)
+	projectNewJWTCmd.SetErr(out)
+	projectNewJWTCmd.SetArgs([]string{"--help"})
+	t.Cleanup(func() {
+		projectNewJWTCmd.SetArgs(nil)
+		projectNewJWTCmd.SetOut(os.Stderr)
+		projectNewJWTCmd.SetErr(nil)
+	})
+
+	require.NoError(t, projectNewJWTCmd.Execute())
+
+	output := out.String()
+	assert.Contains(t, output, "deprecated")
+	assert.Contains(t, output, "October 2026")
+}
+
+func TestGenerateJWTEnvStillWorks(t *testing.T) {
+	require.NoError(t, projectNewJWTCmd.PersistentFlags().Set("env", "true"))
+	t.Cleanup(func() {
+		_ = projectNewJWTCmd.PersistentFlags().Set("env", "false")
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	stdout := os.Stdout
+	os.Stdout = w
+	runErr := projectNewJWTCmd.RunE(projectNewJWTCmd, []string{})
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	require.NoError(t, runErr)
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	text := string(output)
+	assert.Contains(t, text, "JWT_PRIVATE_KEY=")
+	assert.Contains(t, text, "JWT_PUBLIC_KEY=")
+	assert.False(t, strings.Contains(text, "deprecated"), "deprecation notice must not pollute --env stdout")
+}

--- a/cmd/project/project_generate_jwt_test.go
+++ b/cmd/project/project_generate_jwt_test.go
@@ -21,14 +21,14 @@ func TestGenerateJWTPrintsDeprecationNotice(t *testing.T) {
 	out := new(bytes.Buffer)
 	projectNewJWTCmd.SetOut(out)
 	projectNewJWTCmd.SetErr(out)
-	projectNewJWTCmd.SetArgs([]string{"--help"})
+	projectRootCmd.SetArgs([]string{"generate-jwt", "--help"})
 	t.Cleanup(func() {
-		projectNewJWTCmd.SetArgs(nil)
+		projectRootCmd.SetArgs(nil)
 		projectNewJWTCmd.SetOut(os.Stderr)
 		projectNewJWTCmd.SetErr(nil)
 	})
 
-	require.NoError(t, projectNewJWTCmd.Execute())
+	require.NoError(t, projectRootCmd.Execute())
 
 	output := out.String()
 	assert.Contains(t, output, "deprecated")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

`shopware-cli project generate-jwt` and `shopware-cli extension prepare` now print a Cobra deprecation notice and stay fully executable.

Example when the command is used or `--help` is shown:

```
Command "prepare" is deprecated, will be removed in October 2026. Use `extension package` instead.
Command "generate-jwt" is deprecated, will be removed in October 2026
```

`generate-jwt --env` still writes `JWT_*` keys to stdout. The deprecation line is sent to stderr so env output stays parseable. Both commands are hidden from parent `--help` listings, which is Cobra's default for deprecated commands, but they can still be invoked by name.

## Why?

These commands are low-use leftovers. `extension prepare` is a thin wrapper around `PrepareFolderForZipping`, which `extension package` already runs. Both should get a deprecation window before removal in October 2026.

## How was this tested?

Unit tests cover:

- The `Deprecated` field names October 2026
- `--help` and a real run print the notice
- `extension prepare` still succeeds on a sample app
- `project generate-jwt --env` still emits JWT keys without putting the notice on stdout

Manual CLI runs:

<img alt="CLI deprecation notice output" />

See captured command output:

[deprecation_notice_commands.log](https://cursor.com/agents/bc-b6d3211b-90fd-46b1-ad5e-3031b1f5a63c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeprecation_notice_commands.log)

## Related issue or discussion

Closes #1229


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6d3211b-90fd-46b1-ad5e-3031b1f5a63c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6d3211b-90fd-46b1-ad5e-3031b1f5a63c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Deprecated `extension prepare`; users are directed to `extension package`, with a planned removal date.
  * Deprecated `project generate-jwt`, with removal planned for October 2026.
  * Deprecation notices no longer interfere with machine-readable environment-variable output.

* **Bug Fixes**
  * Existing command functionality remains available during the deprecation period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->