### PR TITLE
feat(project): add --file flag to project sql

### DIFF
--- a/cmd/project/project_sql.go
+++ b/cmd/project/project_sql.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -39,6 +40,10 @@ var projectSQLCmd = &cobra.Command{
 			return err
 		}
 
+		if err := errIfNoSQLInput(cmd.Context(), provided); err != nil {
+			return err
+		}
+
 		conn, dbConn, cleanup, err := connectProjectDatabase(cmd)
 		if err != nil {
 			return err
@@ -47,10 +52,6 @@ var projectSQLCmd = &cobra.Command{
 
 		if provided {
 			return sqlshell.Run(cmd.Context(), conn, script, cmd.OutOrStdout(), format)
-		}
-
-		if !system.IsInteractionEnabled(cmd.Context()) {
-			return errors.New("no query given and interaction is disabled, pass a query as argument, use --file, or pipe a script via stdin")
 		}
 
 		logging.FromContext(cmd.Context()).Infof("Connected to database %q at %s. Type \"exit\" or press Ctrl+D to quit.", dbConn.Database, dbConn.Addr())
@@ -93,6 +94,14 @@ func resolveSQLInput(cmd *cobra.Command, args []string) (string, bool, error) {
 	}
 
 	return "", false, nil
+}
+
+func errIfNoSQLInput(ctx context.Context, provided bool) error {
+	if provided || system.IsInteractionEnabled(ctx) {
+		return nil
+	}
+
+	return errors.New("no query given and interaction is disabled, pass a query as argument, use --file, or pipe a script via stdin")
 }
 
 func resolveSQLFormat(cmd *cobra.Command) (sqlshell.Format, error) {

--- a/cmd/project/project_sql.go
+++ b/cmd/project/project_sql.go
@@ -40,7 +40,7 @@ var projectSQLCmd = &cobra.Command{
 			return err
 		}
 
-		if err := errIfNoSQLInput(cmd.Context(), provided); err != nil {
+		if err := errIfNoSQLInput(cmd.Context(), provided, isTerminalStream(cmd.InOrStdin())); err != nil {
 			return err
 		}
 
@@ -90,14 +90,16 @@ func resolveSQLInput(cmd *cobra.Command, args []string) (string, bool, error) {
 			return "", false, err
 		}
 
-		return string(content), true, nil
+		script := string(content)
+
+		return script, strings.TrimSpace(script) != "", nil
 	}
 
 	return "", false, nil
 }
 
-func errIfNoSQLInput(ctx context.Context, provided bool) error {
-	if provided || system.IsInteractionEnabled(ctx) {
+func errIfNoSQLInput(ctx context.Context, provided, canOpenShell bool) error {
+	if provided || (canOpenShell && system.IsInteractionEnabled(ctx)) {
 		return nil
 	}
 

--- a/cmd/project/project_sql.go
+++ b/cmd/project/project_sql.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -19,9 +20,10 @@ var projectSQLCmd = &cobra.Command{
 	Short: "Run SQL queries against the project database",
 	Long: "Connects to the project database using the connection details of the current environment (local, docker, ...), " +
 		"so you don't need to know the host or credentials. " +
-		"Without arguments an interactive SQL shell is opened; a query can be passed as argument or a script piped via stdin.",
+		"Without arguments an interactive SQL shell is opened; a query can be passed as argument, loaded with --file, or a script piped via stdin.",
 	Example: `  shopware-cli project sql "SELECT id, tax_rate FROM tax"
   shopware-cli project sql --format json "SELECT * FROM sales_channel" | jq
+  shopware-cli project sql --file script.sql
   shopware-cli project sql < script.sql
   shopware-cli project sql`,
 	Args:         cobra.ArbitraryArgs,
@@ -32,33 +34,65 @@ var projectSQLCmd = &cobra.Command{
 			return err
 		}
 
+		script, provided, err := resolveSQLInput(cmd, args)
+		if err != nil {
+			return err
+		}
+
 		conn, dbConn, cleanup, err := connectProjectDatabase(cmd)
 		if err != nil {
 			return err
 		}
 		defer cleanup()
 
-		if len(args) > 0 {
-			return sqlshell.Run(cmd.Context(), conn, strings.Join(args, " "), cmd.OutOrStdout(), format)
-		}
-
-		if !isTerminalStream(cmd.InOrStdin()) {
-			script, err := io.ReadAll(cmd.InOrStdin())
-			if err != nil {
-				return err
-			}
-
-			return sqlshell.Run(cmd.Context(), conn, string(script), cmd.OutOrStdout(), format)
+		if provided {
+			return sqlshell.Run(cmd.Context(), conn, script, cmd.OutOrStdout(), format)
 		}
 
 		if !system.IsInteractionEnabled(cmd.Context()) {
-			return errors.New("no query given and interaction is disabled, pass a query as argument or pipe a script via stdin")
+			return errors.New("no query given and interaction is disabled, pass a query as argument, use --file, or pipe a script via stdin")
 		}
 
 		logging.FromContext(cmd.Context()).Infof("Connected to database %q at %s. Type \"exit\" or press Ctrl+D to quit.", dbConn.Database, dbConn.Addr())
 
 		return sqlshell.InteractiveShell(cmd.Context(), conn, format)
 	},
+}
+
+// resolveSQLInput returns the SQL to execute and whether a script was
+// provided. When provided is false, the caller should open the interactive
+// shell (or error if interaction is disabled). --file, a query argument and
+// stdin are mutually exclusive sources; --file wins over stdin, and combining
+// --file with a query argument is an error.
+func resolveSQLInput(cmd *cobra.Command, args []string) (string, bool, error) {
+	file, _ := cmd.Flags().GetString("file")
+	if file != "" {
+		if len(args) > 0 {
+			return "", false, errors.New("cannot pass a query together with --file")
+		}
+
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to read SQL file %q: %w", file, err)
+		}
+
+		return string(content), true, nil
+	}
+
+	if len(args) > 0 {
+		return strings.Join(args, " "), true, nil
+	}
+
+	if !isTerminalStream(cmd.InOrStdin()) {
+		content, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", false, err
+		}
+
+		return string(content), true, nil
+	}
+
+	return "", false, nil
 }
 
 func resolveSQLFormat(cmd *cobra.Command) (sqlshell.Format, error) {
@@ -86,4 +120,5 @@ func isTerminalStream(stream any) bool {
 func init() {
 	projectRootCmd.AddCommand(projectSQLCmd)
 	projectSQLCmd.Flags().String("format", "", "output format: table, tsv, json (default: table when stdout is a terminal, tsv otherwise)")
+	projectSQLCmd.Flags().String("file", "", "path to a SQL file to execute (instead of a query argument or stdin)")
 }

--- a/cmd/project/project_sql_test.go
+++ b/cmd/project/project_sql_test.go
@@ -132,6 +132,21 @@ func TestResolveSQLInputFromStdin(t *testing.T) {
 	assert.Equal(t, "INSERT INTO tax (tax_rate) VALUES (7)", script)
 }
 
+func TestResolveSQLInputEmptyStdinIsMissing(t *testing.T) {
+	for _, stdin := range []string{"", "  \n\t"} {
+		cmd := newSQLCommand(t, "", "")
+		cmd.SetIn(strings.NewReader(stdin))
+
+		script, provided, err := resolveSQLInput(cmd, nil)
+		require.NoError(t, err, "stdin %q", stdin)
+		assert.False(t, provided, "stdin %q", stdin)
+		assert.Equal(t, stdin, script)
+
+		err = errIfNoSQLInput(system.WithInteraction(t.Context(), false), provided, isTerminalStream(cmd.InOrStdin()))
+		assert.ErrorContains(t, err, "no query given and interaction is disabled", "stdin %q", stdin)
+	}
+}
+
 func TestProjectSQLCmdRegistersFileFlag(t *testing.T) {
 	flag := projectSQLCmd.Flags().Lookup("file")
 	require.NotNil(t, flag)
@@ -139,10 +154,13 @@ func TestProjectSQLCmdRegistersFileFlag(t *testing.T) {
 }
 
 func TestErrIfNoSQLInput(t *testing.T) {
-	assert.NoError(t, errIfNoSQLInput(t.Context(), true))
-	assert.NoError(t, errIfNoSQLInput(t.Context(), false))
-	assert.NoError(t, errIfNoSQLInput(system.WithInteraction(t.Context(), false), true))
+	assert.NoError(t, errIfNoSQLInput(t.Context(), true, false))
+	assert.NoError(t, errIfNoSQLInput(t.Context(), false, true))
+	assert.NoError(t, errIfNoSQLInput(system.WithInteraction(t.Context(), false), true, true))
 
-	err := errIfNoSQLInput(system.WithInteraction(t.Context(), false), false)
+	err := errIfNoSQLInput(system.WithInteraction(t.Context(), false), false, true)
+	assert.ErrorContains(t, err, "no query given and interaction is disabled")
+
+	err = errIfNoSQLInput(t.Context(), false, false)
 	assert.ErrorContains(t, err, "no query given and interaction is disabled")
 }

--- a/cmd/project/project_sql_test.go
+++ b/cmd/project/project_sql_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/sqlshell"
+	"github.com/shopware/shopware-cli/internal/system"
 )
 
 func newSQLFormatCommand(t *testing.T, formatFlag string) *cobra.Command {
@@ -135,4 +136,13 @@ func TestProjectSQLCmdRegistersFileFlag(t *testing.T) {
 	flag := projectSQLCmd.Flags().Lookup("file")
 	require.NotNil(t, flag)
 	assert.Equal(t, "path to a SQL file to execute (instead of a query argument or stdin)", flag.Usage)
+}
+
+func TestErrIfNoSQLInput(t *testing.T) {
+	assert.NoError(t, errIfNoSQLInput(t.Context(), true))
+	assert.NoError(t, errIfNoSQLInput(t.Context(), false))
+	assert.NoError(t, errIfNoSQLInput(system.WithInteraction(t.Context(), false), true))
+
+	err := errIfNoSQLInput(system.WithInteraction(t.Context(), false), false)
+	assert.ErrorContains(t, err, "no query given and interaction is disabled")
 }

--- a/cmd/project/project_sql_test.go
+++ b/cmd/project/project_sql_test.go
@@ -17,12 +17,23 @@ import (
 func newSQLFormatCommand(t *testing.T, formatFlag string) *cobra.Command {
 	t.Helper()
 
+	return newSQLCommand(t, formatFlag, "")
+}
+
+func newSQLCommand(t *testing.T, formatFlag, fileFlag string) *cobra.Command {
+	t.Helper()
+
 	cmd := &cobra.Command{}
 	cmd.Flags().String("format", "", "")
+	cmd.Flags().String("file", "", "")
 	cmd.SetOut(&bytes.Buffer{})
 
 	if formatFlag != "" {
 		require.NoError(t, cmd.Flags().Set("format", formatFlag))
+	}
+
+	if fileFlag != "" {
+		require.NoError(t, cmd.Flags().Set("file", fileFlag))
 	}
 
 	return cmd
@@ -58,4 +69,70 @@ func TestIsTerminalStream(t *testing.T) {
 	defer func() { _ = file.Close() }()
 
 	assert.False(t, isTerminalStream(file), "a regular file is not a terminal")
+}
+
+func TestResolveSQLInputFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "script.sql")
+	require.NoError(t, os.WriteFile(path, []byte("SELECT 1;\nUPDATE tax SET tax_rate = 19;"), 0o644))
+
+	script, provided, err := resolveSQLInput(newSQLCommand(t, "", path), nil)
+	require.NoError(t, err)
+
+	assert.True(t, provided)
+	assert.Equal(t, "SELECT 1;\nUPDATE tax SET tax_rate = 19;", script)
+}
+
+func TestResolveSQLInputFileIgnoresStdin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "script.sql")
+	require.NoError(t, os.WriteFile(path, []byte("SELECT id FROM tax"), 0o644))
+
+	cmd := newSQLCommand(t, "", path)
+	cmd.SetIn(strings.NewReader("SELECT * FROM product"))
+
+	script, provided, err := resolveSQLInput(cmd, nil)
+	require.NoError(t, err)
+
+	assert.True(t, provided)
+	assert.Equal(t, "SELECT id FROM tax", script)
+}
+
+func TestResolveSQLInputFileAndQueryConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "script.sql")
+	require.NoError(t, os.WriteFile(path, []byte("SELECT 1"), 0o644))
+
+	_, _, err := resolveSQLInput(newSQLCommand(t, "", path), []string{"SELECT 2"})
+	assert.ErrorContains(t, err, "cannot pass a query together with --file")
+}
+
+func TestResolveSQLInputMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.sql")
+
+	_, _, err := resolveSQLInput(newSQLCommand(t, "", path), nil)
+	assert.ErrorContains(t, err, "failed to read SQL file")
+	assert.ErrorContains(t, err, path)
+}
+
+func TestResolveSQLInputFromArgs(t *testing.T) {
+	script, provided, err := resolveSQLInput(newSQLCommand(t, "", ""), []string{"SELECT", "id", "FROM", "tax"})
+	require.NoError(t, err)
+
+	assert.True(t, provided)
+	assert.Equal(t, "SELECT id FROM tax", script)
+}
+
+func TestResolveSQLInputFromStdin(t *testing.T) {
+	cmd := newSQLCommand(t, "", "")
+	cmd.SetIn(strings.NewReader("INSERT INTO tax (tax_rate) VALUES (7)"))
+
+	script, provided, err := resolveSQLInput(cmd, nil)
+	require.NoError(t, err)
+
+	assert.True(t, provided)
+	assert.Equal(t, "INSERT INTO tax (tax_rate) VALUES (7)", script)
+}
+
+func TestProjectSQLCmdRegistersFileFlag(t *testing.T) {
+	flag := projectSQLCmd.Flags().Lookup("file")
+	require.NotNil(t, flag)
+	assert.Equal(t, "path to a SQL file to execute (instead of a query argument or stdin)", flag.Usage)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?
`project sql` now accepts `--file` to execute a SQL script from disk, as an alternative to a query argument or piping via stdin.

```bash
shopware-cli project sql --file script.sql
shopware-cli project sql --file script.sql --format json
```

`--file` cannot be combined with a query argument. A missing file is reported before the database connection is opened.

In `--no-interaction` mode without a query, `--file`, or a non-empty stdin script, the command returns the missing-input error before connecting to the database. Empty or whitespace-only stdin is treated as missing SQL.

## Why?
Importing a script currently requires `shopware-cli project sql < script.sql`. A `--file` flag is more discoverable and works in contexts where stdin redirection is awkward.

## How was this tested?
- Unit tests for `--file` resolution, conflict with a query argument, missing file, stdin, empty stdin, query args, and the non-interactive missing-input guard (`go test ./cmd/project/ ./internal/sqlshell/`)
- Built the CLI and verified `project sql --help` lists `--file`
- Smoke-tested error paths: missing file, `--file` plus a query argument, and a valid `--file` in a directory that is not a Shopware project

## Related issue or discussion
Requested as a `--file` flag on `project sql` to import a SQL file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c59f12b-91a4-4cec-a565-4353d6b18c71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c59f12b-91a4-4cec-a565-4353d6b18c71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running SQL scripts from a file with the `--file` option.
  * Improved SQL input handling from files, query arguments, standard input, and interactive mode.
  * Updated command help to explain the new option and input behavior.
* **Bug Fixes**
  * Added validation when both a file and query are provided.
  * Added clearer errors for unreadable files and missing SQL input.
  * Empty standard input is now correctly treated as missing input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->