### PR TITLE
fix(project): stop writing the deprecated top-level url on create

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -75,3 +75,91 @@ jobs:
         uses: shopwareLabs/build-project-action@88233d3fdb6b4b6ad7085c45210085c51b727d82 # ratchet:shopwareLabs/build-project-action@main
         with:
           path: shopware
+
+  docker-project:
+    name: Docker project create and dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # ratchet:step-security/harden-runner@v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v7.0.0
+        with:
+          go-version: '1.27'
+          cache: true
+          check-latest: true
+
+      - name: Compile shopware-cli
+        run: go build
+
+      - name: Move to usr/bin
+        run: mv shopware-cli /usr/local/bin/
+
+      # A Docker project gets its PHP from the image, so no PHP is set up here:
+      # needing one on the runner would mean the executor picked the wrong type.
+      - name: Create Docker project
+        run: shopware-cli project create --docker --no-audit shopware-docker
+
+      # The top-level url is deprecated and, while set, used to override
+      # environments.local — which is what selects the executor.
+      - name: Project config targets environments.local only
+        working-directory: shopware-docker
+        run: |
+          cat .shopware-project.yml
+          grep -q 'type: docker' .shopware-project.yml
+          # A top-level url sits at column 0; the environment one is indented.
+          if grep -q '^url:' .shopware-project.yml; then
+            echo "::error::project create wrote a deprecated top-level url"
+            exit 1
+          fi
+
+      - name: Commands do not warn about deprecated config keys
+        working-directory: shopware-docker
+        run: |
+          shopware-cli project dev status 2>&1 | tee status.log || true
+          if grep -qi 'deprecated top-level' status.log; then
+            echo "::error::a freshly created project warns about deprecated config keys"
+            exit 1
+          fi
+
+      - name: Start the development environment
+        working-directory: shopware-docker
+        run: shopware-cli project dev start
+
+      - name: Development environment reports up
+        working-directory: shopware-docker
+        run: shopware-cli project dev status
+
+      - name: Shop responds over HTTP
+        working-directory: shopware-docker
+        run: |
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://127.0.0.1:8000/admin || true)
+            echo "attempt $i: HTTP $code"
+            case "$code" in
+              200|301|302) exit 0 ;;
+            esac
+            sleep 5
+          done
+          echo "::error::shop did not respond on http://127.0.0.1:8000/admin"
+          docker compose ps
+          docker compose logs --tail=100 web
+          exit 1
+
+      - name: Stop the development environment
+        working-directory: shopware-docker
+        run: shopware-cli project dev stop --remove-data
+
+      - name: Development environment reports down
+        working-directory: shopware-docker
+        run: |
+          if shopware-cli project dev status; then
+            echo "::error::dev status must exit non-zero after stop"
+            exit 1
+          fi

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -84,11 +84,10 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 	}
 
 	// Serve the shop at a stable hostname through the shared proxy instead of a
-	// port. The top-level url drives proxy hostname derivation; the environment
-	// url is what `project dev` shows and installs with.
+	// port. Only the environment url is written: the deprecated top-level url
+	// would warn on every later command and override environments.local.
 	if opts.useDocker && opts.useLocalDomain {
 		url := "https://" + proxy.LocalDomainHostname(opts.projectFolder, proxy.BaseDomain())
-		shopCfg.URL = url
 		if env := shopCfg.Environments["local"]; env != nil {
 			env.URL = url
 		}

--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"charm.land/huh/v2/spinner"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
@@ -303,15 +302,14 @@ func (e *devEnvironment) stop(cmd *cobra.Command, opts executor.StopOptions) err
 		title = "Stopping development environment and removing data..."
 	}
 
-	err := spinner.New().
-		Title(title).
-		Context(cmd.Context()).
-		ActionWithErr(func(ctx context.Context) error {
-			return e.executor.StopEnvironment(ctx, opts)
-		}).
-		Run()
+	// runStep drops the spinner when there is no interactive terminal, so
+	// `project dev stop` also works headless (CI, an agent, a pipe with no
+	// /dev/tty) — matching start.
+	stop := func(ctx context.Context) error {
+		return e.executor.StopEnvironment(ctx, opts)
+	}
 
-	if err != nil {
+	if err := runStep(cmd.Context(), title, stop); err != nil {
 		return fmt.Errorf("stopping environment: %w", err)
 	}
 

--- a/cmd/project/project_env_resolution_test.go
+++ b/cmd/project/project_env_resolution_test.go
@@ -75,7 +75,7 @@ environments:
 	})
 }
 
