### PR TITLE
Remove project name validation from user input

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -17,12 +17,6 @@ const (
 	projectNameHelp = "The name of the project directory to create (leave empty to use the current directory)"
 )
 
-// projectNameFieldDescription returns the description shown under the project
-// name input in the interactive form.
-func projectNameFieldDescription() string {
-	return projectNameHelp
-}
-
 type createOptions struct {
 	projectFolder      string
 	selectedVersion    string

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -18,16 +18,8 @@ const (
 )
 
 // projectNameFieldDescription returns the description shown under the project
-// name input in the interactive form. While the typed name is invalid it
-// returns the rule highlighted in red, validating the input live; otherwise it
-// returns the regular help text.
-func projectNameFieldDescription(name string) string {
-	if name != "" {
-		if err := shop.ValidateProjectName(name); err != nil {
-			return tui.RedText.Render(shop.ProjectNameRule)
-		}
-	}
-
+// name input in the interactive form.
+func projectNameFieldDescription() string {
 	return projectNameHelp
 }
 
@@ -119,16 +111,6 @@ var projectCreateCmd = &cobra.Command{
 
 		if opts.phpVersionExplicit {
 			if err := shop.ValidatePHPVersion(opts.phpVersion); err != nil {
-				return err
-			}
-		}
-
-		// A name passed directly as an argument skips the interactive name
-		// prompt, which is where invalid names (e.g. wrong casing) are normally
-		// rejected live. Validate it up front so it is forbidden immediately
-		// instead of only after the rest of the form has been completed.
-		if opts.projectFolder != "" {
-			if err := shop.ValidateProjectName(opts.projectFolder); err != nil {
 				return err
 			}
 		}

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -153,7 +153,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, releases []repositor
 				huh.NewInput().
 					Title("Project Name").
 					DescriptionFunc(func() string {
-						return projectNameFieldDescription(opts.projectFolder)
+						return projectNameFieldDescription()
 					}, &opts.projectFolder).
 					Placeholder("my-shopware-project (leave empty for current directory)").
 					Value(&opts.projectFolder).

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -153,7 +153,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, releases []repositor
 				huh.NewInput().
 					Title("Project Name").
 					DescriptionFunc(func() string {
-						return projectNameFieldDescription()
+						return projectNameHelp
 					}, &opts.projectFolder).
 					Placeholder("my-shopware-project (leave empty for current directory)").
 					Value(&opts.projectFolder).

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -152,9 +152,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, releases []repositor
 			formGroups = append(formGroups, huh.NewGroup(
 				huh.NewInput().
 					Title("Project Name").
-					DescriptionFunc(func() string {
-						return projectNameHelp
-					}, &opts.projectFolder).
+					Description(projectNameHelp).
 					Placeholder("my-shopware-project (leave empty for current directory)").
 					Value(&opts.projectFolder).
 					Validate(func(s string) error {

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -4,52 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/shopware/shopware-cli/internal/shop"
 )
-
-func TestProjectCreateRejectsInvalidNameArgument(t *testing.T) {
-	// A name provided directly as an argument must be rejected up front,
-	// before the interactive form or any network call, the same way the
-	// interactive name prompt rejects it live.
-	invalidNames := []string{"myShop", "MyShop", "müller", "my shop"}
-
-	for _, name := range invalidNames {
-		t.Run(name, func(t *testing.T) {
-			projectCreateCmd.SetContext(t.Context())
-			err := projectCreateCmd.RunE(projectCreateCmd, []string{name})
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid project name")
-		})
-	}
-}
 
 func TestProjectNameFieldDescription(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty shows help text", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, projectNameHelp, projectNameFieldDescription(""))
-	})
-
-	t.Run("valid name shows help text", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, projectNameHelp, projectNameFieldDescription("my-shop"))
-	})
-
-	t.Run("uppercase name shows the rule", func(t *testing.T) {
-		t.Parallel()
-		desc := projectNameFieldDescription("MyShop")
-		assert.NotEqual(t, projectNameHelp, desc)
-		assert.Contains(t, desc, shop.ProjectNameRule)
-	})
-
-	t.Run("umlaut name shows the rule", func(t *testing.T) {
-		t.Parallel()
-		desc := projectNameFieldDescription("müller")
-		assert.NotEqual(t, projectNameHelp, desc)
-		assert.Contains(t, desc, shop.ProjectNameRule)
-	})
+	assert.Equal(t, projectNameHelp, projectNameFieldDescription())
 }
 
 func TestApplyNonInteractiveDefaults(t *testing.T) {

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProjectNameFieldDescription(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, projectNameHelp, projectNameFieldDescription())
-}
-
 func TestApplyNonInteractiveDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shop/compose_project_name.go
+++ b/internal/shop/compose_project_name.go
@@ -17,10 +17,10 @@ const ComposeProjectNameEnvKey = "COMPOSE_PROJECT_NAME"
 
 var nonComposeNameChars = regexp.MustCompile(`[^a-z0-9_-]+`)
 
-// GenerateComposeProjectName builds a unique Compose project name that satisfies
-// ProjectNameRule / ValidateProjectName. Format: sw-<basename>-<6 hex>.
-// The random suffix avoids volume reuse when a directory is deleted and
-// recreated with the same basename.
+// GenerateComposeProjectName builds a unique Compose project name.
+// Format: sw-<basename>-<6 hex>. The random suffix avoids volume reuse when a
+// directory is deleted and recreated with the same basename. The generated name
+// is a valid Compose project name by construction.
 func GenerateComposeProjectName(projectFolder string) (string, error) {
 	base := strings.ToLower(filepath.Base(projectFolder))
 	if base == "" || base == "." || base == string(filepath.Separator) {
@@ -32,7 +32,6 @@ func GenerateComposeProjectName(projectFolder string) (string, error) {
 	if base == "" {
 		base = "shop"
 	}
-	// Note: the "sw-" prefix already satisfies ValidateProjectName's leading-character rule.
 
 	var suffix [3]byte
 	if _, err := rand.Read(suffix[:]); err != nil {
@@ -40,9 +39,6 @@ func GenerateComposeProjectName(projectFolder string) (string, error) {
 	}
 
 	name := fmt.Sprintf("sw-%s-%s", base, hex.EncodeToString(suffix[:]))
-	if err := ValidateProjectName(name); err != nil {
-		return "", err
-	}
 
 	return name, nil
 }

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -35,6 +35,12 @@ func TestGenerateComposeProjectName(t *testing.T) {
 	fancy, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "München Shop"))
 	require.NoError(t, err)
 	assert.Regexp(t, regexp.MustCompile(`^sw-m-nchen-shop-[0-9a-f]{6}$`), fancy)
+
+	// camelCase folder names are lowercased into a valid Compose project name.
+	camel, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "myShopwareProject"))
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`^sw-myshopwareproject-[0-9a-f]{6}$`), camel)
+	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), camel)
 }
 
 func TestEnvFileContent(t *testing.T) {

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -34,7 +34,7 @@ func TestGenerateComposeProjectName(t *testing.T) {
 	// accepted and still yield a valid Compose project name.
 	fancy, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "München Shop"))
 	require.NoError(t, err)
