### PR TITLE
chore: update contributing guide with branching and release strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ Please keep PRs focused. Smaller PRs are easier to review and merge.
 
 ## Development
 
-Develop (branch of) from `main` unless you work on a big feature / epic,
-where you not want to block bug fix releases with a half finished implementation.
-For that use a dedicated feature branch (e.g. `next`) as your target branch.
+Branch from `main` unless you work on a large feature or epic that should not
+block bug-fix releases. In that case, use a dedicated feature branch (for
+example, `next`) as the pull request target branch.
 
 Before submitting, run the relevant checks locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ Please keep PRs focused. Smaller PRs are easier to review and merge.
 
 ## Development
 
+Develop (branch of) from `main` unless you work on a big feature / epic,
+where you not want to block bug fix releases with a half finished implementation.
+For that use a dedicated feature branch (e.g. `next`) as your target branch.
+
 Before submitting, run the relevant checks locally:
 
 ```sh
@@ -80,3 +84,9 @@ manager.
 ## Reviews
 
 Maintainers may ask for changes, suggest a different direction, or decline a PR if the approach was not discussed beforehand. That is not personal; it is how we keep the project consistent and sustainable.
+
+## Releases
+
+In general releases happen from the default `main` branch with everything included there at the time of release.
+If a feature branch (e.g. `next`) is ready for release it needs to be merged back into `main` before the release to be included.
+The specific release process is explained in [RELEASING.md](RELEASING.md) and done on demand by the maintainers.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Available skills are `shopware-cli` and `shopware-cli-docker`.
 ## Contributing
 
 Contributions are welcome. If you want to improve commands, docs, or developer workflows, open an issue or send a pull request.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## What changed?

Added a few sentences to `CONTRIBUTING.md` to explain branching and release strategy used in this repo. Also linking that from the `README.md`

## Why?

To make it clear to new contributors which branch they should target / of which branch releases happen.

## How was this tested?

No need, it's markdown only

## Related issue or discussion

<!--
Before opening this PR:
- Small fixes (typos, docs) can go straight to a PR.
- Larger changes (new features/commands/subcommands, changes to existing
  command behavior) should be discussed in an issue first.
- Run `go test ./...` and `golangci-lint run ./...` locally.
- Add or update tests for bug fixes and new behavior.
- Keep the PR focused — smaller PRs are easier to review and merge.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added development branching guidelines for standard work and larger features.
  * Documented the release process, including when feature branches must be merged.
  * Linked the contributing guide from the README for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->