### PR TITLE
feat: mvp extension create command

### DIFF
--- a/cmd/extension/extension_create.go
+++ b/cmd/extension/extension_create.go
@@ -1,0 +1,74 @@
+package extension
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/extension"
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+func newCreateCmd() *cobra.Command {
+	opts := &extension.CreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new extension",
+		Long:  `Create a new plugin or theme with scaffolding inside a Shopware project.`,
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateInput(opts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			needsName := opts.Name == ""
+			needsStore := !cmd.Flags().Changed("store")
+
+			if needsName {
+				if !system.IsInteractionEnabled(cmd.Context()) {
+					return errors.New("extension name is required when interaction is disabled")
+				}
+
+				if err := runInteractiveCreateForm(opts, needsName, needsStore); err != nil {
+					return fmt.Errorf("running create form: %w", err)
+				}
+			}
+
+			if err := extension.ValidateName(opts.Name, opts.Store); err != nil {
+				return err
+			}
+
+			return extension.Create(cmd.Context(), *opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.Name, "name", "", "Extension name (PascalCase)")
+	flags.BoolVar(&opts.Store, "store", false, "Planning commercial use in Shopware Community Store")
+	flags.StringVarP((*string)(&opts.Type), "type", "t", string(extension.Plugin), "Extension type (plugin|theme)")
+
+	_ = flags.MarkHidden("type") // Since "theme" is not implemented yet, this flag is hidden from the user
+
+	_ = cmd.RegisterFlagCompletionFunc("type", cobra.FixedCompletions(
+		[]string{string(extension.Plugin), string(extension.Theme)},
+		cobra.ShellCompDirectiveNoFileComp,
+	))
+
+	return cmd
+}
+
+func validateInput(opts *extension.CreateOptions) error {
+	if err := extension.ValidateType(opts.Type); err != nil {
+		return err
+	}
+	if opts.Name == "" {
+		return nil
+	}
+
+	return extension.ValidateName(opts.Name, opts.Store)
+}
+
+func init() {
+	extensionRootCmd.AddCommand(newCreateCmd())
+}

--- a/cmd/extension/extension_create_form.go
+++ b/cmd/extension/extension_create_form.go
@@ -1,0 +1,52 @@
+package extension
+
+import (
+	"charm.land/huh/v2"
+
+	"github.com/shopware/shopware-cli/internal/extension"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+func runInteractiveCreateForm(opts *extension.CreateOptions, needsName bool, needsStore bool) error {
+	// Print the shopware banner
+	tui.PrintBanner()
+
+	// Create the form dynamically based on required input.
+	var groups []*huh.Group
+
+	if needsStore {
+		groups = append(groups,
+			huh.NewGroup(
+				huh.NewSelect[bool]().
+					Title("Do you plan to publish this extension in the Community Store?").
+					Description("This affects where the extension is created. Store extensions require a vendor-prefixed name.").
+					Options(
+						huh.NewOption("No, it's only for this project.", false),
+						huh.NewOption("Yes, I plan to publish it.", true),
+					).
+					Value(&opts.Store),
+			),
+		)
+	}
+
+	if needsName {
+		groups = append(groups,
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Extension Name").
+					Description("Use PascalCase and, for Community Store extensions, a vendor prefix, e.g. SwagBasicExample.").
+					Placeholder("SwagBasicExample").
+					Value(&opts.Name).
+					Validate(func(name string) error {
+						return extension.ValidateName(name, opts.Store)
+					}),
+			),
+		)
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+
+	return huh.NewForm(groups...).Run()
+}

--- a/cmd/extension/extension_create_test.go
+++ b/cmd/extension/extension_create_test.go
@@ -1,0 +1,165 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalextension "github.com/shopware/shopware-cli/internal/extension"
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+func TestCreateCommandDefaults(t *testing.T) {
+	cmd := newCreateCmd()
+
+	extensionType, err := cmd.Flags().GetString("type")
+	require.NoError(t, err)
+	assert.Equal(t, string(internalextension.Plugin), extensionType)
+
+	store, err := cmd.Flags().GetBool("store")
+	require.NoError(t, err)
+	assert.False(t, store)
+}
+
+func TestCreateCommandMapsFlags(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("PROJECT_ROOT", projectDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "plugins"), 0o755))
+
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{
+		"--store",
+		"--name", "SwagBasicExample",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.FileExists(t, filepath.Join(
+		projectDir,
+		"custom",
+		"plugins",
+		"SwagBasicExample",
+		"composer.json",
+	))
+}
+
+func TestCreateCommandValidatesTypeFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		extensionType string
+		error         string
+	}{
+		{
+			name:          "plugin",
+			extensionType: "plugin",
+		},
+		{
+			name:          "theme",
+			extensionType: "theme",
+		},
+		{
+			name:          "rejected",
+			extensionType: "unknown",
+			error:         `invalid extension type "unknown"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			t.Setenv("PROJECT_ROOT", projectDir)
+			require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "static-plugins"), 0o755))
+
+			cmd := newCreateCmd()
+			cmd.SetContext(system.WithInteraction(t.Context(), false))
+			cmd.SetArgs([]string{"--type", test.extensionType, "--name", "SwagBasicExample"})
+
+			err := cmd.Execute()
+			if test.error != "" {
+				assert.ErrorContains(t, err, test.error)
+				assert.NoDirExists(t, filepath.Join(projectDir, "custom", "static-plugins", "SwagBasicExample"))
+				return
+			}
+
+			require.NoError(t, err)
+			assert.FileExists(t, filepath.Join(
+				projectDir,
+				"custom",
+				"static-plugins",
+				"SwagBasicExample",
+				"composer.json",
+			))
+		})
+	}
+}
+
+func TestCreateCommandValidatesNameFlag(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{"--name", "invalid-name"})
+
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "invalid extension name")
+}
+
+func TestCreateCommandAcceptsNameFlag(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("PROJECT_ROOT", projectDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "static-plugins"), 0o755))
+
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{"--name", "SwagBasicExample"})
+
+	require.NoError(t, cmd.Execute())
+	assert.FileExists(t, filepath.Join(
+		projectDir,
+		"custom",
+		"static-plugins",
+		"SwagBasicExample",
+		"composer.json",
+	))
+}
+
+func TestCreateCommandAcceptsPrivateNameWithoutVendorPrefix(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("PROJECT_ROOT", projectDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "static-plugins"), 0o755))
+
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{"--name", "Example"})
+
+	require.NoError(t, cmd.Execute())
+	assert.FileExists(t, filepath.Join(
+		projectDir,
+		"custom",
+		"static-plugins",
+		"Example",
+		"composer.json",
+	))
+}
+
+func TestCreateCommandRequiresVendorPrefixForStore(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{"--store", "--name", "Example"})
+
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "vendor prefix")
+}
+
+func TestCreateCommandRejectsArguments(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+	cmd.SetArgs([]string{"SwagBasicExample"})
+
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "unknown command")
+}

--- a/internal/extension/create.go
+++ b/internal/extension/create.go
@@ -1,0 +1,80 @@
+package extension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/shopware/shopware-cli/internal/extension/scaffolding"
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+type ExtensionType string
+
+const (
+	Plugin ExtensionType = "plugin"
+	Theme  ExtensionType = "theme"
+)
+
+// CreateOptions contains the choices used to create extension scaffolding.
+type CreateOptions struct {
+	Name  string
+	Type  ExtensionType
+	Store bool
+}
+
+// Create writes extension scaffolding in the closest Shopware project.
+func Create(ctx context.Context, opts CreateOptions) (err error) {
+	logger := logging.FromContext(ctx)
+
+	logger.Info("Creating plugin...")
+
+	projectDir, err := shop.FindClosestShopwareProject(false)
+	if err != nil {
+		return err
+	}
+
+	extensionDir := extensionDirectory(projectDir, opts.Store, opts.Name)
+
+	err = scaffolding.CreateExtensionDir(extensionDir)
+	if err != nil {
+		return err
+	}
+
+	// Remove only the directory created above if a later step fails.
+	defer func() {
+		if err == nil {
+			return
+		}
+		logger.Debugf("Rollback of %s", extensionDir)
+		if cleanupErr := scaffolding.RemoveCreatedExtensionDir(extensionDir); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("rollback failed: %w", cleanupErr))
+		}
+	}()
+
+	if err = scaffolding.CreateExtensionFiles(extensionDir, opts.Name); err != nil {
+		return fmt.Errorf("create extension files: %w", err)
+	}
+
+	logger.Info("✓ Extension created")
+
+	if err = validateCreatedExtension(ctx, extensionDir); err != nil {
+		return fmt.Errorf("validate created extension: %w", err)
+	}
+
+	logger.Info("✓ Extension validation passed")
+	logger.Infof("Extension created successfully in %s", extensionDir)
+
+	return nil
+}
+
+func extensionDirectory(projectDir string, store bool, name string) string {
+	pluginDir := "static-plugins"
+	if store {
+		pluginDir = "plugins"
+	}
+
+	return filepath.Join(projectDir, "custom", pluginDir, name)
+}

--- a/internal/extension/create_installable.go
+++ b/internal/extension/create_installable.go
@@ -1,0 +1,220 @@
+package extension
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/shopware/shopware-cli/internal/extension/scaffolding"
+	"github.com/shopware/shopware-cli/internal/validation"
+)
+
+const shopwarePluginBaseClass = `Shopware\Core\Framework\Plugin`
+
+var (
+	phpNamespaceRegexp = regexp.MustCompile(`(?m)^namespace\s+([^;]+);`)
+	phpClassRegexp     = regexp.MustCompile(`(?m)^(?:final\s+|abstract\s+)?class\s+(\w+)(?:\s+extends\s+([\w\\]+))?`)
+)
+
+// validateCreatedExtension reloads the generated files before validation. This
+// checks what was written to disk rather than trusting the template input.
+func validateCreatedExtension(ctx context.Context, extensionDir string) error {
+	ext, err := GetExtensionByFolder(ctx, extensionDir)
+	if err != nil {
+		return fmt.Errorf("load extension: %w", err)
+	}
+
+	plugin, ok := ext.(*PlatformPlugin)
+	if !ok {
+		return fmt.Errorf("%s is not a %s", extensionDir, ComposerTypePlugin)
+	}
+
+	check := &installabilityCheck{}
+	validatePluginInstallable(plugin, check)
+	if check.HasErrors() {
+		return installabilityError{results: check.GetResults()}
+	}
+
+	return nil
+}
+
+// validatePluginInstallable checks the metadata, autoload mapping, and PHP
+// class Shopware needs to discover and install a plugin. Loading the plugin
+// above already verifies that composer.json is valid and has the right type.
+func validatePluginInstallable(plugin *PlatformPlugin, check validation.Check) {
+	pluginClass := plugin.Composer.Extra.ShopwarePluginClass
+	namespace, className := splitPHPClass(pluginClass)
+	if namespace == "" || className == "" {
+		addInstallableError(check, "composer.json", "installable.plugin-class",
+			fmt.Sprintf("extra.shopware-plugin-class must be a full class name like %s, got %q", `Swag\BasicExample\SwagBasicExample`, pluginClass))
+		return
+	}
+
+	if _, err := plugin.GetShopwareVersionConstraint(); err != nil {
+		addInstallableError(check, "composer.json", "installable.shopware-core",
+			"require.shopware/core must be a valid version constraint: "+err.Error())
+	}
+
+	if plugin.Composer.Extra.Label["en-GB"] == "" {
+		addInstallableError(check, "composer.json", "installable.label",
+			"extra.label must contain a label for en-GB")
+	}
+
+	technicalName := filepath.Base(plugin.GetPath())
+	if technicalName != className {
+		addInstallableError(check, "composer.json", "installable.technical-name",
+			fmt.Sprintf("extra.shopware-plugin-class must end with the directory name %q, got %q", technicalName, className))
+	}
+
+	validatePluginNameDerivation(technicalName, plugin.Composer.Name, namespace, check)
+
+	classFile, found := pluginClassFile(plugin.Composer, namespace, className)
+	if !found {
+		addInstallableError(check, "composer.json", "installable.autoload",
+			fmt.Sprintf(`autoload must map the namespace "%s\\" through psr-4 or psr-0`, namespace))
+		return
+	}
+
+	validatePluginClassFile(plugin.GetPath(), classFile, namespace, className, check)
+}
+
+func validatePluginNameDerivation(technicalName, composerName, namespace string, check validation.Check) {
+	if expected := scaffolding.DeriveComposerName(technicalName); composerName != expected {
+		addInstallableError(check, "composer.json", "installable.composer-name",
+			fmt.Sprintf("name must be %q for plugin %s, got %q", expected, technicalName, composerName))
+	}
+
+	if expected := scaffolding.DeriveNamespace(technicalName); namespace != expected {
+		addInstallableError(check, "composer.json", "installable.namespace",
+			fmt.Sprintf("plugin namespace must be %q for plugin %s, got %q", expected, technicalName, namespace))
+	}
+}
+
+func validatePluginClassFile(extensionDir, classFile, namespace, className string, check validation.Check) {
+	content, err := os.ReadFile(filepath.Join(extensionDir, classFile))
+	if err != nil {
+		addInstallableError(check, classFile, "installable.plugin-class-file",
+			"plugin class file could not be read: "+err.Error())
+		return
+	}
+
+	php := string(content)
+	if declared := firstSubmatch(phpNamespaceRegexp, php); declared != namespace {
+		addInstallableError(check, classFile, "installable.plugin-class-namespace",
+			fmt.Sprintf("file must declare namespace %q, got %q", namespace, declared))
+	}
+
+	class := phpClassRegexp.FindStringSubmatch(php)
+	if class == nil {
+		addInstallableError(check, classFile, "installable.plugin-class-file",
+			"file must declare class "+className)
+		return
+	}
+
+	if class[1] != className {
+		addInstallableError(check, classFile, "installable.plugin-class-file",
+			fmt.Sprintf("file must declare class %q, got %q", className, class[1]))
+	}
+
+	if !extendsShopwarePlugin(class[2], php) {
+		addInstallableError(check, classFile, "installable.plugin-base-class",
+			fmt.Sprintf("class %s must extend %s", class[1], shopwarePluginBaseClass))
+	}
+}
+
+// pluginClassFile resolves the class file using the mappings generated in
+// composer.json. PSR-4 strips the namespace prefix; PSR-0 keeps the namespace
+// as directories below its mapped path.
+func pluginClassFile(composer PlatformComposerJson, namespace, className string) (string, bool) {
+	prefix := namespace + `\`
+	fileName := className + ".php"
+
+	if dir, ok := composer.Autoload.Psr4[prefix]; ok {
+		return filepath.Join(dir, fileName), true
+	}
+	if dir, ok := composer.Autoload.Psr0[prefix]; ok {
+		namespacePath := filepath.Join(strings.Split(namespace, `\`)...)
+		return filepath.Join(dir, namespacePath, fileName), true
+	}
+
+	return "", false
+}
+
+func splitPHPClass(fullClassName string) (namespace, className string) {
+	parts := strings.Split(strings.TrimPrefix(fullClassName, `\`), `\`)
+	if len(parts) < 2 || slices.Contains(parts, "") {
+		return "", ""
+	}
+
+	return strings.Join(parts[:len(parts)-1], `\`), parts[len(parts)-1]
+}
+
+func extendsShopwarePlugin(parent, php string) bool {
+	parent = strings.TrimPrefix(parent, `\`)
+	if parent == shopwarePluginBaseClass {
+		return true
+	}
+
+	return parent == "Plugin" && strings.Contains(php, "use "+shopwarePluginBaseClass+";")
+}
+
+func firstSubmatch(pattern *regexp.Regexp, content string) string {
+	match := pattern.FindStringSubmatch(content)
+	if match == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(match[1])
+}
+
+func addInstallableError(check validation.Check, path, identifier, message string) {
+	check.AddResult(validation.CheckResult{
+		Path:       path,
+		Identifier: identifier,
+		Message:    message,
+		Severity:   validation.SeverityError,
+	})
+}
+
+type installabilityCheck struct {
+	results []validation.CheckResult
+}
+
+func (c *installabilityCheck) AddResult(result validation.CheckResult) {
+	c.results = append(c.results, result)
+}
+
+func (c *installabilityCheck) GetResults() []validation.CheckResult {
+	return c.results
+}
+
+func (c *installabilityCheck) HasErrors() bool {
+	for _, result := range c.results {
+		if result.Severity == validation.SeverityError {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *installabilityCheck) RemoveByIdentifier([]validation.ToolConfigIgnore) validation.Check {
+	return c
+}
+
+type installabilityError struct {
+	results []validation.CheckResult
+}
+
+func (e installabilityError) Error() string {
+	messages := make([]string, 0, len(e.results))
+	for _, result := range e.results {
+		messages = append(messages, fmt.Sprintf("%s [%s]: %s", result.Path, result.Identifier, result.Message))
+	}
+
+	return strings.Join(messages, "; ")
+}

--- a/internal/extension/create_test.go
+++ b/internal/extension/create_test.go
@@ -1,0 +1,371 @@
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/extension/scaffolding"
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/validation"
+)
+
+func TestValidateExtensionName(t *testing.T) {
+	t.Parallel()
+
+	for _, valid := range []string{"SwagBasicExample", "MyPlugin", "AcmePayPal", "Swag2Example", "Example"} {
+		assert.NoError(t, ValidateName(valid, false), valid)
+	}
+
+	for _, invalid := range []string{
+		"", "swagBasicExample", "my-plugin", "My_Plugin",
+		"My Plugin", "1Plugin", "Swag.Example",
+	} {
+		assert.Error(t, ValidateName(invalid, false), invalid)
+	}
+
+	assert.NoError(t, ValidateName("SwagBasicExample", true))
+	assert.Error(t, ValidateName("Example", true))
+	assert.Error(t, ValidateName("Swag", true))
+}
+
+func TestCreate(t *testing.T) {
+	for _, store := range []bool{false, true} {
+		t.Run(fmt.Sprintf("store=%t", store), func(t *testing.T) {
+			projectDir := prepareProject(t)
+			opts := validCreateOptions()
+			opts.Store = store
+
+			require.NoError(t, Create(system.WithInteraction(t.Context(), false), opts))
+
+			extensionDir := extensionDirectory(projectDir, opts.Store, opts.Name)
+			assert.FileExists(t, filepath.Join(extensionDir, "composer.json"))
+			assert.FileExists(t, filepath.Join(extensionDir, "src", opts.Name+".php"))
+			require.NoError(t, validateCreatedExtension(t.Context(), extensionDir))
+		})
+	}
+}
+
+func TestCreateFindsClosestProject(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "bin", "console"), nil, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "composer.json"),
+		[]byte(`{"require":{"shopware/core":"~6.7.0"}}`),
+		0o644,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "static-plugins"), 0o755))
+	nestedDir := filepath.Join(projectDir, "custom")
+	t.Chdir(nestedDir)
+
+	opts := validCreateOptions()
+	require.NoError(t, Create(system.WithInteraction(t.Context(), false), opts))
+
+	assert.FileExists(t, filepath.Join(extensionDirectory(projectDir, opts.Store, opts.Name), "composer.json"))
+}
+
+func TestCreateFailsOutsideShopwareProject(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	t.Chdir(t.TempDir())
+
+	err := Create(system.WithInteraction(t.Context(), false), validCreateOptions())
+
+	assert.ErrorContains(t, err, "cannot find Shopware project")
+}
+
+func TestCreateReportsMissingExtensionParent(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("PROJECT_ROOT", projectDir)
+	opts := validCreateOptions()
+
+	err := Create(system.WithInteraction(t.Context(), false), opts)
+
+	assert.ErrorContains(t, err, "extension parent directory does not exist")
+	assert.NoDirExists(t, extensionDirectory(projectDir, opts.Store, opts.Name))
+}
+
+func TestCreateDoesNotRemoveExistingDirectory(t *testing.T) {
+	projectDir := prepareProject(t)
+	opts := validCreateOptions()
+	extensionDir := extensionDirectory(projectDir, opts.Store, opts.Name)
+	require.NoError(t, os.Mkdir(extensionDir, 0o755))
+	marker := filepath.Join(extensionDir, "keep.txt")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0o644))
+
+	err := Create(system.WithInteraction(t.Context(), false), opts)
+
+	assert.ErrorContains(t, err, "already exists")
+	assert.FileExists(t, marker)
+}
+
+func TestValidateCreatedExtensionReportsDetails(t *testing.T) {
+	extensionDir := scaffoldPlugin(t)
+	mutateComposer(t, extensionDir, func(composer *PlatformComposerJson) {
+		composer.Extra.Label["en-GB"] = ""
+	})
+
+	err := validateCreatedExtension(t.Context(), extensionDir)
+
+	assert.ErrorContains(t, err, "installable.label")
+	assert.ErrorContains(t, err, "extra.label")
+}
+
+func TestValidatePluginInstallable(t *testing.T) {
+	extensionDir := scaffoldPlugin(t)
+	check := &testCheck{}
+
+	validatePluginInstallable(loadPlugin(t, extensionDir), check)
+
+	assert.Empty(t, check.GetResults())
+}
+
+func TestValidatePluginInstallableReportsBrokenPlugin(t *testing.T) {
+	tests := []struct {
+		name        string
+		breakPlugin func(*testing.T, string)
+		identifiers []string
+	}{
+		{
+			name: "plugin class is missing",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) { c.Extra.ShopwarePluginClass = "" })
+			},
+			identifiers: []string{"installable.plugin-class"},
+		},
+		{
+			name: "shopware core requirement is missing",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) { delete(c.Require, "shopware/core") })
+			},
+			identifiers: []string{"installable.shopware-core"},
+		},
+		{
+			name: "shopware core constraint is invalid",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) { c.Require["shopware/core"] = "not a version" })
+			},
+			identifiers: []string{"installable.shopware-core"},
+		},
+		{
+			name: "English label is empty",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) { c.Extra.Label["en-GB"] = "" })
+			},
+			identifiers: []string{"installable.label"},
+		},
+		{
+			name: "technical name differs",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) {
+					c.Extra.ShopwarePluginClass = `Swag\BasicExample\SwagOtherExample`
+				})
+			},
+			identifiers: []string{"installable.technical-name", "installable.plugin-class-file"},
+		},
+		{
+			name: "composer name differs",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) { c.Name = "swag/basic_example" })
+			},
+			identifiers: []string{"installable.composer-name"},
+		},
+		{
+			name: "namespace differs",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) {
+					c.Extra.ShopwarePluginClass = `Swag\OtherExample\SwagBasicExample`
+					c.Autoload.Psr4 = map[string]string{`Swag\OtherExample\`: "src/"}
+				})
+			},
+			identifiers: []string{"installable.namespace", "installable.plugin-class-namespace"},
+		},
+		{
+			name: "namespace is not autoloaded",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) {
+					c.Autoload.Psr4 = map[string]string{`Swag\WrongExample\`: "src/"}
+				})
+			},
+			identifiers: []string{"installable.autoload"},
+		},
+		{
+			name: "class file is missing",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(dir, "src", "SwagBasicExample.php")))
+			},
+			identifiers: []string{"installable.plugin-class-file"},
+		},
+		{
+			name: "class file namespace differs",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				replaceInFile(t, filepath.Join(dir, "src", "SwagBasicExample.php"),
+					`namespace Swag\BasicExample;`, `namespace Swag\WrongExample;`)
+			},
+			identifiers: []string{"installable.plugin-class-namespace"},
+		},
+		{
+			name: "class name differs",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				replaceInFile(t, filepath.Join(dir, "src", "SwagBasicExample.php"),
+					"class SwagBasicExample extends Plugin", "class OtherClass extends Plugin")
+			},
+			identifiers: []string{"installable.plugin-class-file"},
+		},
+		{
+			name: "base class is missing",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				replaceInFile(t, filepath.Join(dir, "src", "SwagBasicExample.php"),
+					"class SwagBasicExample extends Plugin", "class SwagBasicExample")
+			},
+			identifiers: []string{"installable.plugin-base-class"},
+		},
+		{
+			name: "multiple metadata errors",
+			breakPlugin: func(t *testing.T, dir string) {
+				t.Helper()
+				mutateComposer(t, dir, func(c *PlatformComposerJson) {
+					delete(c.Require, "shopware/core")
+					c.Extra.Label["en-GB"] = ""
+					c.Name = "wrong/name"
+				})
+			},
+			identifiers: []string{
+				"installable.shopware-core",
+				"installable.label",
+				"installable.composer-name",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			extensionDir := scaffoldPlugin(t)
+			test.breakPlugin(t, extensionDir)
+			check := &testCheck{}
+
+			validatePluginInstallable(loadPlugin(t, extensionDir), check)
+
+			assert.ElementsMatch(t, test.identifiers, resultIdentifiers(check.GetResults()))
+		})
+	}
+}
+
+func TestPluginClassFileSupportsPSR0(t *testing.T) {
+	extensionDir := scaffoldPlugin(t)
+	oldClassFile := filepath.Join(extensionDir, "src", "SwagBasicExample.php")
+	newClassFile := filepath.Join(extensionDir, "src", "Swag", "BasicExample", "SwagBasicExample.php")
+	require.NoError(t, os.MkdirAll(filepath.Dir(newClassFile), 0o755))
+	require.NoError(t, os.Rename(oldClassFile, newClassFile))
+	mutateComposer(t, extensionDir, func(c *PlatformComposerJson) {
+		c.Autoload.Psr4 = nil
+		c.Autoload.Psr0 = map[string]string{`Swag\BasicExample\`: "src/"}
+	})
+	check := &testCheck{}
+
+	validatePluginInstallable(loadPlugin(t, extensionDir), check)
+
+	assert.Empty(t, check.GetResults())
+}
+
+func TestPluginClassMayExtendFullyQualifiedBaseClass(t *testing.T) {
+	extensionDir := scaffoldPlugin(t)
+	replaceInFile(t, filepath.Join(extensionDir, "src", "SwagBasicExample.php"),
+		"class SwagBasicExample extends Plugin",
+		`class SwagBasicExample extends \Shopware\Core\Framework\Plugin`)
+	check := &testCheck{}
+
+	validatePluginInstallable(loadPlugin(t, extensionDir), check)
+
+	assert.Empty(t, check.GetResults())
+}
+
+func validCreateOptions() CreateOptions {
+	return CreateOptions{
+		Name: "SwagBasicExample",
+		Type: Plugin,
+	}
+}
+
+func prepareProject(t *testing.T) string {
+	t.Helper()
+
+	projectDir := t.TempDir()
+	t.Setenv("PROJECT_ROOT", projectDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "plugins"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "custom", "static-plugins"), 0o755))
+	return projectDir
+}
+
+func scaffoldPlugin(t *testing.T) string {
+	t.Helper()
+
+	const name = "SwagBasicExample"
+	extensionDir := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.Mkdir(extensionDir, 0o755))
+	require.NoError(t, scaffolding.CreateExtensionFiles(extensionDir, name))
+	return extensionDir
+}
+
+func loadPlugin(t *testing.T, extensionDir string) *PlatformPlugin {
+	t.Helper()
+
+	ext, err := GetExtensionByFolder(t.Context(), extensionDir)
+	require.NoError(t, err)
+	plugin, ok := ext.(*PlatformPlugin)
+	require.True(t, ok, "%s is not a platform plugin", extensionDir)
+	return plugin
+}
+
+func mutateComposer(t *testing.T, extensionDir string, mutate func(*PlatformComposerJson)) {
+	t.Helper()
+
+	path := filepath.Join(extensionDir, "composer.json")
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var composer PlatformComposerJson
+	require.NoError(t, json.Unmarshal(content, &composer))
+	mutate(&composer)
+
+	content, err = json.MarshalIndent(composer, "", "    ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, append(content, '\n'), 0o644))
+}
+
+func replaceInFile(t *testing.T, path, old, replacement string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(content), old)
+	updated := strings.Replace(string(content), old, replacement, 1)
+	require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
+}
+
+func resultIdentifiers(results []validation.CheckResult) []string {
+	identifiers := make([]string, 0, len(results))
+	for _, result := range results {
+		identifiers = append(identifiers, result.Identifier)
+	}
+	return identifiers
+}

--- a/internal/extension/create_validate.go
+++ b/internal/extension/create_validate.go
@@ -1,0 +1,40 @@
+package extension
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// Shopware technical names use UpperCamelCase. Community Store plugins also
+// need a vendor prefix, for example SwagBasicExample.
+var (
+	extensionNameRegexp      = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*$`)
+	storeExtensionNameRegexp = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*$`)
+)
+
+func ValidateName(name string, store bool) error {
+	if name == "" {
+		return errors.New("extension name must not be empty")
+	}
+	if store {
+		if !storeExtensionNameRegexp.MatchString(name) {
+			return fmt.Errorf("invalid extension name %q: Community Store extensions need UpperCamelCase with a vendor prefix, letters and digits only (for example SwagBasicExample)", name)
+		}
+		return nil
+	}
+	if !extensionNameRegexp.MatchString(name) {
+		return fmt.Errorf("invalid extension name %q: use UpperCamelCase, letters and digits only (for example Example or SwagBasicExample)", name)
+	}
+
+	return nil
+}
+
+func ValidateType(extensionType ExtensionType) error {
+	switch extensionType {
+	case Plugin, Theme:
+		return nil
+	default:
+		return fmt.Errorf("invalid extension type %q", extensionType)
+	}
+}

--- a/internal/extension/scaffolding/scaffolding.go
+++ b/internal/extension/scaffolding/scaffolding.go
@@ -1,0 +1,272 @@
+package scaffolding
+
+import (
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"unicode"
+)
+
+const (
+	privatePluginRoot = "custom/static-plugins"
+	storePluginRoot   = "custom/plugins"
+)
+
+//go:embed stubs/*
+var stubsFS embed.FS
+
+// stubFuncs are helpers available inside the stub templates.
+var stubFuncs = template.FuncMap{
+	// jsonEscape makes a value safe inside a JSON string, e.g. the
+	// backslashes of a PHP namespace: Swag\Example -> Swag\\Example.
+	"jsonEscape": func(value string) (string, error) {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return "", fmt.Errorf("escape %q for json: %w", value, err)
+		}
+
+		// Drop the surrounding quotes json.Marshal adds.
+		return string(encoded[1 : len(encoded)-1]), nil
+	},
+}
+
+type scaffoldingFile struct {
+	Path     string
+	StubPath string
+}
+
+// scaffoldingFiles returns a list of files with their paths and corresponding stub paths.
+func scaffoldingFiles(extensionName string) []scaffoldingFile {
+	return []scaffoldingFile{
+		{
+			Path:     "composer.json",
+			StubPath: "stubs/composer.json.tmpl",
+		},
+		{
+			Path:     "phpunit.xml",
+			StubPath: "stubs/phpunit.xml.tmpl",
+		},
+		{
+			Path:     "tests/TestBootstrap.php",
+			StubPath: "stubs/test_bootstrap.php.tmpl",
+		},
+		{
+			Path:     ".gitignore",
+			StubPath: "stubs/gitignore.tmpl",
+		},
+		{
+			Path:     "src/Resources/config/config.xml",
+			StubPath: "stubs/config.xml.tmpl",
+		},
+		{
+			Path:     filepath.Join("src", extensionName+".php"),
+			StubPath: "stubs/plugin_class.php.tmpl",
+		},
+	}
+}
+
+// CreateExtensionDir creates an empty extension directory. Its parents must already exist.
+func CreateExtensionDir(extensionDir string) error {
+	info, err := os.Stat(extensionDir)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", extensionDir)
+		}
+		return fmt.Errorf("extension directory already exists: %s", extensionDir)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat extension directory: %w", err)
+	}
+
+	parent := filepath.Dir(extensionDir)
+	info, err = os.Stat(parent)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("extension parent directory does not exist: %s", parent)
+	}
+	if err != nil {
+		return fmt.Errorf("stat extension parent directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("extension parent path is not a directory: %s", parent)
+	}
+
+	if err := os.Mkdir(extensionDir, 0o755); err != nil {
+		return fmt.Errorf("create extension directory: %w", err)
+	}
+
+	return nil
+}
+
+// CreateExtensionFiles creates all scaffolding Files that are given back by scaffoldingFiles()
+func CreateExtensionFiles(extensionDir, extensionName string) error {
+	data := createScaffoldingData(extensionName)
+	for _, file := range scaffoldingFiles(extensionName) {
+		err := createFileWithScaffolding(extensionDir, file, data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createFileWithScaffolding renders one embedded template into an existing extension.
+func createFileWithScaffolding(extensionDir string, file scaffoldingFile, data scaffoldData) (err error) {
+	dest := filepath.Join(extensionDir, file.Path)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("create subdirectories: %w", err)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close file: %w", closeErr)
+		}
+	}()
+
+	stubBytes, err := stubsFS.ReadFile(file.StubPath)
+	if err != nil {
+		return fmt.Errorf("read stub file: %w", err)
+	}
+
+	tmpl, err := template.New(file.Path).Funcs(stubFuncs).Parse(string(stubBytes))
+	if err != nil {
+		return fmt.Errorf("parse stub: %w", err)
+	}
+
+	if err := tmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("flush file to disk: %w", err)
+	}
+
+	return nil
+}
+
+type scaffoldData struct {
+	Namespace    string
+	ClassName    string
+	ComposerName string
+}
+
+func createScaffoldingData(extensionName string) scaffoldData {
+	return scaffoldData{
+		Namespace:    DeriveNamespace(extensionName),
+		ClassName:    extensionName,
+		ComposerName: DeriveComposerName(extensionName),
+	}
+}
+
+// DeriveNamespace turns a technical plugin name into a PHP namespace.
+// The first PascalCase word is the vendor prefix, the rest stay one segment:
+// SwagBasicExample → Swag\BasicExample.
+func DeriveNamespace(extensionName string) string {
+	parts := splitPascalCase(extensionName)
+	if len(parts) < 2 {
+		return extensionName
+	}
+
+	return parts[0] + "\\" + strings.Join(parts[1:], "")
+}
+
+// DeriveComposerName turns a technical plugin name into a Composer package name:
+// SwagBasicExample → swag/basic-example.
+func DeriveComposerName(extensionName string) string {
+	parts := splitPascalCase(extensionName)
+	if len(parts) == 0 {
+		return ""
+	}
+
+	vendor := strings.ToLower(parts[0])
+	if len(parts) == 1 {
+		return vendor + "/" + vendor
+	}
+
+	return vendor + "/" + strings.ToLower(strings.Join(parts[1:], "-"))
+}
+
+// splitPascalCase is a helper function and splits a PascalCase string into its constituent words.
+func splitPascalCase(name string) []string {
+	if name == "" {
+		return nil
+	}
+
+	runes := []rune(name)
+	start := 0
+	parts := make([]string, 0, 4)
+
+	for i := 1; i < len(runes); i++ {
+		if unicode.IsUpper(runes[i]) {
+			parts = append(parts, string(runes[start:i]))
+			start = i
+		}
+	}
+
+	return append(parts, string(runes[start:]))
+}
+
+// RemoveCreatedExtensionDir deletes the directory created by CreateExtensionDir.
+// It only removes a path that is an extension folder (custom/plugins/<name> or
+// custom/static-plugins/<name>), never parents, the project root, or a symlink.
+func RemoveCreatedExtensionDir(extensionDir string) error {
+	// Reject an empty path variable.
+	if strings.TrimSpace(extensionDir) == "" {
+		return errors.New("extension directory variable must not be empty")
+	}
+
+	// Turn the path into an absolute, cleaned path (no "..").
+	abs, err := filepath.Abs(extensionDir)
+	if err != nil {
+		return fmt.Errorf("resolve extension directory: %w", err)
+	}
+	abs = filepath.Clean(abs)
+
+	// Never delete the filesystem root.
+	if abs == string(filepath.Separator) {
+		return fmt.Errorf("refusing to remove %s", abs)
+	}
+
+	// The last segment must be a real folder name.
+	name := filepath.Base(abs)
+	if name == "." || name == ".." || name == string(filepath.Separator) {
+		return fmt.Errorf("refusing to remove %s", abs)
+	}
+
+	// Parent must be custom/plugins or custom/static-plugins.
+	parent := filepath.Dir(abs)
+	pluginRoot := filepath.Join(filepath.Base(filepath.Dir(parent)), filepath.Base(parent))
+	if pluginRoot != filepath.FromSlash(storePluginRoot) && pluginRoot != filepath.FromSlash(privatePluginRoot) {
+		return fmt.Errorf("refusing to remove %s: not an extension directory", abs)
+	}
+
+	// Inspect the path itself, do not follow a symlink.
+	info, err := os.Lstat(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // Already gone.
+		}
+		return fmt.Errorf("stat extension directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove %s: is a symlink", abs)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", abs)
+	}
+
+	// Delete the folder and everything inside it.
+	if err := os.RemoveAll(abs); err != nil {
+		return fmt.Errorf("remove extension directory: %w", err)
+	}
+
+	return nil
+}

--- a/internal/extension/scaffolding/scaffolding_test.go
+++ b/internal/extension/scaffolding/scaffolding_test.go
@@ -1,0 +1,146 @@
+package scaffolding
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameDerivation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		parts        []string
+		namespace    string
+		composerName string
+	}{
+		{
+			name:         "SwagBasicExample",
+			parts:        []string{"Swag", "Basic", "Example"},
+			namespace:    `Swag\BasicExample`,
+			composerName: "swag/basic-example",
+		},
+		{
+			name:         "AcmePayPal",
+			parts:        []string{"Acme", "Pay", "Pal"},
+			namespace:    `Acme\PayPal`,
+			composerName: "acme/pay-pal",
+		},
+		{
+			name:         "Swag2Example",
+			parts:        []string{"Swag2", "Example"},
+			namespace:    `Swag2\Example`,
+			composerName: "swag2/example",
+		},
+		{
+			name:         "",
+			parts:        nil,
+			namespace:    "",
+			composerName: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.parts, splitPascalCase(test.name))
+			assert.Equal(t, test.namespace, DeriveNamespace(test.name))
+			assert.Equal(t, test.composerName, DeriveComposerName(test.name))
+		})
+	}
+}
+
+func TestCreateScaffoldingFiles(t *testing.T) {
+	extensionDir := t.TempDir()
+
+	require.NoError(t, CreateExtensionFiles(extensionDir, "SwagBasicExample"))
+
+	expectedFiles := []string{
+		".gitignore",
+		"composer.json",
+		"phpunit.xml",
+		filepath.Join("src", "SwagBasicExample.php"),
+		filepath.Join("src", "Resources", "config", "config.xml"),
+		filepath.Join("tests", "TestBootstrap.php"),
+	}
+	for _, file := range expectedFiles {
+		assert.FileExists(t, filepath.Join(extensionDir, file))
+	}
+
+	content, err := os.ReadFile(filepath.Join(extensionDir, "composer.json"))
+	require.NoError(t, err)
+	var composer struct {
+		Name  string `json:"name"`
+		Extra struct {
+			PluginClass string `json:"shopware-plugin-class"`
+		} `json:"extra"`
+	}
+	require.NoError(t, json.Unmarshal(content, &composer))
+	assert.Equal(t, "swag/basic-example", composer.Name)
+	assert.Equal(t, `Swag\BasicExample\SwagBasicExample`, composer.Extra.PluginClass)
+
+	pluginClass, err := os.ReadFile(filepath.Join(extensionDir, "src", "SwagBasicExample.php"))
+	require.NoError(t, err)
+	assert.Contains(t, string(pluginClass), `namespace Swag\BasicExample;`)
+	assert.Contains(t, string(pluginClass), "class SwagBasicExample extends Plugin")
+}
+
+func TestCreateExtensionDir(t *testing.T) {
+	parent := t.TempDir()
+	extensionDir := filepath.Join(parent, "SwagBasicExample")
+
+	require.NoError(t, CreateExtensionDir(extensionDir))
+	assert.DirExists(t, extensionDir)
+	assert.ErrorContains(t, CreateExtensionDir(extensionDir), "already exists")
+
+	filePath := filepath.Join(parent, "file")
+	require.NoError(t, os.WriteFile(filePath, nil, 0o644))
+	assert.ErrorContains(t, CreateExtensionDir(filePath), "not a directory")
+
+	missingParent := filepath.Join(parent, "missing", "Extension")
+	assert.ErrorContains(t, CreateExtensionDir(missingParent), "parent directory does not exist")
+	assert.NoDirExists(t, filepath.Dir(missingParent))
+}
+
+func TestRemoveCreatedExtensionDir(t *testing.T) {
+	for _, pluginRoot := range []string{"plugins", "static-plugins"} {
+		t.Run(pluginRoot, func(t *testing.T) {
+			extensionDir := filepath.Join(t.TempDir(), "custom", pluginRoot, "SwagBasicExample")
+			require.NoError(t, os.MkdirAll(extensionDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "file.txt"), nil, 0o644))
+
+			require.NoError(t, RemoveCreatedExtensionDir(extensionDir))
+			assert.NoDirExists(t, extensionDir)
+			// Removing an already absent extension is safe and idempotent.
+			require.NoError(t, RemoveCreatedExtensionDir(extensionDir))
+		})
+	}
+}
+
+func TestRemoveCreatedExtensionDirRejectsUnsafePaths(t *testing.T) {
+	root := t.TempDir()
+	pluginRoot := filepath.Join(root, "custom", "plugins")
+	require.NoError(t, os.MkdirAll(pluginRoot, 0o755))
+
+	ordinaryDir := filepath.Join(root, "ordinary", "SwagBasicExample")
+	require.NoError(t, os.MkdirAll(ordinaryDir, 0o755))
+	assert.ErrorContains(t, RemoveCreatedExtensionDir(ordinaryDir), "not an extension directory")
+	assert.DirExists(t, ordinaryDir)
+
+	assert.Error(t, RemoveCreatedExtensionDir(""))
+	assert.Error(t, RemoveCreatedExtensionDir(string(filepath.Separator)))
+	assert.ErrorContains(t, RemoveCreatedExtensionDir(pluginRoot), "not an extension directory")
+	assert.DirExists(t, pluginRoot)
+
+	target := filepath.Join(pluginRoot, "Target")
+	link := filepath.Join(pluginRoot, "Link")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	require.NoError(t, os.Symlink(target, link))
+	assert.ErrorContains(t, RemoveCreatedExtensionDir(link), "symlink")
+	assert.DirExists(t, target)
+}

--- a/internal/extension/scaffolding/stubs/composer.json.tmpl
+++ b/internal/extension/scaffolding/stubs/composer.json.tmpl
@@ -1,0 +1,27 @@
+{
+    "name": "{{ .ComposerName }}",
+    "description": "{{ .ComposerName }}",
+    "type": "shopware-platform-plugin",
+    "version": "1.0.0",
+    "license": "MIT",
+    "require": {
+        "shopware/core": "~6.7.0"
+    },
+    "extra": {
+        "shopware-plugin-class": "{{ jsonEscape .Namespace }}\\{{ .ClassName }}",
+        "label": {
+            "de-DE": "Skeleton plugin",
+            "en-GB": "Skeleton plugin"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "{{ jsonEscape .Namespace }}\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "{{ jsonEscape .Namespace }}\\Tests\\": "tests/"
+        }
+    }
+}

--- a/internal/extension/scaffolding/stubs/config.xml.tmpl
+++ b/internal/extension/scaffolding/stubs/config.xml.tmpl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+
+    <card>
+        <title>Minimal configuration</title>
+
+        <input-field type="text">
+            <name>textField</name>
+            <label>Test field with default value</label>
+            <defaultValue>test</defaultValue>
+        </input-field>
+    </card>
+
+</config>

--- a/internal/extension/scaffolding/stubs/gitignore.tmpl
+++ b/internal/extension/scaffolding/stubs/gitignore.tmpl
@@ -1,0 +1,5 @@
+/composer.lock
+/src/Resources/app/administration/node_modules/
+/src/Resources/app/administration/src/.vite
+/src/Resources/public/
+/vendor

--- a/internal/extension/scaffolding/stubs/phpunit.xml.tmpl
+++ b/internal/extension/scaffolding/stubs/phpunit.xml.tmpl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="tests/TestBootstrap.php"
+         executionOrder="random">
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <server name="KERNEL_CLASS" value="Shopware\Core\Kernel"/>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
+    <testsuites>
+        <testsuite name="{{ .ClassName }} Testsuite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/internal/extension/scaffolding/stubs/plugin_class.php.tmpl
+++ b/internal/extension/scaffolding/stubs/plugin_class.php.tmpl
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace {{ .Namespace }};
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\ActivateContext;
+use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+
+class {{ .ClassName }} extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        // Do stuff such as creating a new payment method
+    }
+
+    public function uninstall(UninstallContext $uninstallContext): void
+    {
+        parent::uninstall($uninstallContext);
+
+        if ($uninstallContext->keepUserData()) {
+            return;
+        }
+
+        // Remove or deactivate the data created by the plugin
+    }
+
+    public function activate(ActivateContext $activateContext): void
+    {
+        // Activate entities, such as a new payment method
+        // Or create new entities here, because now your plugin is installed and active for sure
+    }
+
+    public function deactivate(DeactivateContext $deactivateContext): void
+    {
+        // Deactivate entities, such as a new payment method
+        // Or remove previously created entities
+    }
+
+    public function update(UpdateContext $updateContext): void
+    {
+        // Update necessary stuff, mostly non-database related
+    }
+
+    public function postInstall(InstallContext $installContext): void
+    {
+    }
+
+    public function postUpdate(UpdateContext $updateContext): void
+    {
+    }
+}

--- a/internal/extension/scaffolding/stubs/test_bootstrap.php.tmpl
+++ b/internal/extension/scaffolding/stubs/test_bootstrap.php.tmpl
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+use Shopware\Core\TestBootstrapper;
+
+$loader = (new TestBootstrapper())
+    ->addCallingPlugin()
+    ->addActivePlugins('{{ .ClassName }}')
+    ->setForceInstallPlugins(true)
+    ->bootstrap()
+    ->getClassLoader();
+
+$loader->addPsr4('{{ .Namespace }}\\Tests\\', __DIR__);


### PR DESCRIPTION
Dear gentle Reviewer, this description was not generated with AI and is here to make your life easier. I tried to keep it easy to read and short :)

## What changed?

Added a new command: `extension create`
It creates scaffolding files for a sw-plugin inside the closest sw-project.

## Implementation details
**Command flags**
- `--name`: extension name
- `--type`: can be plugin or theme (type theme is not implemented yet)
- `--store`: reflects if commercial use is intended, affects the extension parent directory. Default=false

**Interactive mode**
- runs only when any of the inputs where not provided via flag and only asks for missing information

**Input validation**
- flags get validated directly after input
- form fields use huh’s `Validate` (checked when the field is submitted / focus leaves the input).

**What happens with the provided name?**
- used as the folder name and to derive namespace, class, and composer package name
<details>
<summary>Derived values (from `--name` / form name)</summary>

This is important, because it decides if the generated plugin will be correct and the functionality of plugin:create was copied correctly.

Example: `SwagBasicExample`

| Field | How | Result | Where |
|-------|-----|--------|-------|
| `TechnicalName` | name as given | `SwagBasicExample` | unused in stubs; Go uses the raw name for the class file path `src/SwagBasicExample.php` |
| `ClassName` | same as technical name | `SwagBasicExample` | `src/SwagBasicExample.php` (`class`); `composer.json` (`shopware-plugin-class`); `phpunit.xml` (testsuite name); `tests/TestBootstrap.php` (`addActivePlugins`) |
| `Namespace` | first PascalCase word = vendor; rest concatenated as one segment | `Swag\BasicExample` | `src/SwagBasicExample.php` (`namespace`); `composer.json` (`shopware-plugin-class`, PSR-4 keys); `tests/TestBootstrap.php` (PSR-4) |
| `ComposerName` | vendor lowercased + `/` + remaining words kebab-cased | `swag/basic-example` | `composer.json` (`name`, `description`) |

**How get the values derived:** 
`splitPascalCase()` splits on uppercase letters.

</details>

**What gets generated?**

 `extension create --name SwagBasicExample`

```
<project>/custom/static-plugins/SwagBasicExample/
├── .gitignore
├── composer.json
├── phpunit.xml
├── src/
│   ├── SwagBasicExample.php
│   └── Resources/
│       └── config/
│           └── config.xml
└── tests/
    └── TestBootstrap.php
```

**How does scaffolding get generated?**
- stubs live in `internal/extension/scaffolding/stubs/*.tmpl` with placeholder values
- those templates get embedded in the binary with `//go:embed`
- the extension directory itself is created with Mkdir (not MkdirAll -> custom/plugins must already exist)
- go package `text/template` renders the placeholders with derived values from name
- files are written, then `Sync()`’d

**Command execution fails, if...**
- not inside a sw-project (nothing gets created)
- target parent (`custom/plugins`) does not exist
- target directory already exists (nothing gets created or deleted)
- generating scaffolding fails
- user cancels
- created plugin is described as not valid

**What happens, if execution fails**
- rollback: deletion of directory and content after some security constraints (not deleting root etc.)
- rollback only if *this* process created the directory
- pre-existing target dirs are never deleted
- error gets communicated to user

## Screenshot with description

<details>

<summary>Screenshots</summary>

<img width="500" alt="Screenshot_2026-09-04_15-03-59" src="https://github.com/user-attachments/assets/84a7ca55-697a-45a8-89f4-53e50b0b83cd" />

User gets asked if he intends to publish the extension on the store. This affects the location of the extension in the project directory.
<img width="500" alt="Screenshot_2026-09-04_15-04-30" src="https://github.com/user-attachments/assets/9695fd96-98ef-4ce7-a41d-45cc4ac4cf1f" />

User gets prompted for name:
<img width="500" alt="Screenshot_2026-09-04_15-06-20" src="https://github.com/user-attachments/assets/a1a0a768-a5d2-4d52-b28e-e90234655281" />

Input gets validated right after entering:
<img width="500" alt="Screenshot_2026-09-04_15-07-42" src="https://github.com/user-attachments/assets/6ab1dd79-b684-4426-9957-bcad085b0338" />

Extension gets created if input is valid. Informs user what happens.
<img width="500" alt="Screenshot_2026-09-04_15-15-52" src="https://github.com/user-attachments/assets/2a696403-71c6-4d89-ab7f-7791d5c7c8c3" />

TUI only starts when necessary, if all necessary parameters are provided, the form gets skipped:
<img width="500" alt="Screenshot_2026-09-04_15-21-36" src="https://github.com/user-attachments/assets/fec3d9c0-4fe7-40a8-90f0-25b41c15c048" />

Validation rules also apply for flags:
<img width="500" alt="Screenshot_2026-09-04_15-19-04" src="https://github.com/user-attachments/assets/c20c4595-5e52-4510-bc6a-f5a2ae6d328c" />

</details>

### Related Issue

Related to #1274