-func TestNoEnvFlagKeepsBaseConfig(t *testing.T) {
+func TestNoEnvFlagPrefersLocalEnvironmentOverTopLevel(t *testing.T) {
 	clearShopClientEnv(t)
 	t.Setenv("PROJECT_ROOT", t.TempDir())
 
@@ -104,9 +104,10 @@ environments:
 
 	err := projectExtensionListCmd.RunE(projectExtensionListCmd, []string{})
 	require.Error(t, err)
-	// Deprecation-window compatibility: mixed files keep the top-level shop.
-	assert.Contains(t, err.Error(), "127.0.0.1:9", "without -e the base URL must be used")
-	assert.NotContains(t, err.Error(), "127.0.0.1:7", "environments.local must not silently retarget commands")
+	// environments.local is what the empty -e selects; the deprecated
+	// top-level url only fills in what it leaves unset.
+	assert.Contains(t, err.Error(), "127.0.0.1:7", "without -e environments.local must be used")
+	assert.NotContains(t, err.Error(), "127.0.0.1:9", "the deprecated top-level url must not override environments.local")
 }
 
 func TestNoEnvFlagUsesLocalWhenNoTopLevel(t *testing.T) {

--- a/internal/proxy/hostname.go
+++ b/internal/proxy/hostname.go
@@ -13,16 +13,17 @@ import (
 )
 
 // ProjectHostname derives the hostname a project should be reachable at
-// through the shared proxy. If cfg.URL is explicitly set in
-// .shopware-project.yml, its host is used as an override — unless it is an
-// IP address or localhost, which is what freshly created projects point at
+// through the shared proxy. If a url is explicitly set in
+// .shopware-project.yml (environments.local.url, or the deprecated top-level
+// url), its host is used as an override — unless it is an IP address or
+// localhost, which is what freshly created projects point at
 // (http://127.0.0.1:8000) and never a usable proxy hostname. Otherwise the
 // hostname is derived from the project directory name.
 func ProjectHostname(projectRoot string, cfg *shop.Config, baseDomain string) (string, error) {
-	if cfg != nil && cfg.URL != "" {
-		parsed, err := url.Parse(cfg.URL)
+	if configured := cfg.EffectiveURL(); configured != "" {
+		parsed, err := url.Parse(configured)
 		if err != nil {
-			return "", fmt.Errorf("parsing configured url %q: %w", cfg.URL, err)
+			return "", fmt.Errorf("parsing configured url %q: %w", configured, err)
 		}
 
 		if host := parsed.Hostname(); host != "" && host != "localhost" && net.ParseIP(host) == nil {

--- a/internal/proxy/infra.go
+++ b/internal/proxy/infra.go
@@ -150,12 +150,9 @@ func IsProxyProjectForDomain(cfg *shop.Config, baseDomain string) bool {
 		return false
 	}
 
-	// The local environment's url overrides the top-level one in the executor,
-	// so honor the same precedence when detecting proxy mode.
-	effective := cfg.URL
-	if env, ok := cfg.Environments["local"]; ok && env != nil && env.URL != "" {
-		effective = env.URL
-	}
+	// Resolve the url the same way the executor does, so proxy detection and
+	// the executor never disagree about which url the project serves.
+	effective := cfg.EffectiveURL()
 
 	if effective == "" {
 		return false

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -55,10 +55,10 @@ type Config struct {
 	foundConfig            bool
 }
 
-// ResolveEnvironment returns the named environment. An empty name uses the
-// deprecated top-level url/admin_api when either is set, otherwise
-// environments.local. Mixed files are not silently retargeted during the
-// deprecation window.
+// ResolveEnvironment returns the named environment. An empty name uses
+// environments.local; the deprecated top-level url/admin_api only fill in what
+// that environment does not set, so a mixed file never loses the environment's
+// type (which selects the executor) or its url.
 func (c *Config) ResolveEnvironment(name string) (*EnvironmentConfig, error) {
 	if name != "" {
 		env, ok := c.Environments[name]
@@ -71,23 +71,54 @@ func (c *Config) ResolveEnvironment(name string) (*EnvironmentConfig, error) {
 		return env, nil
 	}
 
-	if c.URL != "" || c.AdminApi != nil {
-		return c.topLevelEnvironment(), nil
+	local, ok := c.Environments["local"]
+	if !ok || local == nil {
+		return c.topLevelEnvironment(nil), nil
 	}
 
-	if env, ok := c.Environments["local"]; ok && env != nil {
-		return env, nil
+	if !c.HasDeprecatedTopLevelShop() {
+		return local, nil
 	}
 
-	return c.topLevelEnvironment(), nil
+	return c.topLevelEnvironment(local), nil
 }
 
-func (c *Config) topLevelEnvironment() *EnvironmentConfig {
-	return &EnvironmentConfig{
-		Type:     "local",
-		URL:      c.URL,
-		AdminApi: c.AdminApi,
+// topLevelEnvironment builds the environment described by the deprecated
+// top-level url/admin_api. Values set on base take precedence over them.
+func (c *Config) topLevelEnvironment(base *EnvironmentConfig) *EnvironmentConfig {
+	env := EnvironmentConfig{Type: "local"}
+	if base != nil {
+		env = *base
+		if env.Type == "" {
+			env.Type = "local"
+		}
 	}
+
+	if env.URL == "" {
+		env.URL = c.URL
+	}
+
+	if env.AdminApi == nil {
+		env.AdminApi = c.AdminApi
+	}
+
+	return &env
+}
+
+// EffectiveURL returns the shop URL the CLI resolves for the default
+// environment: environments.local.url, falling back to the deprecated
+// top-level url. It mirrors ResolveEnvironment for callers that only need the
+// URL and cannot fail on an unknown environment name.
+func (c *Config) EffectiveURL() string {
+	if c == nil {
+		return ""
+	}
+
+	if env, ok := c.Environments["local"]; ok && env != nil && env.URL != "" {
+		return env.URL
+	}
+
+	return c.URL
 }
 
 // HasDeprecatedTopLevelShop reports whether the config still stores a shop
@@ -962,29 +993,35 @@ func ReadProjectURLState(configPath, envName string) (ConfigURLState, error) {
 	return state, nil
 }
 
-// SetProjectURL points the project config at url in place: the top-level url
-// key always (created when missing), the environment url only when it already
-// exists — an absent environment url already falls back to the top-level one,
-// so there is nothing to override. Comments, ordering and unknown keys are
-// preserved.
+// SetProjectURL points the project config at url in place: the environment
+// url when the environment exists, otherwise the deprecated top-level url. An
+// existing top-level url is updated too, so a mixed file does not keep serving
+// the old url to anything still reading it — but it is never newly created,
+// which would deprecation-warn on every later command. Comments, ordering and
+// unknown keys are preserved.
 func SetProjectURL(configPath, envName, url string) error {
 	doc, root, err := loadConfigDoc(configPath)
 	if err != nil {
 		return err
 	}
 
-	setConfigMapValue(root, "url", url)
+	env := envNode(root, envName)
 
-	if envURL := envURLNode(root, envName); envURL != nil {
-		envURL.SetString(url)
+	if env == nil || configMapValue(root, "url") != nil {
+		setConfigURLValue(root, url)
+	}
+
+	if env != nil {
+		setConfigURLValue(env, url)
 	}
 
 	return writeConfigDoc(configPath, doc)
 }
 
 // RestoreProjectURL puts the url values captured in prev back in place:
-// previously present keys get their old value, a previously absent top-level
-// url is removed again. An environment url we never touched stays untouched.
+// previously present keys get their old value, previously absent ones are
+// removed again — for the environment url too, since SetProjectURL creates it
+// when the environment exists.
 func RestoreProjectURL(configPath, envName string, prev ConfigURLState) error {
 	doc, root, err := loadConfigDoc(configPath)
 	if err != nil {
@@ -992,22 +1029,25 @@ func RestoreProjectURL(configPath, envName string, prev ConfigURLState) error {
 	}
 
 	if prev.HasRoot {
-		setConfigMapValue(root, "url", prev.RootURL)
+		setConfigURLValue(root, prev.RootURL)
 	} else {
 		removeConfigMapKey(root, "url")
 	}
 
-	if prev.HasEnv {
-		if envURL := envURLNode(root, envName); envURL != nil {
-			envURL.SetString(prev.EnvURL)
+	if env := envNode(root, envName); env != nil {
+		if prev.HasEnv {
+			setConfigURLValue(env, prev.EnvURL)
+		} else {
+			removeConfigMapKey(env, "url")
 		}
 	}
 
 	return writeConfigDoc(configPath, doc)
 }
 
-// envURLNode returns the environments.<env>.url value node, or nil.
-func envURLNode(root *yaml.Node, envName string) *yaml.Node {
+// envNode returns the environments.<env> mapping node, or nil when the
+// environment is not configured in the file.
+func envNode(root *yaml.Node, envName string) *yaml.Node {
 	environments := configMapValue(root, "environments")
 	if environments == nil || environments.Kind != yaml.MappingNode {
 		return nil
@@ -1015,6 +1055,16 @@ func envURLNode(root *yaml.Node, envName string) *yaml.Node {
 
 	env := configMapValue(environments, urlEnvKey(envName))
 	if env == nil || env.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	return env
+}
+
+// envURLNode returns the environments.<env>.url value node, or nil.
+func envURLNode(root *yaml.Node, envName string) *yaml.Node {
+	env := envNode(root, envName)
+	if env == nil {
 		return nil
 	}
 
@@ -1059,16 +1109,16 @@ func configMapValue(mapping *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-// setConfigMapValue updates key's value in a mapping node, appending the pair
-// when the key is missing.
-func setConfigMapValue(mapping *yaml.Node, key, value string) {
-	if node := configMapValue(mapping, key); node != nil {
+// setConfigURLValue updates the url key's value in a mapping node, appending
+// the pair when the key is missing.
+func setConfigURLValue(mapping *yaml.Node, value string) {
+	if node := configMapValue(mapping, "url"); node != nil {
 		node.SetString(value)
 		return
 	}
 
 	keyNode := &yaml.Node{}
-	keyNode.SetString(key)
+	keyNode.SetString("url")
 	valueNode := &yaml.Node{}
 	valueNode.SetString(value)
 

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -175,8 +175,7 @@ func TestResolveEnvironment(t *testing.T) {
 		assert.Equal(t, "http://localhost:8000", env.URL)
 	})
 
-	t.Run("empty name keeps top-level when environments.local also exists", func(t *testing.T) {
-		// Deprecation-window compatibility: mixed files keep the top-level shop.
+	t.Run("empty name prefers environments.local over the deprecated top-level shop", func(t *testing.T) {
 		cfg := &Config{
 			URL:      "https://myshop.com",
 			AdminApi: &ConfigAdminApi{Username: "admin"},
@@ -187,9 +186,38 @@ func TestResolveEnvironment(t *testing.T) {
 
 		env, err := cfg.ResolveEnvironment("")
 		require.NoError(t, err)
-		assert.Equal(t, "local", env.Type)
+		// The type picks the executor, so it must never come from the
+		// deprecated top-level keys, which never described one.
+		assert.Equal(t, "docker", env.Type)
+		assert.Equal(t, "http://localhost:8000", env.URL)
+		assert.Equal(t, "admin", env.AdminApi.Username)
+	})
+
+	t.Run("empty name fills unset environment values from the deprecated top-level shop", func(t *testing.T) {
+		cfg := &Config{
+			URL:      "https://myshop.com",
+			AdminApi: &ConfigAdminApi{Username: "admin"},
+			Environments: map[string]*EnvironmentConfig{
+				"local": {Type: "docker"},
+			},
+		}
+
+		env, err := cfg.ResolveEnvironment("")
+		require.NoError(t, err)
+		assert.Equal(t, "docker", env.Type)
 		assert.Equal(t, "https://myshop.com", env.URL)
 		assert.Equal(t, "admin", env.AdminApi.Username)
+	})
+
+	t.Run("empty name does not mutate the stored environment", func(t *testing.T) {
+		cfg := &Config{
+			URL:          "https://myshop.com",
+			Environments: map[string]*EnvironmentConfig{"local": {Type: "docker"}},
+		}
+
+		_, err := cfg.ResolveEnvironment("")
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Environments["local"].URL)
 	})
 
 	t.Run("synthesizes from top-level when no environments configured", func(t *testing.T) {
@@ -301,8 +329,7 @@ func TestWithEnvironment(t *testing.T) {
 		assert.Equal(t, "admin", resolved.AdminApi.Username)
 	})
 
-	t.Run("empty name keeps top-level when environments.local also exists", func(t *testing.T) {
-		// Deprecation-window compatibility: mixed files keep the top-level shop.
+	t.Run("empty name prefers environments.local over the deprecated top-level shop", func(t *testing.T) {
 		cfg := &Config{
 			URL:      "https://myshop.com",
 			AdminApi: &ConfigAdminApi{Username: "admin"},
@@ -316,8 +343,8 @@ func TestWithEnvironment(t *testing.T) {
 
 		resolved, err := cfg.WithEnvironment("")
 		require.NoError(t, err)
-		assert.Equal(t, "https://myshop.com", resolved.URL)
-		assert.Equal(t, "admin", resolved.AdminApi.Username)
+		assert.Equal(t, "http://localhost:8000", resolved.URL)
+		assert.Equal(t, "local-admin", resolved.AdminApi.Username)
 	})
 
 	t.Run("empty name applies environments.local when top-level shop is unset", func(t *testing.T) {
@@ -1003,4 +1030,25 @@ func TestConfigBuildMJMLResolveIncludePaths(t *testing.T) {
 		want := []string{filepath.Join(projectRoot, "shared/email"), abs}
 		assert.Equal(t, want, got)
 	})
+}
+
+func TestEffectiveURL(t *testing.T) {
+	assert.Empty(t, (*Config)(nil).EffectiveURL())
+	assert.Empty(t, (&Config{}).EffectiveURL())
+	assert.Equal(t, "https://myshop.com", (&Config{URL: "https://myshop.com"}).EffectiveURL())
+
+	// environments.local wins over the deprecated top-level url, matching
+	// ResolveEnvironment.
+	mixed := &Config{
+		URL:          "http://127.0.0.1:8000",
+		Environments: map[string]*EnvironmentConfig{"local": {URL: "https://my-shop.shopware.local"}},
+	}
+	assert.Equal(t, "https://my-shop.shopware.local", mixed.EffectiveURL())
+
+	// An environment without a url falls back to the top-level one.
+	fallback := &Config{
+		URL:          "https://myshop.com",
+		Environments: map[string]*EnvironmentConfig{"local": {Type: "docker"}},
+	}
+	assert.Equal(t, "https://myshop.com", fallback.EffectiveURL())
 }

--- a/internal/shop/config_url_test.go
+++ b/internal/shop/config_url_test.go
@@ -103,3 +103,64 @@ func countOccurrences(s, sub string) int {
 	}
 	return count
 }
+
+func TestSetProjectURLDoesNotCreateTopLevelURL(t *testing.T) {
+	t.Parallel()
+
+	// The shape `project create` writes: environments only, no top-level url.
+	path := writeTestConfig(t, `compatibility_date: "2026-07-15"
+environments:
+    local:
+        type: docker
+        url: http://127.0.0.1:8000
+`)
+
+	state, err := ReadProjectURLState(path, "")
+	require.NoError(t, err)
+	assert.False(t, state.HasRoot)
+	assert.True(t, state.HasEnv)
+
+	require.NoError(t, SetProjectURL(path, "", "https://my-shop.shopware.local"))
+
+	updated, err := os.ReadFile(path)
+	require.NoError(t, err)
+	// Only the environment url is rewritten; a top-level url would
+	// deprecation-warn on every later command.
+	assert.Equal(t, 1, countOccurrences(string(updated), "https://my-shop.shopware.local"))
+	assert.NotContains(t, string(updated), "\nurl:")
+
+	require.NoError(t, RestoreProjectURL(path, "", state))
+
+	restored, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(restored), "my-shop.shopware.local")
+	assert.NotContains(t, string(restored), "\nurl:")
+	assert.Contains(t, string(restored), "url: http://127.0.0.1:8000")
+}
+
+func TestSetProjectURLCreatesEnvironmentURLAndRestoreRemovesIt(t *testing.T) {
+	t.Parallel()
+
+	path := writeTestConfig(t, `environments:
+    local:
+        type: docker
+`)
+
+	state, err := ReadProjectURLState(path, "")
+	require.NoError(t, err)
+	assert.False(t, state.HasEnv)
+
+	require.NoError(t, SetProjectURL(path, "", "https://my-shop.shopware.local"))
+
+	updated, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "url: https://my-shop.shopware.local")
+	assert.NotContains(t, string(updated), "\nurl:")
+
+	require.NoError(t, RestoreProjectURL(path, "", state))
+
+	restored, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(restored), "url:")
+	assert.Contains(t, string(restored), "type: docker")
+}


### PR DESCRIPTION
## Problem

Creating a new project surfaces two issues that share a root cause:

1. Every command after `project create` warns `uses deprecated top-level url/admin_api`.
2. A Docker project runs through the **local** executor — `environments.local` is ignored.

`project create --local-domain` wrote the shop URL to *both* the deprecated top-level `url:` and `environments.local.url`. `ResolveEnvironment("")` then treated any top-level `url` as a signal to discard `environments.local` entirely, returning a synthesized `{Type: "local", URL: c.URL, AdminApi: c.AdminApi}` — throwing away the environment's `type: docker`, which is what picks the executor.

## Changes

- **`cmd/project/project_create_install.go`** — create writes only `environments.local.url`. The top-level key existed to feed proxy hostname derivation, handled below instead.
- **`internal/shop/config.go` — `ResolveEnvironment`** — an empty `-e` returns `environments.local`, with the deprecated top-level `url`/`admin_api` filling in only fields the environment leaves unset.
- **`internal/shop/config.go` — new `EffectiveURL()`** — one place resolving the default environment's URL, mirroring `ResolveEnvironment`. `ProjectHostname` read only `cfg.URL` and would otherwise have stopped deriving the proxy hostname once create stopped writing that key; `IsProxyProjectForDomain` already implemented the same precedence by hand and now shares the helper.
- **`SetProjectURL` / `RestoreProjectURL`** — `proxy up` no longer *creates* a top-level `url` (which would reintroduce the warning); it writes the environment url, creating that key when the environment exists, and only updates an already-present top-level url. Restore removes an env url it created.

A fresh `--docker` project now yields:

```yaml
compatibility_date: "2026-08-25"
docker:
    php:
        version: "8.5"
environments:
    local:
        type: docker
        url: http://127.0.0.1:8000
        admin_api:
            username: admin
            password: shopware
```

No top-level `url`, no deprecation warning, Docker executor resolved.

## Smoke test

Adds a `docker-project` job to the smoke workflow that creates a `--docker` project, starts it, checks the shop answers over HTTP, and stops it again — a separate job, so a Docker failure does not mask the extension packaging coverage in `run`. It guards this regression directly: no top-level `url:` in the generated config, and no deprecation warning from commands. It also installs no PHP on the runner, since a Docker project takes its PHP from the image — needing one would mean the executor resolved to the wrong type.

## Drive-by fix: `project dev stop` was broken headless

Writing the smoke test surfaced that `project dev stop` could not run without a TTY at all:

```
ERROR   stopping environment: bubbletea: error opening TTY: bubbletea: could not open TTY: open /dev/tty: device not configured
```

`start` routes through `runStep`, which drops the spinner when there is no interactive terminal, but `stop` called `spinner.New()` directly. So `project dev stop` failed in CI, in an agent, or in any pipe without `/dev/tty`. `stop` now uses `runStep` too.

## Behavior change worth flagging

This **inverts the precedence for mixed files**: `environments.local.url` now wins over the top-level `url`, where before the top-level won. Three tests asserted the old rule and are updated (`TestResolveEnvironment`, `TestWithEnvironment`, and `TestNoEnvFlagKeepsBaseConfig` → `TestNoEnvFlagPrefersLocalEnvironmentOverTopLevel`).

Rationale:

- `IsProxyProjectForDomain` already implemented environment-wins ("The local environment's url overrides the top-level one in the executor") — the two disagreed, and keeping top-level-wins would have broken proxy detection for already-proxied mixed configs.
- Anyone who hit this bug worked around it by editing `environments.local`; top-level-wins would keep ignoring that edit.

Configs that use only the top-level keys are unaffected — they still resolve as a full fallback.

If you'd rather keep strict top-level precedence for the remainder of the deprecation window and only rescue the `type` field, that's a one-line change to `topLevelEnvironment`.

## Testing

`go test ./...` passes; `golangci-lint run` reports 0 issues. Added coverage for `EffectiveURL`, the environments-only config shape in `SetProjectURL`/`RestoreProjectURL`, env-url creation and removal, and the mixed-file resolution cases (including that resolution does not mutate the stored environment).

The full Docker flow was also run locally end to end: create → `dev start` (5 services up) → `dev status` exit 0 → `curl /admin` 302 → `dev stop --remove-data` → `dev status` exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)