### PR TITLE
chore: retire next branch, use main only

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ on:
     tags-ignore:
       - "*"
   pull_request:
-    branches: ["main", "next"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,7 @@ Please keep PRs focused. Smaller PRs are easier to review and merge.
 
 ## Development
 
-Branch from `main` unless you work on a large feature or epic that should not
-block bug-fix releases. In that case, use a dedicated feature branch (for
-example, `next`) as the pull request target branch.
+Branch from `main` and target `main` with your pull request.
 
 Before submitting, run the relevant checks locally:
 
@@ -87,6 +85,5 @@ Maintainers may ask for changes, suggest a different direction, or decline a PR 
 
 ## Releases
 
-In general releases happen from the default `main` branch with everything included there at the time of release.
-If a feature branch (e.g. `next`) is ready for release it needs to be merged back into `main` before the release to be included.
+Releases happen from the default `main` branch with everything included there at the time of release.
 The specific release process is explained in [RELEASING.md](RELEASING.md) and done on demand by the maintainers.


### PR DESCRIPTION
## What changed?
Updates related to retiring `next` branch.

## Why?
It's retired 🤷 

## How was this tested?
Not needed.

## Related issue or discussion
Internal decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to clarify that pull requests and releases use the `main` branch.
* **Chores**
  * Automated pull request checks now run only for changes targeting `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->