-	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), fancy)
+	assert.Regexp(t, regexp.MustCompile(`^sw-m-nchen-shop-[0-9a-f]{6}$`), fancy)
 }
 
 func TestEnvFileContent(t *testing.T) {

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -17,7 +17,7 @@ func TestGenerateComposeProjectName(t *testing.T) {
 	name, err := GenerateComposeProjectName("/tmp/my-shop")
 	require.NoError(t, err)
 	assert.Regexp(t, regexp.MustCompile(`^sw-my-shop-[0-9a-f]{6}$`), name)
-	assert.NoError(t, ValidateProjectName(name))
+	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), name)
 
 	// Same basename must still differ (random suffix).
 	name2, err := GenerateComposeProjectName("/other/my-shop")
@@ -28,7 +28,7 @@ func TestGenerateComposeProjectName(t *testing.T) {
 	weird, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "My Shop!"))
 	require.NoError(t, err)
 	assert.Regexp(t, regexp.MustCompile(`^sw-my-shop-[0-9a-f]{6}$`), weird)
-	assert.NoError(t, ValidateProjectName(weird))
+	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), weird)
 }
 
 func TestEnvFileContent(t *testing.T) {
@@ -47,7 +47,7 @@ func TestEnvFileContent(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(content, ComposeProjectNameEnvKey+"=sw-demo-shop-"))
 		assert.True(t, strings.HasSuffix(content, "\n"))
-		assert.NoError(t, ValidateProjectName(strings.TrimPrefix(strings.TrimSpace(content), ComposeProjectNameEnvKey+"=")))
+		assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), strings.TrimPrefix(strings.TrimSpace(content), ComposeProjectNameEnvKey+"="))
 	})
 }
 

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -29,6 +29,12 @@ func TestGenerateComposeProjectName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Regexp(t, regexp.MustCompile(`^sw-my-shop-[0-9a-f]{6}$`), weird)
 	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), weird)
+
+	// Regression: user-facing names with uppercase, spaces and umlauts are
+	// accepted and still yield a valid Compose project name.
+	fancy, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "München Shop"))
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), fancy)
 }
 
 func TestEnvFileContent(t *testing.T) {

--- a/internal/shop/project_creation.go
+++ b/internal/shop/project_creation.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -15,36 +13,10 @@ import (
 
 const (
 	VersionLatest = "latest"
-
-	// ProjectNameRule describes project names that can also be used as Docker
-	// Compose project names.
-	ProjectNameRule = "only lowercase letters, digits, dashes (-) and underscores (_) are allowed, and it must start with a lowercase letter or digit"
 )
 
-var projectNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
-
-// ValidateProjectName ensures the final path element can be used as a Docker
-// Compose project name. The special value "." is always allowed.
-func ValidateProjectName(name string) error {
-	if name == "." {
-		return nil
-	}
-
-	base := filepath.Base(name)
-	if !projectNameRegexp.MatchString(base) {
-		return fmt.Errorf("invalid project name %q: %s, so it can be used as a Docker Compose project name", base, ProjectNameRule)
-	}
-
-	return nil
-}
-
-// ValidateProjectFolder ensures the project name is valid and that an existing
-// target is an empty directory.
+// ValidateProjectFolder ensures that an existing target is an empty directory.
 func ValidateProjectFolder(projectFolder string) error {
-	if err := ValidateProjectName(projectFolder); err != nil {
-		return err
-	}
-
 	info, err := os.Stat(projectFolder)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil

--- a/internal/shop/project_creation_test.go
+++ b/internal/shop/project_creation_test.go
@@ -103,6 +103,13 @@ func TestValidateProjectFolder(t *testing.T) {
 		assert.NoError(t, ValidateProjectFolder(projectFolder))
 	})
 
+	t.Run("accepts a camelCase name", func(t *testing.T) {
+		t.Parallel()
+		projectFolder := filepath.Join(t.TempDir(), "myShopwareProject")
+		require.NoError(t, os.MkdirAll(projectFolder, 0o755))
+		assert.NoError(t, ValidateProjectFolder(projectFolder))
+	})
+
 	t.Run("rejects a non-empty folder", func(t *testing.T) {
 		t.Parallel()
 		projectFolder := filepath.Join(t.TempDir(), "shop")

--- a/internal/shop/project_creation_test.go
+++ b/internal/shop/project_creation_test.go
@@ -81,62 +81,8 @@ func TestResolveInstallVersion(t *testing.T) {
 	}
 }
 
-func TestValidateProjectName(t *testing.T) {
-	t.Parallel()
-
-	validNames := []string{
-		"my-shopware-project",
-		"myshop",
-		"my_shop",
-		"shop123",
-		"123shop",
-		"a",
-		"path/to/my-shop",
-		".",
-	}
-	for _, name := range validNames {
-		t.Run("valid: "+name, func(t *testing.T) {
-			t.Parallel()
-			assert.NoError(t, ValidateProjectName(name))
-		})
-	}
-
-	invalidNames := []string{
-		"MyShop",
-		"myShop",
-		"SHOP",
-		"müller",
-		"über-shop",
-		"Müller-Shop",
-		"café",
-		"straße",
-		"my shop",
-		"my.shop",
-		"shop!",
-		"-shop",
-		"_shop",
-		"ä",
-		"",
-		"path/to/müller",
-		"path/to/MyShop",
-	}
-	for _, name := range invalidNames {
-		t.Run("invalid: "+name, func(t *testing.T) {
-			t.Parallel()
-			err := ValidateProjectName(name)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid project name")
-		})
-	}
-}
-
 func TestValidateProjectFolder(t *testing.T) {
 	t.Parallel()
-
-	t.Run("rejects an invalid project name", func(t *testing.T) {
-		t.Parallel()
-		assert.ErrorContains(t, ValidateProjectFolder(filepath.Join(t.TempDir(), "MyShop")), "invalid project name")
-	})
 
 	t.Run("accepts a missing folder", func(t *testing.T) {
 		t.Parallel()

--- a/internal/shop/project_creation_test.go
+++ b/internal/shop/project_creation_test.go
@@ -96,6 +96,13 @@ func TestValidateProjectFolder(t *testing.T) {
 		assert.NoError(t, ValidateProjectFolder(projectFolder))
 	})
 
+	t.Run("accepts a user-facing name with uppercase, spaces and umlauts", func(t *testing.T) {
+		t.Parallel()
+		projectFolder := filepath.Join(t.TempDir(), "München Shop")
+		require.NoError(t, os.MkdirAll(projectFolder, 0o755))
+		assert.NoError(t, ValidateProjectFolder(projectFolder))
+	})
+
 	t.Run("rejects a non-empty folder", func(t *testing.T) {
 		t.Parallel()
 		projectFolder := filepath.Join(t.TempDir(), "shop")

--- a/internal/shop/project_scaffold_test.go
+++ b/internal/shop/project_scaffold_test.go
@@ -3,6 +3,7 @@ package shop
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -71,7 +72,7 @@ func TestShopwareProjectScaffold(t *testing.T) {
 		assert.True(t, strings.HasPrefix(envContent, ComposeProjectNameEnvKey+"=sw-demo-shop-"), "got %q", envContent)
 		assert.True(t, strings.HasSuffix(envContent, "\n"))
 		name := strings.TrimPrefix(strings.TrimSpace(envContent), ComposeProjectNameEnvKey+"=")
-		assert.NoError(t, ValidateProjectName(name))
+		assert.Regexp(t, regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`), name)
 
 		// Two docker scaffolds with the same basename get different compose names.
 		projectFolder2 := filepath.Join(t.TempDir(), "demo-shop")


### PR DESCRIPTION
## What changed?

Removed the `ValidateProjectName` function and `ProjectNameRule` constant that enforced Docker Compose naming rules on user-provided project names. This validation is no longer applied to:
- Project names passed as CLI arguments
- Project names entered in the interactive form
- Project folder validation

The generated Compose project name (via `GenerateComposeProjectName`) continues to produce valid names by construction, without needing explicit validation.

## Why?

The validation was overly restrictive for user input. Users should be able to name their project directories however they want (e.g., "MyShop", "my shop", "müller"). The actual Compose project name is generated separately and is guaranteed to be valid by its construction algorithm (prefixed with "sw-", lowercased, with special characters replaced). There's no need to constrain user-facing directory names to Docker Compose naming rules.

## How was this tested?

- Removed `TestValidateProjectName` test (54 lines)
- Removed `TestProjectCreateRejectsInvalidNameArgument` test (16 lines)
- Removed `TestProjectNameFieldDescription` test (24 lines)
- Updated `TestGenerateComposeProjectName` to verify output format via regex instead of calling the removed validation function
- Updated `TestEnvFileContent` and `TestShopwareProjectScaffold` to verify Compose names via regex patterns
- Existing `TestValidateProjectFolder` test updated to remove the invalid name rejection check
- All remaining tests pass with the validation logic removed

## Related issue or discussion

fixes #1420

https://claude.ai/code/session_015As3RHHxxoUSxRBjNFKehZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Project creation now accepts names with uppercase letters, spaces, and accented characters.
  - Previous name restrictions no longer block project creation.
  - Interactive project-name guidance is now static.
  - Project folders are still checked for existence and emptiness.
  - Automatically generated Compose project names remain limited to lowercase letters, numbers, underscores, and hyphens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->