### PR TITLE
feat(project): add non-interactive project dev install command

### DIFF
--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/proxy"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/internal/tui/dev"
@@ -90,7 +91,7 @@ var projectDevCmd = &cobra.Command{
 			if !isatty.IsTerminal(os.Stdin.Fd()) {
 				return shop.ErrDevModeNotSupported
 			}
-			return runMigrationWizardTUI(projectRoot, cfg)
+			return runMigrationWizardTUI(cmd.Context(), projectRoot, cfg)
 		}
 
 		env, err := newDevEnvironment(cmd, projectRoot, cfg)
@@ -101,10 +102,17 @@ var projectDevCmd = &cobra.Command{
 		env.bootstrapProxyFallback(cmd)
 
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
-			return env.start(cmd)
+			if err := env.start(cmd); err != nil {
+				return err
+			}
+			if !install.IsInstalled(cmd.Context(), env.executor) {
+				fmt.Println(tui.DimText.Render("  Shopware is not installed yet. Run ") + tui.BoldText.Render("shopware-cli project dev install") + tui.DimText.Render(" to install it."))
+				fmt.Println()
+			}
+			return nil
 		}
 
-		return env.runTUI()
+		return env.runTUI(cmd.Context())
 	},
 }
 
@@ -153,14 +161,14 @@ var projectDevStatusCmd = &cobra.Command{
 	},
 }
 
-func runMigrationWizardTUI(projectRoot string, cfg *shop.Config) error {
+func runMigrationWizardTUI(ctx context.Context, projectRoot string, cfg *shop.Config) error {
 	envCfg := &shop.EnvironmentConfig{Type: "docker", URL: "http://127.0.0.1:8000"}
 	exec, err := executor.New(projectRoot, envCfg, cfg)
 	if err != nil {
 		return err
 	}
 
-	_, err = dev.NewMigrationWizardApp(dev.Options{
+	_, err = dev.NewMigrationWizardApp(ctx, dev.Options{
 		ProjectRoot: projectRoot,
 		Config:      cfg,
 		EnvConfig:   envCfg,
@@ -341,8 +349,8 @@ func (e *devEnvironment) status(cmd *cobra.Command) error {
 	return ErrEnvironmentDown
 }
 
-func (e *devEnvironment) runTUI() error {
-	_, err := dev.NewApp(dev.Options{
+func (e *devEnvironment) runTUI(ctx context.Context) error {
+	_, err := dev.NewApp(ctx, dev.Options{
 		ProjectRoot:   e.projectRoot,
 		Config:        e.cfg,
 		EnvConfig:     e.envCfg,

--- a/cmd/project/project_dev_install.go
+++ b/cmd/project/project_dev_install.go
@@ -1,0 +1,64 @@
+package project
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/shop/install"
+)
+
+var projectDevInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install Shopware non-interactively",
+	Long:  "Install Shopware without the interactive TUI: starts the development environment, runs the deployment helper and saves the admin credentials to the project config. Skips the installation when the shop is already installed.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		locale, _ := cmd.Flags().GetString("locale")
+		currency, _ := cmd.Flags().GetString("currency")
+		adminUsername, _ := cmd.Flags().GetString("admin-username")
+		adminPassword, _ := cmd.Flags().GetString("admin-password")
+
+		opts := install.Options{
+			Locale:        locale,
+			Currency:      currency,
+			AdminUsername: adminUsername,
+			AdminPassword: adminPassword,
+		}
+		opts.ApplyDefaults()
+		// Fail on a bad flag value before Docker gets involved.
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+
+		env, err := setupDevEnvironment(cmd)
+		if err != nil {
+			return err
+		}
+
+		env.bootstrapProxyFallback(cmd)
+
+		if err := runStep(cmd.Context(), "Starting development environment...", env.executor.StartEnvironment); err != nil {
+			return err
+		}
+
+		return install.RunHeadless(cmd.Context(), env.executor, env.cfg, env.envCfg, env.projectRoot, install.HeadlessOptions{
+			Install: opts,
+			Out:     cmd.OutOrStdout(),
+		})
+	},
+}
+
+func init() {
+	projectDevCmd.AddCommand(projectDevInstallCmd)
+
+	flags := projectDevInstallCmd.Flags()
+	flags.String("locale", install.DefaultLocale, "Default storefront language (e.g. en-GB, de-DE)")
+	flags.String("currency", install.DefaultCurrency, "Default currency (e.g. EUR, USD)")
+	flags.String("admin-username", install.DefaultAdminUsername, "Admin account username")
+	flags.String("admin-password", install.DefaultAdminPassword, "Admin account password (at least 8 characters)")
+
+	_ = projectDevInstallCmd.RegisterFlagCompletionFunc("locale", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return install.LocaleIDs(), cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = projectDevInstallCmd.RegisterFlagCompletionFunc("currency", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return install.Currencies, cobra.ShellCompDirectiveNoFileComp
+	})
+}

--- a/cmd/project/project_upgrade.go
+++ b/cmd/project/project_upgrade.go
@@ -57,7 +57,7 @@ var projectUpgradeCmd = &cobra.Command{
 			envName = "local"
 		}
 
-		shell := upgradetui.NewApp(upgradetui.Options{
+		shell := upgradetui.NewApp(cmd.Context(), upgradetui.Options{
 			ProjectRoot: projectRoot,
 			EnvName:     envName,
 			Executor:    exec,

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -162,15 +162,17 @@ ever transmitted — only enumerated choices, outcomes, and durations.
 ### `shopware_cli.project.dev.install` — first-run Shopware installation
 
 Sent when the "Shopware is not initialized yet" wizard reaches a terminal
-state, or when the non-interactive `project dev install` command finishes.
-Choice tags are only present once the user made that choice (an event for a
-run cancelled on the language step carries no `language` tag).
+state, or when the non-interactive `project dev install` command finishes an
+installation attempt (failures to start the development environment before
+the installation begins are not reported under this event). Choice tags are
+only present once the user made that choice (an event for a run cancelled on
+the language step carries no `language` tag).
 
 | Tag                  | Meaning                                                       | Example          |
 |----------------------|---------------------------------------------------------------|------------------|
 | `result`             | Outcome of the wizard                                         | `success` / `failure` / `cancelled` / `skipped` |
 | `abandoned_at`       | Step shown when the user quit (only for `cancelled`)          | `ask` / `language` / `currency` / `credentials` / `installing` |
-| `failed_step`        | Last install step that had started (only for `failure`)       | `system:install` |
+| `failed_step`        | Last install step that had started (only for `failure`); `save_credentials` when the install succeeded but the config write failed | `system:install` |
 | `duration_ms`        | Install runtime, once the install actually started            | `84213`          |
 | `language`           | Selected default language                                     | `de-DE`          |
 | `currency`           | Selected default currency                                     | `EUR`            |

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -162,8 +162,9 @@ ever transmitted — only enumerated choices, outcomes, and durations.
 ### `shopware_cli.project.dev.install` — first-run Shopware installation
 
 Sent when the "Shopware is not initialized yet" wizard reaches a terminal
-state. Choice tags are only present once the user made that choice (an event
-for a run cancelled on the language step carries no `language` tag).
+state, or when the non-interactive `project dev install` command finishes.
+Choice tags are only present once the user made that choice (an event for a
+run cancelled on the language step carries no `language` tag).
 
 | Tag                  | Meaning                                                       | Example          |
 |----------------------|---------------------------------------------------------------|------------------|
@@ -174,6 +175,7 @@ for a run cancelled on the language step carries no `language` tag).
 | `language`           | Selected default language                                     | `de-DE`          |
 | `currency`           | Selected default currency                                     | `EUR`            |
 | `custom_credentials` | Whether the default admin username/password were changed. The credentials themselves are **never** sent. | `false` |
+| `interactive`        | `true` for the TUI wizard, `false` for `project dev install`  | `true`           |
 
 ### `shopware_cli.project.dev.migration_wizard` — dev-environment setup wizard
 

--- a/internal/shop/install/headless.go
+++ b/internal/shop/install/headless.go
@@ -67,11 +67,14 @@ func RunHeadless(ctx context.Context, exec executor.Executor, cfg *shop.Config, 
 		return fmt.Errorf("installing Shopware: %w", runErr)
 	}
 
-	trackOutcome(tracking.ResultSuccess, install, elapsed, "")
-
+	// Persist before recording the outcome, so a failed config write is not
+	// reported as a successful run.
 	if err := PersistCredentials(cfg, envCfg, projectRoot, install); err != nil {
+		trackOutcome(tracking.ResultFailure, install, elapsed, FailedStepSaveCredentials)
 		return fmt.Errorf("installation succeeded, but failed to save admin credentials to the project config: %w", err)
 	}
+
+	trackOutcome(tracking.ResultSuccess, install, elapsed, "")
 
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, tui.SuccessLine(fmt.Sprintf("Shopware installed in %s", elapsed.Round(time.Second))))

--- a/internal/shop/install/headless.go
+++ b/internal/shop/install/headless.go
@@ -1,0 +1,112 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tracking"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+// HeadlessOptions configure a non-interactive installation run.
+type HeadlessOptions struct {
+	// Install parameterizes the installation; empty fields get the wizard
+	// defaults.
+	Install Options
+	// Out receives the progress output.
+	Out io.Writer
+}
+
+// RunHeadless installs Shopware without the TUI — for the
+// `project dev install` command and environments without a terminal. An
+// already-installed shop is reported and skipped, so the command is
+// idempotent for scripts and CI.
+func RunHeadless(ctx context.Context, exec executor.Executor, cfg *shop.Config, envCfg *shop.EnvironmentConfig, projectRoot string, opts HeadlessOptions) error {
+	out := opts.Out
+	if out == nil {
+		out = io.Discard
+	}
+
+	install := opts.Install
+	install.ApplyDefaults()
+	if err := install.Validate(); err != nil {
+		return err
+	}
+
+	if IsInstalled(ctx, exec) {
+		_, _ = fmt.Fprintln(out, tui.SuccessLine("Shopware is already installed — nothing to do."))
+		_, _ = fmt.Fprintln(out, tui.DimText.Render("Run ")+tui.BoldText.Render("shopware-cli project dev stop --remove-data")+tui.DimText.Render(" first for a clean reinstall."))
+		trackOutcome(tracking.ResultSkipped, install, 0, "")
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(out, tui.SectionHeadingStyle.Render("Installing Shopware"))
+
+	start := time.Now()
+	currentStep := -1
+	runErr := Run(ctx, exec, install, func(line string) {
+		if idx, ok := MatchStep(line, currentStep+1); ok {
+			currentStep = idx
+			_, _ = fmt.Fprintln(out, tui.BoldText.Render("▸ "+Steps[idx].Label))
+		}
+		_, _ = fmt.Fprintln(out, "  "+tui.DimText.Render(line))
+	})
+	elapsed := time.Since(start)
+
+	if runErr != nil {
+		failedStep := FailedStep(max(currentStep, 0))
+		trackOutcome(tracking.ResultFailure, install, elapsed, failedStep)
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, tui.FailLine("Installation failed during "+failedStep+"."))
+		return fmt.Errorf("installing Shopware: %w", runErr)
+	}
+
+	trackOutcome(tracking.ResultSuccess, install, elapsed, "")
+
+	if err := PersistCredentials(cfg, envCfg, projectRoot, install); err != nil {
+		return fmt.Errorf("installation succeeded, but failed to save admin credentials to the project config: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, tui.SuccessLine(fmt.Sprintf("Shopware installed in %s", elapsed.Round(time.Second))))
+
+	shopURL := envCfg.URL
+	if shopURL == "" {
+		shopURL = cfg.URL
+	}
+	if shopURL != "" {
+		_, _ = fmt.Fprintln(out, tui.DimText.Render("Admin URL: ")+tui.BoldText.Render(strings.TrimSuffix(shopURL, "/")+"/admin"))
+	}
+	_, _ = fmt.Fprintln(out, tui.DimText.Render("Admin user: ")+tui.BoldText.Render(install.AdminUsername)+tui.DimText.Render(" (credentials saved to "+shop.DefaultConfigFileName()+")"))
+
+	return nil
+}
+
+// trackOutcome sends the project.dev.install event for a headless run. Unlike
+// the TUI it sends synchronously (with a short timeout), because the process
+// exits right after.
+func trackOutcome(result string, opts Options, duration time.Duration, failedStep string) {
+	tags := map[string]string{
+		tracking.TagResult:            result,
+		tracking.TagLanguage:          opts.Locale,
+		tracking.TagCurrency:          opts.Currency,
+		tracking.TagCustomCredentials: strconv.FormatBool(opts.CustomCredentials()),
+		tracking.TagInteractive:       "false",
+	}
+	if duration > 0 {
+		tags[tracking.TagDurationMS] = strconv.FormatInt(duration.Milliseconds(), 10)
+	}
+	if failedStep != "" {
+		tags[tracking.TagFailedStep] = failedStep
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	tracking.Track(ctx, tracking.EventDevInstall, tags)
+}

--- a/internal/shop/install/headless_test.go
+++ b/internal/shop/install/headless_test.go
@@ -1,0 +1,115 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func notInstalledConsole(ctx context.Context, _ ...string) *executor.Process {
+	return shellProcess(ctx, "false")
+}
+
+func TestRunHeadlessSkipsWhenInstalled(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	fake := &fakeExecutor{
+		php: func(ctx context.Context, _ ...string) *executor.Process {
+			t.Fatal("the deployment helper must not run when Shopware is already installed")
+			return nil
+		},
+	}
+
+	var out bytes.Buffer
+	cfg := &shop.Config{}
+	envCfg := &shop.EnvironmentConfig{}
+	err := RunHeadless(t.Context(), fake, cfg, envCfg, t.TempDir(), HeadlessOptions{Out: &out})
+
+	require.NoError(t, err)
+	plain := ansi.Strip(out.String())
+	assert.Contains(t, plain, "already installed")
+	assert.Contains(t, plain, "project dev stop --remove-data")
+}
+
+func TestRunHeadlessInstallsAndPersists(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	dir := t.TempDir()
+
+	fake := &fakeExecutor{
+		console: notInstalledConsole,
+		php: func(ctx context.Context, _ ...string) *executor.Process {
+			return shellProcess(ctx, `echo "Start: bin/console system:install"; echo migrated; echo "Start: bin/console user:create admin"`)
+		},
+	}
+
+	envCfg := &shop.EnvironmentConfig{Type: "docker", URL: "http://localhost:8000"}
+	cfg := &shop.Config{Environments: map[string]*shop.EnvironmentConfig{"local": envCfg}}
+
+	var out bytes.Buffer
+	err := RunHeadless(t.Context(), fake, cfg, envCfg, dir, HeadlessOptions{
+		Install: Options{AdminPassword: "secret123"},
+		Out:     &out,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "en-GB", fake.env["INSTALL_LOCALE"], "defaults are applied to empty fields")
+	assert.Equal(t, "secret123", fake.env["INSTALL_ADMIN_PASSWORD"])
+
+	plain := ansi.Strip(out.String())
+	assert.Contains(t, plain, "▸ Installing Shopware")
+	assert.Contains(t, plain, "▸ Creating admin account")
+	assert.Contains(t, plain, "migrated", "raw helper output is echoed")
+	assert.Contains(t, plain, "Shopware installed in")
+	assert.Contains(t, plain, "http://localhost:8000/admin")
+	assert.Contains(t, plain, "Admin user: admin")
+
+	written, err := os.ReadFile(filepath.Join(dir, ".shopware-project.yml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "password: secret123")
+}
+
+func TestRunHeadlessFailureNamesStep(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	fake := &fakeExecutor{
+		console: notInstalledConsole,
+		php: func(ctx context.Context, _ ...string) *executor.Process {
+			return shellProcess(ctx, `echo "Start: bin/console system:install"; echo "Start: bin/console user:create admin"; exit 1`)
+		},
+	}
+
+	var out bytes.Buffer
+	cfg := &shop.Config{}
+	envCfg := &shop.EnvironmentConfig{}
+	err := RunHeadless(t.Context(), fake, cfg, envCfg, t.TempDir(), HeadlessOptions{Out: &out})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "installing Shopware")
+	assert.Contains(t, ansi.Strip(out.String()), "failed during user:create")
+}
+
+func TestRunHeadlessValidatesOptions(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	fake := &fakeExecutor{
+		console: func(ctx context.Context, _ ...string) *executor.Process {
+			t.Fatal("invalid options must fail before any command runs")
+			return nil
+		},
+	}
+
+	err := RunHeadless(t.Context(), fake, &shop.Config{}, &shop.EnvironmentConfig{}, t.TempDir(), HeadlessOptions{
+		Install: Options{Locale: "xx-XX"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown locale")
+}

--- a/internal/shop/install/install.go
+++ b/internal/shop/install/install.go
@@ -1,0 +1,185 @@
+// Package install holds the Shopware installation logic shared by the
+// interactive dev TUI (internal/tui/dev) and the non-interactive
+// `project dev install` command. The actual installation is delegated to
+// vendor/bin/shopware-deployment-helper, parameterized via INSTALL_* env vars.
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+// Defaults applied when an Options field is left empty. They match the
+// pre-selected values of the TUI install wizard.
+const (
+	DefaultLocale        = "en-GB"
+	DefaultCurrency      = "EUR"
+	DefaultAdminUsername = "admin"
+	DefaultAdminPassword = "shopware"
+)
+
+// MinAdminPasswordLength is the minimum admin password length enforced by the
+// Shopware core (user:create / system:install). Validating it here rejects
+// too-short passwords up front instead of failing late during the
+// deployment-helper run.
+const MinAdminPasswordLength = 8
+
+// Language is a storefront locale selectable during installation.
+type Language struct {
+	ID    string
+	Label string
+}
+
+// Languages are the locales offered by the install wizard, in display order.
+// The IDs are Shopware locale codes accepted by system:install.
+var Languages = []Language{
+	{"en-GB", "English (UK)"},
+	{"en-US", "English (US)"},
+	{"de-DE", "Deutsch"},
+	{"cs-CZ", "Čeština"},
+	{"da-DK", "Dansk"},
+	{"es-ES", "Español"},
+	{"fr-FR", "Français"},
+	{"it-IT", "Italiano"},
+	{"nl-NL", "Nederlands"},
+	{"nn-NO", "Norsk"},
+	{"pl-PL", "Język polski"},
+	{"pt-PT", "Português"},
+	{"sv-SE", "Svenska"},
+}
+
+// Currencies are the ISO codes offered by the install wizard.
+var Currencies = []string{"EUR", "USD", "GBP", "PLN", "CHF", "SEK", "DKK", "NOK", "CZK"}
+
+// LocaleIDs returns the locale codes of Languages, for flag completion and
+// validation errors.
+func LocaleIDs() []string {
+	ids := make([]string, len(Languages))
+	for i, lang := range Languages {
+		ids[i] = lang.ID
+	}
+	return ids
+}
+
+// ValidateLocale checks the locale against the Languages allow-list.
+func ValidateLocale(locale string) error {
+	for _, lang := range Languages {
+		if lang.ID == locale {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown locale %q, valid values: %s", locale, strings.Join(LocaleIDs(), ", "))
+}
+
+// ValidateCurrency checks the currency against the Currencies allow-list.
+func ValidateCurrency(currency string) error {
+	for _, c := range Currencies {
+		if c == currency {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown currency %q, valid values: %s", currency, strings.Join(Currencies, ", "))
+}
+
+// ValidateAdminPassword mirrors the Shopware core password length requirement.
+func ValidateAdminPassword(password string) error {
+	if len([]rune(password)) < MinAdminPasswordLength {
+		return fmt.Errorf("password must be at least %d characters long", MinAdminPasswordLength)
+	}
+	return nil
+}
+
+// Options parameterize a Shopware installation.
+type Options struct {
+	Locale        string
+	Currency      string
+	AdminUsername string
+	AdminPassword string
+}
+
+// ApplyDefaults fills empty fields with the wizard defaults.
+func (o *Options) ApplyDefaults() {
+	if o.Locale == "" {
+		o.Locale = DefaultLocale
+	}
+	if o.Currency == "" {
+		o.Currency = DefaultCurrency
+	}
+	if o.AdminUsername == "" {
+		o.AdminUsername = DefaultAdminUsername
+	}
+	if o.AdminPassword == "" {
+		o.AdminPassword = DefaultAdminPassword
+	}
+}
+
+// Validate checks locale, currency and password against the same rules the
+// TUI wizard enforces.
+func (o Options) Validate() error {
+	if err := ValidateLocale(o.Locale); err != nil {
+		return err
+	}
+	if err := ValidateCurrency(o.Currency); err != nil {
+		return err
+	}
+	return ValidateAdminPassword(o.AdminPassword)
+}
+
+// CustomCredentials reports whether the admin credentials differ from the
+// defaults. Telemetry sends only this flag, never the credentials.
+func (o Options) CustomCredentials() bool {
+	return o.AdminUsername != DefaultAdminUsername || o.AdminPassword != DefaultAdminPassword
+}
+
+// IsInstalled reports whether the shop is already installed.
+func IsInstalled(ctx context.Context, exec executor.Executor) bool {
+	return exec.ConsoleCommand(ctx, "system:is-installed").Run() == nil
+}
+
+// Run installs Shopware by running the deployment helper with the INSTALL_*
+// env vars. Combined stdout/stderr is emitted line by line via onLine.
+func Run(ctx context.Context, exec executor.Executor, opts Options, onLine func(string)) error {
+	withEnv := exec.WithEnv(map[string]string{
+		"INSTALL_LOCALE":         opts.Locale,
+		"INSTALL_CURRENCY":       opts.Currency,
+		"INSTALL_ADMIN_USERNAME": opts.AdminUsername,
+		"INSTALL_ADMIN_PASSWORD": opts.AdminPassword,
+	})
+	p := withEnv.PHPCommand(ctx, "vendor/bin/shopware-deployment-helper", "run")
+
+	lw := tui.NewLineWriter(onLine)
+	err := p.RunWithOutput(lw)
+	lw.Flush()
+	return err
+}
+
+// PersistCredentials stores the admin credentials of a fresh installation in
+// the project config so API commands work out of the box. ResolveEnvironment
+// can return a copy that is not stored in cfg.Environments (the deprecated
+// top-level url/admin_api form) — credentials set on that copy would be lost
+// on write, so they are mirrored onto the top-level config in that case.
+func PersistCredentials(cfg *shop.Config, envCfg *shop.EnvironmentConfig, projectRoot string, opts Options) error {
+	adminApi := &shop.ConfigAdminApi{
+		Username: opts.AdminUsername,
+		Password: opts.AdminPassword,
+	}
+	envCfg.AdminApi = adminApi
+
+	stored := false
+	for _, env := range cfg.Environments {
+		if env == envCfg {
+			stored = true
+			break
+		}
+	}
+	if !stored {
+		cfg.AdminApi = adminApi
+	}
+
+	return shop.WriteConfig(cfg, projectRoot)
+}

--- a/internal/shop/install/install_test.go
+++ b/internal/shop/install/install_test.go
@@ -1,0 +1,267 @@
+package install
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+// fakeExecutor satisfies executor.Executor and lets each test decide which
+// shell command backs console/php invocations.
+type fakeExecutor struct {
+	console func(ctx context.Context, args ...string) *executor.Process
+	php     func(ctx context.Context, args ...string) *executor.Process
+	// env records the last WithEnv call so tests can assert the variables
+	// the deployment helper runs with.
+	env map[string]string
+}
+
+func shellProcess(ctx context.Context, script string) *executor.Process {
+	return &executor.Process{Cmd: exec.CommandContext(ctx, "sh", "-c", script)}
+}
+
+func (f *fakeExecutor) ConsoleCommand(ctx context.Context, args ...string) *executor.Process {
+	if f.console != nil {
+		return f.console(ctx, args...)
+	}
+	return shellProcess(ctx, "true")
+}
+
+func (f *fakeExecutor) PHPCommand(ctx context.Context, args ...string) *executor.Process {
+	if f.php != nil {
+		return f.php(ctx, args...)
+	}
+	return shellProcess(ctx, "true")
+}
+
+func (f *fakeExecutor) ComposerCommand(ctx context.Context, args ...string) *executor.Process {
+	return shellProcess(ctx, "true")
+}
+
+func (f *fakeExecutor) NPMCommand(ctx context.Context, args ...string) *executor.Process {
+	return shellProcess(ctx, "true")
+}
+
+func (f *fakeExecutor) NormalizePath(hostPath string) string { return hostPath }
+func (f *fakeExecutor) Type() string                         { return executor.TypeLocal }
+func (f *fakeExecutor) WithEnv(env map[string]string) executor.Executor {
+	f.env = env
+	return f
+}
+func (f *fakeExecutor) WithRelDir(string) executor.Executor    { return f }
+func (f *fakeExecutor) StartEnvironment(context.Context) error { return nil }
+func (f *fakeExecutor) StopEnvironment(context.Context, executor.StopOptions) error {
+	return nil
+}
+func (f *fakeExecutor) EnvironmentStatus(context.Context) (bool, error) { return true, nil }
+func (f *fakeExecutor) AdminAPIClient(context.Context) (*adminSdk.Client, error) {
+	return nil, executor.ErrNotSupported
+}
+func (f *fakeExecutor) ShopConfig() *shop.Config { return nil }
+func (f *fakeExecutor) DatabaseConnection(context.Context) (*executor.DatabaseConnection, error) {
+	return nil, executor.ErrNotSupported
+}
+
+func TestApplyDefaults(t *testing.T) {
+	var opts Options
+	opts.ApplyDefaults()
+	assert.Equal(t, Options{
+		Locale:        "en-GB",
+		Currency:      "EUR",
+		AdminUsername: "admin",
+		AdminPassword: "shopware",
+	}, opts)
+
+	opts = Options{Locale: "de-DE", Currency: "CHF", AdminUsername: "boss", AdminPassword: "secret123"}
+	opts.ApplyDefaults()
+	assert.Equal(t, "de-DE", opts.Locale)
+	assert.Equal(t, "CHF", opts.Currency)
+	assert.Equal(t, "boss", opts.AdminUsername)
+	assert.Equal(t, "secret123", opts.AdminPassword)
+}
+
+func TestValidate(t *testing.T) {
+	valid := Options{Locale: "de-DE", Currency: "EUR", AdminUsername: "admin", AdminPassword: "shopware"}
+
+	cases := []struct {
+		name    string
+		mutate  func(*Options)
+		wantErr string
+	}{
+		{"valid", func(*Options) {}, ""},
+		{"unknown locale", func(o *Options) { o.Locale = "xx-XX" }, "unknown locale"},
+		{"unknown currency", func(o *Options) { o.Currency = "BTC" }, "unknown currency"},
+		{"short password", func(o *Options) { o.AdminPassword = "short" }, "at least 8 characters"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := valid
+			tc.mutate(&opts)
+			err := opts.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateAdminPasswordCountsRunes(t *testing.T) {
+	assert.NoError(t, ValidateAdminPassword("äöüäöüäö"), "8 multibyte runes are enough")
+	assert.Error(t, ValidateAdminPassword("äöüäöüä"))
+}
+
+func TestValidateErrorListsValidValues(t *testing.T) {
+	err := ValidateLocale("klingon")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "en-GB")
+	assert.Contains(t, err.Error(), "sv-SE")
+
+	err = ValidateCurrency("gold")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EUR")
+	assert.Contains(t, err.Error(), "CZK")
+}
+
+func TestCustomCredentials(t *testing.T) {
+	opts := Options{AdminUsername: "admin", AdminPassword: "shopware"}
+	assert.False(t, opts.CustomCredentials())
+
+	opts.AdminPassword = "different1"
+	assert.True(t, opts.CustomCredentials())
+
+	opts = Options{AdminUsername: "boss", AdminPassword: "shopware"}
+	assert.True(t, opts.CustomCredentials())
+}
+
+func TestLocaleIDs(t *testing.T) {
+	ids := LocaleIDs()
+	assert.Len(t, ids, len(Languages))
+	assert.Equal(t, "en-GB", ids[0])
+}
+
+func TestMatchStep(t *testing.T) {
+	idx, ok := MatchStep("Start: bin/console system:install --create-database", 0)
+	require.True(t, ok)
+	assert.Equal(t, 0, idx)
+
+	idx, ok = MatchStep("Start: bin/console user:create admin", 0)
+	require.True(t, ok)
+	assert.Equal(t, 1, idx)
+
+	_, ok = MatchStep("running system:install now", 0)
+	assert.False(t, ok, "lines without the Start: prefix never match")
+
+	_, ok = MatchStep("Start: bin/console system:install", 1)
+	assert.False(t, ok, "progress is monotonic — earlier steps do not match again")
+
+	idx, ok = MatchStep("Start: bin/console theme:change --all", 1)
+	require.True(t, ok)
+	assert.Equal(t, 4, idx, "steps may be skipped")
+}
+
+func TestFailedStep(t *testing.T) {
+	assert.Equal(t, "system:install", FailedStep(0))
+	assert.Equal(t, "user:create", FailedStep(1))
+	assert.Equal(t, "plugin:refresh", FailedStep(len(Steps)+5), "out-of-range clamps to the last step")
+}
+
+func TestIsInstalled(t *testing.T) {
+	installed := &fakeExecutor{}
+	assert.True(t, IsInstalled(t.Context(), installed))
+
+	notInstalled := &fakeExecutor{
+		console: func(ctx context.Context, args ...string) *executor.Process {
+			assert.Equal(t, []string{"system:is-installed"}, args)
+			return shellProcess(ctx, "false")
+		},
+	}
+	assert.False(t, IsInstalled(t.Context(), notInstalled))
+}
+
+func TestRunPassesEnvAndStreamsLines(t *testing.T) {
+	fake := &fakeExecutor{
+		php: func(ctx context.Context, args ...string) *executor.Process {
+			assert.Equal(t, []string{"vendor/bin/shopware-deployment-helper", "run"}, args)
+			return shellProcess(ctx, "echo one; echo two 1>&2")
+		},
+	}
+
+	var lines []string
+	err := Run(t.Context(), fake, Options{
+		Locale:        "de-DE",
+		Currency:      "CHF",
+		AdminUsername: "boss",
+		AdminPassword: "secret123",
+	}, func(line string) { lines = append(lines, line) })
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"INSTALL_LOCALE":         "de-DE",
+		"INSTALL_CURRENCY":       "CHF",
+		"INSTALL_ADMIN_USERNAME": "boss",
+		"INSTALL_ADMIN_PASSWORD": "secret123",
+	}, fake.env)
+	assert.ElementsMatch(t, []string{"one", "two"}, lines, "stdout and stderr are both streamed")
+}
+
+func TestRunReturnsHelperError(t *testing.T) {
+	fake := &fakeExecutor{
+		php: func(ctx context.Context, args ...string) *executor.Process {
+			return shellProcess(ctx, "echo boom; exit 3")
+		},
+	}
+
+	var lines []string
+	err := Run(t.Context(), fake, Options{}, func(line string) { lines = append(lines, line) })
+	require.Error(t, err)
+	assert.Equal(t, []string{"boom"}, lines)
+}
+
+func TestPersistCredentialsStoredEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	envCfg := &shop.EnvironmentConfig{Type: "docker", URL: "http://localhost:8000"}
+	cfg := &shop.Config{Environments: map[string]*shop.EnvironmentConfig{"local": envCfg}}
+
+	opts := Options{AdminUsername: "boss", AdminPassword: "secret123"}
+	require.NoError(t, PersistCredentials(cfg, envCfg, dir, opts))
+
+	assert.Nil(t, cfg.AdminApi, "a stored environment does not touch the deprecated top-level admin_api")
+
+	written, err := os.ReadFile(filepath.Join(dir, ".shopware-project.yml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "username: boss")
+	assert.Contains(t, string(written), "password: secret123")
+}
+
+func TestPersistCredentialsTopLevelCopy(t *testing.T) {
+	dir := t.TempDir()
+
+	// A config in the deprecated top-level form: ResolveEnvironment returns a
+	// copy that is not stored in cfg.Environments.
+	cfg := &shop.Config{URL: "http://localhost:8000"}
+	envCfg, err := cfg.ResolveEnvironment("")
+	require.NoError(t, err)
+
+	opts := Options{AdminUsername: "boss", AdminPassword: "secret123"}
+	require.NoError(t, PersistCredentials(cfg, envCfg, dir, opts))
+
+	require.NotNil(t, cfg.AdminApi, "credentials must land on the config that gets written, not only the copy")
+	assert.Equal(t, "boss", cfg.AdminApi.Username)
+
+	written, err := os.ReadFile(filepath.Join(dir, ".shopware-project.yml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "username: boss")
+}

--- a/internal/shop/install/steps.go
+++ b/internal/shop/install/steps.go
@@ -1,0 +1,48 @@
+package install
+
+import "strings"
+
+// Step maps a deployment-helper console command to a user-facing label. The
+// helper prints "Start: <command> ..." lines; matching them is the only
+// progress signal the installation offers.
+type Step struct {
+	Pattern string
+	Label   string
+}
+
+// Steps are the recognized installation phases, in execution order.
+var Steps = []Step{
+	{"system:install", "Installing Shopware"},
+	{"user:create", "Creating admin account"},
+	{"messenger:setup-transports", "Setting up message transports"},
+	{"sales-channel:create:storefront", "Creating storefront"},
+	{"theme:change", "Compiling theme"},
+	{"plugin:refresh", "Refreshing plugins"},
+}
+
+// stepStartPrefix marks deployment-helper lines that announce a new command.
+const stepStartPrefix = "Start: "
+
+// MatchStep reports the index of the step a deployment-helper output line
+// starts. Progress is monotonic: only steps at or after from match, so a
+// pattern echoed later in the output cannot move progress backwards.
+func MatchStep(line string, from int) (int, bool) {
+	if !strings.HasPrefix(line, stepStartPrefix) {
+		return 0, false
+	}
+	for i, step := range Steps {
+		if i >= from && strings.Contains(line, step.Pattern) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// FailedStep names the last step that had started when the install failed.
+// Failures before the first recognized step report the first step.
+func FailedStep(current int) string {
+	if current >= len(Steps) {
+		current = len(Steps) - 1
+	}
+	return Steps[current].Pattern
+}

--- a/internal/shop/install/steps.go
+++ b/internal/shop/install/steps.go
@@ -38,6 +38,11 @@ func MatchStep(line string, from int) (int, bool) {
 	return 0, false
 }
 
+// FailedStepSaveCredentials is the failed_step telemetry value for an
+// installation that succeeded but whose admin credentials could not be saved
+// to the project config.
+const FailedStepSaveCredentials = "save_credentials"
+
 // FailedStep names the last step that had started when the install failed.
 // Failures before the first recognized step report the first step.
 func FailedStep(current int) string {

--- a/internal/tui/dev/install_wizard.go
+++ b/internal/tui/dev/install_wizard.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/progress"
@@ -9,24 +8,11 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tracking"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/internal/tui/app"
 )
-
-// minAdminPasswordLength is the minimum admin password length enforced by the
-// Shopware core (user:create / system:install). Validating it here lets the
-// wizard reject too-short passwords up front instead of failing late during the
-// deployment-helper run.
-const minAdminPasswordLength = 8
-
-// validateAdminPassword mirrors the Shopware core password length requirement.
-func validateAdminPassword(password string) error {
-	if len([]rune(password)) < minAdminPasswordLength {
-		return fmt.Errorf("password must be at least %d characters long", minAdminPasswordLength)
-	}
-	return nil
-}
 
 type installStep int
 
@@ -35,30 +21,6 @@ const (
 	installStepLanguage
 	installStepCurrency
 	installStepCredentials
-)
-
-type installLanguage struct {
-	id    string
-	label string
-}
-
-var (
-	installLanguages = []installLanguage{
-		{"en-GB", "English (UK)"},
-		{"en-US", "English (US)"},
-		{"de-DE", "Deutsch"},
-		{"cs-CZ", "Čeština"},
-		{"da-DK", "Dansk"},
-		{"es-ES", "Español"},
-		{"fr-FR", "Français"},
-		{"it-IT", "Italiano"},
-		{"nl-NL", "Nederlands"},
-		{"nn-NO", "Norsk"},
-		{"pl-PL", "Język polski"},
-		{"pt-PT", "Português"},
-		{"sv-SE", "Svenska"},
-	}
-	installCurrencies = []string{"EUR", "USD", "GBP", "PLN", "CHF", "SEK", "DKK", "NOK", "CZK"}
 )
 
 type installWizard struct {
@@ -76,12 +38,12 @@ type installWizard struct {
 // prompts that match the install prompt layout.
 func newInstallCredentialStep() tui.CredentialStep {
 	return tui.NewCredentialStep(tui.CredentialStepOptions{
-		UsernamePlaceholder: defaultUsername,
+		UsernamePlaceholder: install.DefaultAdminUsername,
 		UsernamePrompt:      "Username: ",
-		PasswordPlaceholder: "shopware",
+		PasswordPlaceholder: install.DefaultAdminPassword,
 		PasswordPrompt:      "Password: ",
 		CharLimit:           50,
-		ValidatePassword:    validateAdminPassword,
+		ValidatePassword:    install.ValidateAdminPassword,
 	})
 }
 
@@ -91,18 +53,6 @@ type installProgress struct {
 	showLogs    bool
 	spinner     spinner.Model
 	progress    progress.Model
-}
-
-var installStepPatterns = []struct {
-	pattern string
-	label   string
-}{
-	{"system:install", "Installing Shopware"},
-	{"user:create", "Creating admin account"},
-	{"messenger:setup-transports", "Setting up message transports"},
-	{"sales-channel:create:storefront", "Creating storefront"},
-	{"theme:change", "Compiling theme"},
-	{"plugin:refresh", "Refreshing plugins"},
 }
 
 func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (app.Content, tea.Cmd) {
@@ -149,24 +99,24 @@ func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (app.Content, tea.Cmd) 
 
 func (m Model) updateInstallStepLanguage(msg tea.KeyPressMsg) (app.Content, tea.Cmd) {
 	if tui.KeyString(msg) == tui.KeyEnter {
-		m.install.language = installLanguages[m.install.cursor].id
+		m.install.language = install.Languages[m.install.cursor].ID
 		m.install.step = installStepCurrency
 		m.install.cursor = 0
 		return m, nil
 	}
-	m.install.cursor = tui.MoveCursor(m.install.cursor, tui.KeyString(msg), len(installLanguages))
+	m.install.cursor = tui.MoveCursor(m.install.cursor, tui.KeyString(msg), len(install.Languages))
 	return m, nil
 }
 
 func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (app.Content, tea.Cmd) {
 	if tui.KeyString(msg) == tui.KeyEnter {
-		m.install.currency = installCurrencies[m.install.cursor]
+		m.install.currency = install.Currencies[m.install.cursor]
 		m.install.step = installStepCredentials
-		m.install.SetUsername(defaultUsername)
-		m.install.SetPassword("shopware")
+		m.install.SetUsername(install.DefaultAdminUsername)
+		m.install.SetPassword(install.DefaultAdminPassword)
 		return m, m.install.Focus(tui.CredFocusUsername)
 	}
-	m.install.cursor = tui.MoveCursor(m.install.cursor, tui.KeyString(msg), len(installCurrencies))
+	m.install.cursor = tui.MoveCursor(m.install.cursor, tui.KeyString(msg), len(install.Currencies))
 	return m, nil
 }
 
@@ -198,17 +148,17 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 	case installStepLanguage:
 		b.WriteString(tui.TextBadge("Step 1/3"))
 		b.WriteString("\n\n")
-		opts := make([]tui.SelectOption, len(installLanguages))
-		for i, lang := range installLanguages {
-			opts[i] = tui.SelectOption{Label: lang.label, Detail: lang.id}
+		opts := make([]tui.SelectOption, len(install.Languages))
+		for i, lang := range install.Languages {
+			opts[i] = tui.SelectOption{Label: lang.Label, Detail: lang.ID}
 		}
 		b.WriteString(tui.RenderSelectList("Default Language", "Select the primary language for your storefront", opts, m.install.cursor))
 
 	case installStepCurrency:
 		b.WriteString(tui.TextBadge("Step 2/3"))
 		b.WriteString("\n\n")
-		opts := make([]tui.SelectOption, len(installCurrencies))
-		for i, curr := range installCurrencies {
+		opts := make([]tui.SelectOption, len(install.Currencies))
+		for i, curr := range install.Currencies {
 			opts[i] = tui.SelectOption{Label: curr}
 		}
 		b.WriteString(tui.RenderSelectList("Default Currency", "Select the default currency for pricing", opts, m.install.cursor))

--- a/internal/tui/dev/install_wizard_test.go
+++ b/internal/tui/dev/install_wizard_test.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -93,9 +94,9 @@ func TestInstallStepLanguage_CursorClampedAtBounds(t *testing.T) {
 
 	m2 := newTestInstallModel()
 	m2.install.step = installStepLanguage
-	m2.install.cursor = len(installLanguages) - 1
+	m2.install.cursor = len(install.Languages) - 1
 	updated, _ = m2.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
-	assert.Equal(t, len(installLanguages)-1, updated.(Model).install.cursor)
+	assert.Equal(t, len(install.Languages)-1, updated.(Model).install.cursor)
 }
 
 func TestInstallStepLanguage_EnterSelectsLanguageAdvancesToCurrency(t *testing.T) {
@@ -123,7 +124,7 @@ func TestInstallStepCurrency_UpDownAndEnter(t *testing.T) {
 	out := updated.(Model)
 	assert.Equal(t, "USD", out.install.currency)
 	assert.Equal(t, installStepCredentials, out.install.step)
-	assert.Equal(t, defaultUsername, out.install.Username())
+	assert.Equal(t, install.DefaultAdminUsername, out.install.Username())
 	assert.Equal(t, "shopware", out.install.Password())
 	assert.Equal(t, tui.CredFocusUsername, out.install.FocusTarget())
 	assert.NotNil(t, cmd)
@@ -132,10 +133,10 @@ func TestInstallStepCurrency_UpDownAndEnter(t *testing.T) {
 func TestInstallStepCurrency_CursorClampedAtBounds(t *testing.T) {
 	m := newTestInstallModel()
 	m.install.step = installStepCurrency
-	m.install.cursor = len(installCurrencies) - 1
+	m.install.cursor = len(install.Currencies) - 1
 
 	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
-	assert.Equal(t, len(installCurrencies)-1, updated.(Model).install.cursor)
+	assert.Equal(t, len(install.Currencies)-1, updated.(Model).install.cursor)
 }
 
 func TestInstallStepCredentials_EnterOnUsernameFocusesPassword(t *testing.T) {
@@ -256,15 +257,6 @@ func TestInstallStepCredentials_CheckboxFocusedSwallowsTypedKeys(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-func TestValidateAdminPassword(t *testing.T) {
-	assert.NoError(t, validateAdminPassword("shopware"))
-	assert.NoError(t, validateAdminPassword("12345678"))
-	assert.Error(t, validateAdminPassword("shopwar"))
-	assert.Error(t, validateAdminPassword(""))
-	// Length is counted in runes, not bytes.
-	assert.Error(t, validateAdminPassword("äöü"))
-}
-
 func TestInstallStepCredentials_EnterWithShortPasswordBlocks(t *testing.T) {
 	m := newTestInstallModel()
 	m.install.step = installStepCredentials
@@ -370,12 +362,4 @@ func TestInstallFooterHint_UnknownStepReturnsEmpty(t *testing.T) {
 	m := newTestInstallModel()
 	m.install.step = installStep(999)
 	assert.Empty(t, m.installFooterHint())
-}
-
-func TestInstallStepPatterns_NonEmpty(t *testing.T) {
-	assert.NotEmpty(t, installStepPatterns)
-	for _, sp := range installStepPatterns {
-		assert.NotEmpty(t, sp.pattern)
-		assert.NotEmpty(t, sp.label)
-	}
 }

--- a/internal/tui/dev/lifecycle.go
+++ b/internal/tui/dev/lifecycle.go
@@ -1,11 +1,9 @@
 package dev
 
 import (
-	"strings"
-
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tracking"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/internal/tui/app"
@@ -27,16 +25,11 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 	case dockerOutputLineMsg:
 		m.overlayLines = tui.AppendTail(m.overlayLines, m.overlayMaxLines(), string(msg))
 		if m.phase == phaseInstalling {
-			line := string(msg)
-			if strings.HasPrefix(line, "Start: ") {
-				for i, sp := range installStepPatterns {
-					if strings.Contains(line, sp.pattern) && i >= m.installProg.currentStep {
-						m.installProg.currentStep = i
-						pct := float64(i) / float64(len(installStepPatterns))
-						cmd := m.installProg.progress.SetPercent(pct)
-						return m, tea.Batch(cmd, m.readNextDockerOutput())
-					}
-				}
+			if i, ok := install.MatchStep(string(msg), m.installProg.currentStep); ok {
+				m.installProg.currentStep = i
+				pct := float64(i) / float64(len(install.Steps))
+				cmd := m.installProg.progress.SetPercent(pct)
+				return m, tea.Batch(cmd, m.readNextDockerOutput())
 			}
 		}
 		return m, m.readNextDockerOutput()
@@ -78,7 +71,7 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 		if msg.err != nil {
 			if m.telemetry.installOnce() {
 				tags := m.telemetry.installTags(tracking.ResultFailure, m.install)
-				tags[tracking.TagFailedStep] = installFailedStep(m.installProg.currentStep)
+				tags[tracking.TagFailedStep] = install.FailedStep(m.installProg.currentStep)
 				trackEvent(tracking.EventDevInstall, tags)
 			}
 			m.installProg.showLogs = true
@@ -87,7 +80,7 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 			return m, nil
 		}
 		m.installProg.done = true
-		m.installProg.currentStep = len(installStepPatterns)
+		m.installProg.currentStep = len(install.Steps)
 		if m.telemetry.installOnce() {
 			trackEvent(tracking.EventDevInstall, m.telemetry.installTags(tracking.ResultSuccess, m.install))
 		}
@@ -95,12 +88,15 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 		username := m.install.Username()
 		password := m.install.Password()
 
-		adminApi := &shop.ConfigAdminApi{
-			Username: username,
-			Password: password,
+		if err := install.PersistCredentials(m.config, m.envConfig, m.projectRoot, install.Options{
+			AdminUsername: username,
+			AdminPassword: password,
+		}); err != nil {
+			m.installProg.showLogs = true
+			m.overlayLines = append(m.overlayLines, "", errorStyle.Render("Shopware was installed, but saving the admin credentials to the project config failed: "+err.Error()))
+			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
+			return m, nil
 		}
-		m.envConfig.AdminApi = adminApi
-		_ = shop.WriteConfig(m.config, m.projectRoot)
 
 		m.overview.username = username
 		m.overview.password = password

--- a/internal/tui/dev/lifecycle.go
+++ b/internal/tui/dev/lifecycle.go
@@ -81,21 +81,29 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 		}
 		m.installProg.done = true
 		m.installProg.currentStep = len(install.Steps)
-		if m.telemetry.installOnce() {
-			trackEvent(tracking.EventDevInstall, m.telemetry.installTags(tracking.ResultSuccess, m.install))
-		}
 
 		username := m.install.Username()
 		password := m.install.Password()
 
+		// Persist before recording the outcome, so a failed config write is
+		// not reported as a successful run.
 		if err := install.PersistCredentials(m.config, m.envConfig, m.projectRoot, install.Options{
 			AdminUsername: username,
 			AdminPassword: password,
 		}); err != nil {
+			if m.telemetry.installOnce() {
+				tags := m.telemetry.installTags(tracking.ResultFailure, m.install)
+				tags[tracking.TagFailedStep] = install.FailedStepSaveCredentials
+				trackEvent(tracking.EventDevInstall, tags)
+			}
 			m.installProg.showLogs = true
 			m.overlayLines = append(m.overlayLines, "", errorStyle.Render("Shopware was installed, but saving the admin credentials to the project config failed: "+err.Error()))
 			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
 			return m, nil
+		}
+
+		if m.telemetry.installOnce() {
+			trackEvent(tracking.EventDevInstall, m.telemetry.installTags(tracking.ResultSuccess, m.install))
 		}
 
 		m.overview.username = username

--- a/internal/tui/dev/lifecycle_test.go
+++ b/internal/tui/dev/lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -176,7 +177,7 @@ func TestUpdateLifecycle_ShopwareInstallDone_Success(t *testing.T) {
 
 	assert.Equal(t, phaseDashboard, final.phase)
 	assert.True(t, final.installProg.done)
-	assert.Equal(t, len(installStepPatterns), final.installProg.currentStep)
+	assert.Equal(t, len(install.Steps), final.installProg.currentStep)
 
 	assert.NotNil(t, final.envConfig.AdminApi)
 	assert.Equal(t, "myadmin", final.envConfig.AdminApi.Username)

--- a/internal/tui/dev/migration_wizard.go
+++ b/internal/tui/dev/migration_wizard.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shyim/go-composer"
 
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -94,7 +95,7 @@ func newMigrationWizard(projectRoot string) migrationWizard {
 			Password:            "shopware",
 			UsernamePlaceholder: "admin",
 			PasswordPlaceholder: "shopware",
-			ValidatePassword:    validateAdminPassword,
+			ValidatePassword:    install.ValidateAdminPassword,
 		}),
 		step:        migrationStepWelcome,
 		phpVersions: phpVersions,

--- a/internal/tui/dev/model.go
+++ b/internal/tui/dev/model.go
@@ -33,8 +33,6 @@ const (
 var tabNames = []string{"Overview", "Instance", "Config"}
 
 const (
-	defaultUsername = "admin"
-
 	watcherAdmin      = "Admin Watcher"
 	watcherStorefront = "Storefront Watcher"
 )
@@ -67,6 +65,12 @@ type Options struct {
 const fallbackShopURL = "http://127.0.0.1:8000"
 
 type Model struct {
+	// ctx is the command context of the CLI invocation (cancelled on
+	// SIGINT/SIGTERM, carries the logger). tea.Cmd closures derive their
+	// subprocess and API contexts from it. Bubbletea's fixed Update(msg)
+	// signature offers no parameter path into command builders, so the model
+	// has to carry it.
+	ctx             context.Context //nolint:containedctx
 	host            app.Host
 	header          tui.Header
 	activeTab       activeTab
@@ -107,8 +111,26 @@ type shopwareInstallDoneMsg struct{ err error }
 
 type configRestartDoneMsg struct{ err error }
 
-func New(opts Options) Model {
+// commandContext returns the context tea.Cmd closures should derive from.
+// Tests construct Model literals without New, so a nil ctx falls back to
+// Background.
+func (m Model) commandContext() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
+// cleanupContext returns a context for teardown work (stopping watchers and
+// containers, final telemetry) that must still run when the command context
+// is already cancelled, e.g. on SIGTERM.
+func (m Model) cleanupContext() context.Context {
+	return context.WithoutCancel(m.commandContext())
+}
+
+func New(ctx context.Context, opts Options) Model {
 	m := Model{
+		ctx:           ctx,
 		header:        tui.NewHeader(),
 		activeTab:     tabOverview,
 		dockerMode:    opts.Executor.Type() == executor.TypeDocker,
@@ -152,15 +174,15 @@ func (m *Model) rebuildTabs() {
 	isDocker := m.executor.Type() == executor.TypeDocker
 	envValues, _ := envfile.ReadValues(m.projectRoot, EnvFieldKeys()...)
 
-	m.overview = NewOverviewModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
-	m.instance = NewInstanceModel(m.projectRoot, isDocker)
+	m.overview = NewOverviewModel(m.commandContext(), m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
+	m.instance = NewInstanceModel(m.commandContext(), m.projectRoot, isDocker)
 	m.configTab = NewConfigModel(m.config, envValues)
 }
 
 // NewMigrationWizard creates a Model that starts in the migration wizard phase
 // for projects that don't yet have a development environment configured.
-func NewMigrationWizard(opts Options) Model {
-	m := New(opts)
+func NewMigrationWizard(ctx context.Context, opts Options) Model {
+	m := New(ctx, opts)
 	m.phase = phaseMigrationWizard
 	m.dockerMode = true // migration wizard always creates Docker env
 	m.migrationWizard = newMigrationWizard(opts.ProjectRoot)
@@ -168,13 +190,13 @@ func NewMigrationWizard(opts Options) Model {
 }
 
 // NewApp hosts the dashboard model inside the application shell.
-func NewApp(opts Options) *app.App {
-	return newShell(New(opts))
+func NewApp(ctx context.Context, opts Options) *app.App {
+	return newShell(New(ctx, opts))
 }
 
 // NewMigrationWizardApp hosts the migration-wizard model inside the shell.
-func NewMigrationWizardApp(opts Options) *app.App {
-	return newShell(NewMigrationWizard(opts))
+func NewMigrationWizardApp(ctx context.Context, opts Options) *app.App {
+	return newShell(NewMigrationWizard(ctx, opts))
 }
 
 // newShell wires a Model into the app host. Chrome and window title read the
@@ -214,7 +236,7 @@ func (m Model) initPhase() tea.Cmd {
 		return nil
 	}
 	if m.dockerMode {
-		return checkContainersRunning(m.projectRoot)
+		return checkContainersRunning(m.commandContext(), m.projectRoot)
 	}
 	return m.checkShopwareInstalled()
 }
@@ -222,7 +244,7 @@ func (m Model) initPhase() tea.Cmd {
 func (m *Model) shutdown() {
 	m.instance.StopStreaming()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(m.cleanupContext(), 3*time.Second)
 	defer cancel()
 
 	for name, h := range m.watchers {
@@ -308,7 +330,7 @@ func (m Model) updateContent(msg tea.Msg) (app.Content, tea.Cmd) {
 		// status and the setup-health checks it affects.
 		m.overview.domainsSetupDone = overviewSetupDone(m.projectRoot)
 		m.overview.healthLoading = true
-		return m, loadSetupHealth(context.Background(), m.projectRoot, m.executor)
+		return m, loadSetupHealth(m.commandContext(), m.projectRoot, m.executor)
 
 	case watcherStartedMsg, watcherRunningMsg, watcherProbeMsg, stopWatcherRequestMsg,
 		startStorefrontWatchRequestMsg, watcherStoppedMsg, logDoneMsg:
@@ -380,14 +402,14 @@ func (m Model) updateWatcherMsg(msg tea.Msg) (app.Content, tea.Cmd) {
 			if msg.err == nil && exists {
 				m.overview.adminWatchRunning = true
 				m.overview.adminWatchReady = false
-				return m, probeWatcher(watcherAdmin, m.overview.adminWatchURL)
+				return m, probeWatcher(m.commandContext(), watcherAdmin, m.overview.adminWatchURL)
 			}
 		case watcherStorefront:
 			m.overview.sfWatchStarting = false
 			if msg.err == nil && exists {
 				m.overview.sfWatchRunning = true
 				m.overview.sfWatchReady = false
-				return m, probeWatcher(watcherStorefront, m.overview.sfWatchURL)
+				return m, probeWatcher(m.commandContext(), watcherStorefront, m.overview.sfWatchURL)
 			}
 		}
 		return m, nil
@@ -407,7 +429,7 @@ func (m Model) updateWatcherMsg(msg tea.Msg) (app.Content, tea.Cmd) {
 			return m, nil
 		}
 		// Not serving yet — keep polling until it is.
-		return m, probeWatcher(msg.name, msg.url)
+		return m, probeWatcher(m.commandContext(), msg.name, msg.url)
 
 	case stopWatcherRequestMsg:
 		return m, m.stopWatcher(msg.name)
@@ -460,7 +482,7 @@ func (m Model) runProxySetup() (app.Content, tea.Cmd) {
 		bin = "shopware-cli"
 	}
 
-	c := exec.CommandContext(context.Background(), bin, "project", "proxy", "setup")
+	c := exec.CommandContext(m.commandContext(), bin, "project", "proxy", "setup")
 	c.Dir = m.projectRoot
 
 	return m, tea.ExecProcess(c, func(error) tea.Msg {

--- a/internal/tui/dev/model_commands.go
+++ b/internal/tui/dev/model_commands.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/shopware/shopware-cli/internal/proxy"
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -19,9 +20,9 @@ func newInstallProgress() progress.Model {
 	)
 }
 
-func checkContainersRunning(projectRoot string) tea.Cmd {
+func checkContainersRunning(ctx context.Context, projectRoot string) tea.Cmd {
 	return func() tea.Msg {
-		running := composeServiceSet(projectRoot, "ps", "--services", "--status=running")
+		running := composeServiceSet(ctx, projectRoot, "ps", "--services", "--status=running")
 		if len(running) == 0 {
 			return dockerNeedStartMsg{}
 		}
@@ -31,7 +32,7 @@ func checkContainersRunning(projectRoot string) tea.Cmd {
 		// compose.yaml (e.g. the messenger worker when the admin worker is
 		// disabled) is not running yet, so fall through to a start and let
 		// `up -d` reconcile the newcomers instead of jumping to the dashboard.
-		defined := composeServiceSet(projectRoot, "config", "--services")
+		defined := composeServiceSet(ctx, projectRoot, "config", "--services")
 		if !allRunning(defined, running) {
 			return dockerNeedStartMsg{}
 		}
@@ -57,8 +58,8 @@ func allRunning(defined, running map[string]struct{}) bool {
 // per line (e.g. `config --services` or `ps --services`) and returns the names
 // as a set. It returns nil when the command fails, so callers treat an
 // undeterminable list as "no constraint".
-func composeServiceSet(projectRoot string, args ...string) map[string]struct{} {
-	output, err := composeCommand(context.Background(), projectRoot, args...).Output()
+func composeServiceSet(ctx context.Context, projectRoot string, args ...string) map[string]struct{} {
+	output, err := composeCommand(ctx, projectRoot, args...).Output()
 	if err != nil {
 		return nil
 	}
@@ -74,9 +75,10 @@ func composeServiceSet(projectRoot string, args ...string) map[string]struct{} {
 }
 
 func (m *Model) checkShopwareInstalled() tea.Cmd {
+	ctx := m.commandContext()
 	exec := m.executor
 	return func() tea.Msg {
-		if err := exec.ConsoleCommand(context.Background(), "system:is-installed").Run(); err != nil {
+		if !install.IsInstalled(ctx, exec) {
 			return shopwareNotInstalledMsg{}
 		}
 		return shopwareInstalledMsg{}
@@ -84,25 +86,21 @@ func (m *Model) checkShopwareInstalled() tea.Cmd {
 }
 
 func (m *Model) runShopwareInstall() tea.Cmd {
+	ctx := m.commandContext()
 	e := m.executor
-	language := m.install.language
-	currency := m.install.currency
-	username := m.install.Username()
-	password := m.install.Password()
+	opts := install.Options{
+		Locale:        m.install.language,
+		Currency:      m.install.currency,
+		AdminUsername: m.install.Username(),
+		AdminPassword: m.install.Password(),
+	}
 
 	ch := make(chan string, tui.StreamBufferSize)
 	m.dockerOutChan = ch
 
 	doneCmd := func() tea.Msg {
-		withEnv := e.WithEnv(map[string]string{
-			"INSTALL_LOCALE":         language,
-			"INSTALL_CURRENCY":       currency,
-			"INSTALL_ADMIN_USERNAME": username,
-			"INSTALL_ADMIN_PASSWORD": password,
-		})
-		p := withEnv.PHPCommand(context.Background(), "vendor/bin/shopware-deployment-helper", "run")
-
-		err := tui.StreamCmdOutput(p.Cmd, ch, true)
+		err := install.Run(ctx, e, opts, func(line string) { ch <- line })
+		close(ch)
 		return shopwareInstallDoneMsg{err: err}
 	}
 
@@ -138,7 +136,7 @@ func runComposeCommand(ctx context.Context, projectRoot string, args []string, r
 func (m *Model) startContainers() tea.Cmd {
 	m.telemetry.beginDockerStart()
 	ch, outputCmd, doneCmd := runComposeCommand(
-		context.Background(),
+		m.commandContext(),
 		m.projectRoot,
 		[]string{"up", "-d"},
 		func(err error) tea.Msg { return dockerStartedMsg{err: err} },
@@ -149,20 +147,23 @@ func (m *Model) startContainers() tea.Cmd {
 
 func (m *Model) restartContainersForConfig() tea.Cmd {
 	m.telemetry.beginConfigRestart()
+	ctx := m.commandContext()
 	projectRoot := m.projectRoot
 	cfg := m.config
 	return func() tea.Msg {
 		if err := proxy.WriteComposeFile(projectRoot, cfg); err != nil {
 			return configRestartDoneMsg{err: err}
 		}
-		cmd := composeCommand(context.Background(), projectRoot, "up", "-d")
+		cmd := composeCommand(ctx, projectRoot, "up", "-d")
 		return configRestartDoneMsg{err: cmd.Run()}
 	}
 }
 
 func (m *Model) stopContainers() tea.Cmd {
+	// Stopping happens on the way out — it must still work when the command
+	// context was already cancelled by a signal.
 	ch, outputCmd, doneCmd := runComposeCommand(
-		context.Background(),
+		m.cleanupContext(),
 		m.projectRoot,
 		[]string{"down"},
 		func(err error) tea.Msg { return dockerStoppedMsg{err: err} },

--- a/internal/tui/dev/model_test.go
+++ b/internal/tui/dev/model_test.go
@@ -1,6 +1,7 @@
 package dev
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,8 +25,8 @@ import (
 func newTestModel() Model {
 	m := Model{
 		phase:       phaseDashboard,
-		overview:    NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
-		instance:    NewInstanceModel("/tmp/project", false),
+		overview:    NewOverviewModel(context.Background(), "local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		instance:    NewInstanceModel(context.Background(), "/tmp/project", false),
 		configTab:   NewConfigModel(nil, nil),
 		watchers:    make(map[string]*watcherHandle),
 		projectRoot: "/tmp/project",
@@ -70,7 +71,7 @@ func TestNew_InitializesFields(t *testing.T) {
 	// the case. We construct a real local executor instead.
 	exec := &executor.LocalExecutor{}
 	opts.Executor = exec
-	m := New(opts)
+	m := New(t.Context(), opts)
 
 	assert.Equal(t, tabOverview, m.activeTab)
 	assert.False(t, m.dockerMode)
@@ -87,7 +88,7 @@ func TestNewMigrationWizard_StartsInMigrationWizardPhase(t *testing.T) {
 		EnvConfig:   &shop.EnvironmentConfig{},
 		Executor:    &executor.LocalExecutor{},
 	}
-	m := NewMigrationWizard(opts)
+	m := NewMigrationWizard(t.Context(), opts)
 	assert.Equal(t, phaseMigrationWizard, m.phase)
 	assert.True(t, m.dockerMode)
 }

--- a/internal/tui/dev/model_test.go
+++ b/internal/tui/dev/model_test.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,11 +21,12 @@ import (
 // dashboard-phase key dispatch tests without nil-deref panics. The model is
 // attached to an app shell so overlay pushes have a host; assert on open
 // overlays with topOverlay.
-func newTestModel() Model {
+func newTestModel(t *testing.T) Model {
+	t.Helper()
 	m := Model{
 		phase:       phaseDashboard,
-		overview:    NewOverviewModel(context.Background(), "local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
-		instance:    NewInstanceModel(context.Background(), "/tmp/project", false),
+		overview:    NewOverviewModel(t.Context(), "local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		instance:    NewInstanceModel(t.Context(), "/tmp/project", false),
 		configTab:   NewConfigModel(nil, nil),
 		watchers:    make(map[string]*watcherHandle),
 		projectRoot: "/tmp/project",
@@ -94,13 +94,13 @@ func TestNewMigrationWizard_StartsInMigrationWizardPhase(t *testing.T) {
 }
 
 func TestInit_MigrationWizardPhaseReturnsNil(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseMigrationWizard
 	assert.Nil(t, m.Init())
 }
 
 func TestUpdateKeyPress_PhaseStarting_QuitKey(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseStarting
 
 	_, cmd := m.Update(keyRune('q'))
@@ -110,7 +110,7 @@ func TestUpdateKeyPress_PhaseStarting_QuitKey(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseStarting_LTogglesLogs(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseStarting
 	m.dockerShowLogs = false
 
@@ -122,7 +122,7 @@ func TestUpdateKeyPress_PhaseStarting_LTogglesLogs(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseStarting_OtherKeyIgnored(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseStarting
 
 	updated, cmd := m.Update(keyRune('x'))
@@ -131,7 +131,7 @@ func TestUpdateKeyPress_PhaseStarting_OtherKeyIgnored(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseStopping_CtrlCQuits(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseStopping
 
 	_, cmd := m.Update(keyCtrl('c'))
@@ -141,7 +141,7 @@ func TestUpdateKeyPress_PhaseStopping_CtrlCQuits(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseInstalling_LTogglesLogs(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseInstalling
 	m.installProg.showLogs = false
 
@@ -150,7 +150,7 @@ func TestUpdateKeyPress_PhaseInstalling_LTogglesLogs(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseInstalling_QuitKey(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseInstalling
 
 	_, cmd := m.Update(keyRune('q'))
@@ -160,7 +160,7 @@ func TestUpdateKeyPress_PhaseInstalling_QuitKey(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseTask_DoneTransitionsToDashboard(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseTask
 	m.task = tui.NewTask("Building...")
 	m.task, _ = m.task.Update(tui.TaskDoneMsg{})
@@ -173,7 +173,7 @@ func TestUpdateKeyPress_PhaseTask_DoneTransitionsToDashboard(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseTask_NotDoneQuitOnQ(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseTask
 	m.task = tui.NewTask("Building...")
 
@@ -184,7 +184,7 @@ func TestUpdateKeyPress_PhaseTask_NotDoneQuitOnQ(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseTask_NotDoneOtherKeyIgnored(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseTask
 	m.task = tui.NewTask("Building...")
 
@@ -194,7 +194,7 @@ func TestUpdateKeyPress_PhaseTask_NotDoneOtherKeyIgnored(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseInstallPrompt_Routed(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseInstallPrompt
 
 	// Ctrl+C in install prompt should quit (per updateInstallPrompt)
@@ -205,7 +205,7 @@ func TestUpdateKeyPress_PhaseInstallPrompt_Routed(t *testing.T) {
 }
 
 func TestUpdateKeyPress_PhaseMigrationWizard_RoutesToMigrationWizard(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.phase = phaseMigrationWizard
 	m.migrationWizard = newMigrationWizard("")
 	// Welcome step: Enter with confirmYes=true advances to admin user step
@@ -216,7 +216,7 @@ func TestUpdateKeyPress_PhaseMigrationWizard_RoutesToMigrationWizard(t *testing.
 }
 
 func TestUpdateDashboardKeys_CtrlPOpensPalette(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 
 	updated, cmd := m.Update(keyCtrl('p'))
 	um := updated.(Model)
@@ -226,7 +226,7 @@ func TestUpdateDashboardKeys_CtrlPOpensPalette(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_DigitSwitchesTabs(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 
 	updated, _ := m.Update(keyRune('2'))
 	assert.Equal(t, tabInstance, updated.(Model).activeTab)
@@ -239,7 +239,7 @@ func TestUpdateDashboardKeys_DigitSwitchesTabs(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_TabCyclesForward(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	assert.Equal(t, tabOverview, m.activeTab)
 
 	updated, _ := m.Update(keySpecial(tea.KeyTab))
@@ -253,7 +253,7 @@ func TestUpdateDashboardKeys_TabCyclesForward(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_ShiftTabCyclesBackward(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 
 	updated, _ := m.Update(keyShiftTabMsg())
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
@@ -263,7 +263,7 @@ func TestUpdateDashboardKeys_ShiftTabCyclesBackward(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_QuitWhenNotDockerQuits(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = false
 
 	_, cmd := m.Update(keyRune('q'))
@@ -273,7 +273,7 @@ func TestUpdateDashboardKeys_QuitWhenNotDockerQuits(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_QuitDockerModeOpensConfirm(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = true
 
 	updated, cmd := m.Update(keyRune('q'))
@@ -284,7 +284,7 @@ func TestUpdateDashboardKeys_QuitDockerModeOpensConfirm(t *testing.T) {
 }
 
 func TestUpdateDashboardKeys_CtrlCDockerModeOpensConfirm(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = true
 
 	updated, _ := m.Update(keyCtrl('c'))
@@ -296,7 +296,7 @@ func TestUpdateDashboardKeys_CtrlCDockerModeOpensConfirm(t *testing.T) {
 func TestUpdateConfigTab_EnterOnSaveWritesConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &shop.Config{URL: "http://localhost:8000"}
-	m := newTestModel()
+	m := newTestModel(t)
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
@@ -328,7 +328,7 @@ func TestUpdateConfigTab_EnterOnSaveFailureSetsErr(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 
 	cfg := &shop.Config{}
-	m := newTestModel()
+	m := newTestModel(t)
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
@@ -343,7 +343,7 @@ func TestUpdateConfigTab_EnterOnSaveFailureSetsErr(t *testing.T) {
 }
 
 func TestUpdateConfigTab_EnterOnPickerFieldOpensModal(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.activeTab = tabConfig
 	m.configTab.cursor = fieldPHPVersion
 
@@ -355,7 +355,7 @@ func TestUpdateConfigTab_EnterOnPickerFieldOpensModal(t *testing.T) {
 }
 
 func TestExecuteCommand_TabRouting(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 
 	updated, _ := m.executeCommand("tab-instance")
 	assert.Equal(t, tabInstance, updated.(Model).activeTab)
@@ -368,7 +368,7 @@ func TestExecuteCommand_TabRouting(t *testing.T) {
 }
 
 func TestExecuteCommand_QuitNonDockerReturnsTeaQuit(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = false
 
 	_, cmd := m.executeCommand("quit")
@@ -378,7 +378,7 @@ func TestExecuteCommand_QuitNonDockerReturnsTeaQuit(t *testing.T) {
 }
 
 func TestExecuteCommand_QuitDockerOpensStopConfirm(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = true
 
 	updated, cmd := m.executeCommand("quit")
@@ -389,7 +389,7 @@ func TestExecuteCommand_QuitDockerOpensStopConfirm(t *testing.T) {
 }
 
 func TestExecuteCommand_AdminWatchStartSetsStarting(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.overview.adminWatchRunning = false
 	m.overview.adminWatchStarting = false
 
@@ -400,7 +400,7 @@ func TestExecuteCommand_AdminWatchStartSetsStarting(t *testing.T) {
 }
 
 func TestExecuteCommand_AdminWatchStartNoOpWhenRunning(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.overview.adminWatchRunning = true
 
 	updated, cmd := m.executeCommand("admin-watch-start")
@@ -410,7 +410,7 @@ func TestExecuteCommand_AdminWatchStartNoOpWhenRunning(t *testing.T) {
 }
 
 func TestExecuteCommand_AdminWatchStopClearsRunning(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.overview.adminWatchRunning = true
 	m.watchers[watcherAdmin] = &watcherHandle{}
 
@@ -424,7 +424,7 @@ func TestExecuteCommand_AdminWatchStopClearsRunning(t *testing.T) {
 }
 
 func TestStopWatcher_RemovesFromMapAndEmitsMsg(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	// Use a nil process entry so cmd() doesn't try to Stop a real exec.Cmd.
 	m.watchers["test-watcher"] = nil
 
@@ -440,7 +440,7 @@ func TestStopWatcher_RemovesFromMapAndEmitsMsg(t *testing.T) {
 }
 
 func TestStopWatcher_NoEntryStillEmitsMsg(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 
 	cmd := m.stopWatcher("missing")
 	msg := cmd()
@@ -510,7 +510,7 @@ func TestView_DoesNotPanicForEachPhase(t *testing.T) {
 	ctx := app.Context{Width: 120, Height: 40, MainHeight: 36}
 	phases := []phase{phaseDashboard, phaseStarting, phaseStopping, phaseInstallPrompt, phaseInstalling, phaseTask, phaseMigrationWizard}
 	for _, p := range phases {
-		m := newTestModel()
+		m := newTestModel(t)
 		m.width = 120
 		m.height = 40
 		m.phase = p
@@ -534,14 +534,14 @@ func TestView_DoesNotPanicForEachPhase(t *testing.T) {
 }
 
 func TestView_ZeroSizeDoesNotPanic(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	assert.NotPanics(t, func() {
 		_ = m.View(app.Context{})
 	})
 }
 
 func TestView_StopConfirmOverlayRenders(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.dockerMode = true
 
 	updated, _ := m.Update(keyCtrl('c'))
@@ -556,7 +556,7 @@ func TestView_StopConfirmOverlayRenders(t *testing.T) {
 
 func TestSaveMigrationWizard_PersistsConfigToDisk(t *testing.T) {
 	dir := t.TempDir()
-	m := newTestModel()
+	m := newTestModel(t)
 	m.projectRoot = dir
 	m.config = &shop.Config{}
 	m.migrationWizard = newMigrationWizard(dir)
@@ -581,7 +581,7 @@ func TestSaveMigrationWizard_FailedWriteSetsErr(t *testing.T) {
 	assert.NoError(t, os.Chmod(dir, 0o500))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 
-	m := newTestModel()
+	m := newTestModel(t)
 	m.projectRoot = dir
 	m.config = &shop.Config{}
 	m.migrationWizard = newMigrationWizard("")
@@ -596,7 +596,7 @@ func TestSaveMigrationWizard_FailedWriteSetsErr(t *testing.T) {
 // one tab leaking into the hidden tabs' handlers. With the Logs tab active,
 // pressing Enter must not run the Overview tab's activate() logic.
 func TestUpdateChildren_KeyOnlyReachesActiveTab(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.activeTab = tabInstance
 	// Overview cursor sits on the Admin watcher (0); an Enter leaking through
 	// would flip adminWatchStarting.
@@ -611,7 +611,7 @@ func TestUpdateChildren_KeyOnlyReachesActiveTab(t *testing.T) {
 // TestUpdateChildren_KeyReachesActiveOverview confirms the active tab still
 // receives its keys after the routing change.
 func TestUpdateChildren_KeyReachesActiveOverview(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.activeTab = tabOverview
 	m.overview.cursor = 0 // Admin watcher
 
@@ -626,7 +626,7 @@ func TestUpdateChildren_KeyReachesActiveOverview(t *testing.T) {
 // storefront-watch start to the parent so the sales-channel picker resolves the
 // theme/domain, instead of starting with empty options.
 func TestStartStorefrontWatchRequest_OpensPicker(t *testing.T) {
-	m := newTestModel()
+	m := newTestModel(t)
 	m.activeTab = tabOverview
 	m.executor = &executor.LocalExecutor{}
 	m.overview.cursor = 1 // Storefront watcher
@@ -661,7 +661,7 @@ func TestView_WindowTitlePerPhase(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		m := newTestModel()
+		m := newTestModel(t)
 		m.projectRoot = "/tmp/project"
 		m.phase = tc.phase
 

--- a/internal/tui/dev/model_update.go
+++ b/internal/tui/dev/model_update.go
@@ -178,9 +178,9 @@ func (m Model) executeCommand(id string) (app.Content, tea.Cmd) {
 		m.telemetry.countAction()
 		trackEvent(tracking.EventDevAction, map[string]string{tracking.TagAction: id})
 		if id == "open-shop" {
-			return m, openInBrowser(m.overview.shopURL)
+			return m, openInBrowser(m.commandContext(), m.overview.shopURL)
 		}
-		return m, openInBrowser(m.overview.adminURL)
+		return m, openInBrowser(m.commandContext(), m.overview.adminURL)
 	case "cache-clear":
 		m.telemetry.beginTask(id)
 		return m, m.runCacheClear()
@@ -233,7 +233,7 @@ func (m Model) openSalesChannelPicker() (app.Content, tea.Cmd) {
 	if m.overview.sfWatchRunning || m.overview.sfWatchStarting {
 		return m, nil
 	}
-	return m, m.host.PushOverlay(newSalesChannelPicker(m.executor))
+	return m, m.host.PushOverlay(newSalesChannelPicker(m.commandContext(), m.executor))
 }
 
 func (m *Model) stopWatcher(name string) tea.Cmd {
@@ -245,9 +245,10 @@ func (m *Model) stopWatcher(name string) tea.Cmd {
 	h := m.watchers[name]
 	delete(m.watchers, name)
 
+	cleanupCtx := m.cleanupContext()
 	return func() tea.Msg {
 		if h != nil {
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			stopCtx, stopCancel := context.WithTimeout(cleanupCtx, 3*time.Second)
 			defer stopCancel()
 			h.stop(stopCtx)
 		}

--- a/internal/tui/dev/model_view.go
+++ b/internal/tui/dev/model_view.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/internal/tui/app"
 )
@@ -181,21 +182,21 @@ func (m Model) renderPhase(ctx app.Context) string {
 			return m.renderDockerLogs("Installing Shopware...", ctx.Width, ctx.MainHeight)
 		}
 		var card strings.Builder
-		total := len(installStepPatterns)
+		total := len(install.Steps)
 		pctText := fmt.Sprintf(" %d%%", int(float64(m.installProg.currentStep)/float64(total)*100))
 		card.WriteString(m.installProg.progress.View())
 		card.WriteString(tui.DimStyle.Render(pctText))
 		card.WriteString("\n\n")
 
-		items := make([]tui.StepItem, len(installStepPatterns))
-		for i, sp := range installStepPatterns {
+		items := make([]tui.StepItem, len(install.Steps))
+		for i, sp := range install.Steps {
 			switch {
 			case i < m.installProg.currentStep || (i == m.installProg.currentStep && m.installProg.done):
-				items[i] = tui.StepItem{Label: sp.label, State: tui.StepStateDone}
+				items[i] = tui.StepItem{Label: sp.Label, State: tui.StepStateDone}
 			case i == m.installProg.currentStep && !m.installProg.done:
-				items[i] = tui.StepItem{Label: sp.label, State: tui.StepStateActive, Indicator: m.installProg.spinner.View()}
+				items[i] = tui.StepItem{Label: sp.Label, State: tui.StepStateActive, Indicator: m.installProg.spinner.View()}
 			default:
-				items[i] = tui.StepItem{Label: tui.DimStyle.Render(sp.label), State: tui.StepStatePending}
+				items[i] = tui.StepItem{Label: tui.DimStyle.Render(sp.Label), State: tui.StepStatePending}
 			}
 		}
 		card.WriteString(tui.NewStepList(tui.StepListOptions{Steps: items}).Render())

--- a/internal/tui/dev/overlay_sales_channel_picker.go
+++ b/internal/tui/dev/overlay_sales_channel_picker.go
@@ -35,6 +35,9 @@ type salesChannelEntry struct {
 }
 
 type salesChannelPicker struct {
+	// ctx is the CLI command context the Admin API calls run under. See
+	// Model.ctx for why bubbletea forces it onto the struct.
+	ctx      context.Context //nolint:containedctx
 	executor executor.Executor
 	loading  bool
 	err      error
@@ -42,21 +45,25 @@ type salesChannelPicker struct {
 	inner    *picker.Overlay
 }
 
-func newSalesChannelPicker(exec executor.Executor) *salesChannelPicker {
-	return &salesChannelPicker{executor: exec, loading: true}
+func newSalesChannelPicker(ctx context.Context, exec executor.Executor) *salesChannelPicker {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &salesChannelPicker{ctx: ctx, executor: exec, loading: true}
 }
 
 func (sp *salesChannelPicker) ID() string { return "sales-channel-picker" }
 
 func (sp *salesChannelPicker) Init() tea.Cmd {
+	ctx := sp.ctx
 	exec := sp.executor
 	return func() tea.Msg {
-		client, err := exec.AdminAPIClient(context.Background())
+		client, err := exec.AdminAPIClient(ctx)
 		if err != nil {
 			return salesChannelsLoadedMsg{err: err}
 		}
 
-		apiCtx := adminSdk.NewApiContext(context.Background())
+		apiCtx := adminSdk.NewApiContext(ctx)
 		channels, err := client.SalesChannel.ListStorefront(apiCtx)
 		if err != nil {
 			return salesChannelsLoadedMsg{err: err}

--- a/internal/tui/dev/overlay_sales_channel_picker_test.go
+++ b/internal/tui/dev/overlay_sales_channel_picker_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSalesChannelPicker_ConfirmEmitsWatcherOpts(t *testing.T) {
-	sp := newSalesChannelPicker(nil)
+	sp := newSalesChannelPicker(t.Context(), nil)
 
 	loaded := salesChannelsLoadedMsg{
 		channels: []salesChannelEntry{
@@ -57,14 +57,14 @@ func TestSalesChannelPicker_ConfirmEmitsWatcherOpts(t *testing.T) {
 func TestModel_SalesChannelPicker_FullRoutingFlow(t *testing.T) {
 	m := Model{
 		phase:    phaseDashboard,
-		overview: NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		overview: NewOverviewModel(t.Context(), "local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		watchers: make(map[string]*watcherHandle),
 	}
 	shell := app.New(app.Options{DisableDefaultKeys: true})
 	m.host = shell
 	shell.SetContent(m)
 
-	sp := newSalesChannelPicker(nil)
+	sp := newSalesChannelPicker(t.Context(), nil)
 	_ = shell.PushOverlay(sp)
 
 	_, _ = shell.Update(salesChannelsLoadedMsg{
@@ -103,7 +103,7 @@ func TestSalesChannelPicker_ExitWhileLoading(t *testing.T) {
 	// Before channels load the user must always have a way out, otherwise the
 	// loading/error/empty view feels stuck.
 	for _, key := range []rune{tea.KeyEsc, tea.KeyEnter} {
-		sp := newSalesChannelPicker(nil)
+		sp := newSalesChannelPicker(t.Context(), nil)
 		assert.Nil(t, sp.inner, "inner picker should not exist before channels load")
 
 		next, cmd := sp.Update(tea.KeyPressMsg(tea.Key{Code: key}))
@@ -116,7 +116,7 @@ func TestSalesChannelPicker_ExitWhileLoading(t *testing.T) {
 	}
 
 	// 'q' is also accepted as an exit key.
-	sp := newSalesChannelPicker(nil)
+	sp := newSalesChannelPicker(t.Context(), nil)
 	next, cmd := sp.Update(tea.KeyPressMsg(tea.Key{Code: 'q', Text: "q"}))
 	assert.Nil(t, next)
 	res, ok := cmd().(salesChannelPickerResultMsg)

--- a/internal/tui/dev/overlay_stop_confirm_test.go
+++ b/internal/tui/dev/overlay_stop_confirm_test.go
@@ -51,26 +51,26 @@ func TestStopConfirm_ViewRendersAllChoices(t *testing.T) {
 
 func TestHandleStopConfirmResult_Choices(t *testing.T) {
 	// Cancel (or dismissal) keeps the dashboard running.
-	m := newTestModel()
+	m := newTestModel(t)
 	updated, cmd := m.handleStopConfirmResult(prompt.ResultMsg{ID: stopConfirmID, Choice: stopConfirmCancel})
 	assert.Equal(t, phaseDashboard, updated.(Model).phase)
 	assert.Nil(t, cmd)
 
 	// Quit keeps containers running and exits.
-	m = newTestModel()
+	m = newTestModel(t)
 	_, cmd = m.handleStopConfirmResult(prompt.ResultMsg{ID: stopConfirmID, Choice: stopConfirmQuit})
 	require.NotNil(t, cmd)
 	_, isQuit := cmd().(tea.QuitMsg)
 	assert.True(t, isQuit)
 
 	// Stop enters the stopping phase instead of quitting outright.
-	m = newTestModel()
+	m = newTestModel(t)
 	updated, cmd = m.handleStopConfirmResult(prompt.ResultMsg{ID: stopConfirmID, Choice: stopConfirmStop})
 	assert.Equal(t, phaseStopping, updated.(Model).phase)
 	assert.NotNil(t, cmd)
 
 	// Results from other prompts are ignored.
-	m = newTestModel()
+	m = newTestModel(t)
 	updated, cmd = m.handleStopConfirmResult(prompt.ResultMsg{ID: "other", Choice: stopConfirmStop})
 	assert.Equal(t, phaseDashboard, updated.(Model).phase)
 	assert.Nil(t, cmd)

--- a/internal/tui/dev/tab_instance.go
+++ b/internal/tui/dev/tab_instance.go
@@ -38,6 +38,10 @@ type logSource struct {
 }
 
 type InstanceModel struct {
+	// ctx is the CLI command context the per-source log streams derive their
+	// cancellable contexts from. See Model.ctx for why bubbletea forces it
+	// onto the struct.
+	ctx         context.Context //nolint:containedctx
 	viewport    viewport.Model
 	sources     []logSource
 	cursor      int
@@ -78,8 +82,12 @@ type logSourcesLoadedMsg struct{ sources []logSource }
 
 const sidebarWidth = 28
 
-func NewInstanceModel(projectRoot string, dockerMode bool) InstanceModel {
+func NewInstanceModel(ctx context.Context, projectRoot string, dockerMode bool) InstanceModel {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return InstanceModel{
+		ctx:         ctx,
 		projectRoot: projectRoot,
 		dockerMode:  dockerMode,
 		follow:      true,
@@ -599,14 +607,14 @@ func (m *InstanceModel) streamProcess(src logSource) tea.Cmd {
 }
 
 func (m *InstanceModel) streamContainer(name, container string) tea.Cmd {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(m.ctx)
 	m.cancels[name] = cancel
 	cmd := composeCommand(ctx, m.projectRoot, "logs", "-f", "--tail=100", container)
 	return m.streamCommand(ctx, name, cmd, true)
 }
 
 func (m *InstanceModel) streamFile(name, filePath string) tea.Cmd {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(m.ctx)
 	m.cancels[name] = cancel
 	cmd := exec.CommandContext(ctx, "tail", "-n", "100", "-f", filePath)
 	return m.streamCommand(ctx, name, cmd, false)
@@ -671,13 +679,14 @@ func (m *InstanceModel) readNextLine() tea.Cmd {
 }
 
 func (m *InstanceModel) discoverSources() tea.Cmd {
+	ctx := m.ctx
 	projectRoot := m.projectRoot
 	dockerMode := m.dockerMode
 	return func() tea.Msg {
 		var sources []logSource
 
 		if dockerMode {
-			sources = append(sources, discoverContainers(projectRoot)...)
+			sources = append(sources, discoverContainers(ctx, projectRoot)...)
 		}
 
 		sources = append(sources, discoverLogFiles(projectRoot)...)
@@ -686,8 +695,8 @@ func (m *InstanceModel) discoverSources() tea.Cmd {
 	}
 }
 
-func discoverContainers(projectRoot string) []logSource {
-	cmd := composeCommand(context.Background(), projectRoot, "ps", "--format", "{{.Service}}")
+func discoverContainers(ctx context.Context, projectRoot string) []logSource {
+	cmd := composeCommand(ctx, projectRoot, "ps", "--format", "{{.Service}}")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil

--- a/internal/tui/dev/tab_instance_test.go
+++ b/internal/tui/dev/tab_instance_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewInstanceModel(t *testing.T) {
-	m := NewInstanceModel("/tmp/project", true)
+	m := NewInstanceModel(t.Context(), "/tmp/project", true)
 
 	assert.Equal(t, "/tmp/project", m.projectRoot)
 	assert.True(t, m.dockerMode)
@@ -29,7 +29,7 @@ func activeLines(m InstanceModel) []string {
 }
 
 func TestInstanceModel_LogLineMsg_AppendsLine(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "web"}}
 	m.active = 0
@@ -45,7 +45,7 @@ func TestInstanceModel_LogLineMsg_RoutesToOwningSource(t *testing.T) {
 	// A line tagged for a background (non-active) source must land in that
 	// source's buffer, not the active one - this is what preserves scrollback
 	// while viewing another source.
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "web"}, {name: "worker"}}
 	m.active = 0
@@ -57,7 +57,7 @@ func TestInstanceModel_LogLineMsg_RoutesToOwningSource(t *testing.T) {
 }
 
 func TestInstanceModel_LogLineMsg_NoCap(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "web"}}
 	m.active = 0
@@ -72,7 +72,7 @@ func TestInstanceModel_LogLineMsg_NoCap(t *testing.T) {
 }
 
 func TestInstanceModel_LogLineMsg_FollowAutoScrolls(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 10)
 	m.sources = []logSource{{name: "web"}}
 	m.active = 0
@@ -87,7 +87,7 @@ func TestInstanceModel_LogLineMsg_FollowAutoScrolls(t *testing.T) {
 }
 
 func TestInstanceModel_LogErrMsg_StylesErrorLine(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "web"}}
 	m.active = 0
@@ -102,7 +102,7 @@ func TestInstanceModel_LogErrMsg_StylesErrorLine(t *testing.T) {
 }
 
 func TestInstanceModel_LogDoneMsg_AppendsTerminator(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "test"}}
 	m.active = 0
@@ -113,7 +113,7 @@ func TestInstanceModel_LogDoneMsg_AppendsTerminator(t *testing.T) {
 }
 
 func TestInstanceModel_FollowToggle(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	assert.True(t, m.follow)
 
@@ -127,7 +127,7 @@ func TestInstanceModel_FollowToggle(t *testing.T) {
 }
 
 func TestInstanceModel_SourcesLoadedMsg(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 
 	sources := []logSource{
 		{name: "web"},
@@ -141,7 +141,7 @@ func TestInstanceModel_SourcesLoadedMsg(t *testing.T) {
 }
 
 func TestInstanceModel_SourcesLoadedMsg_EmptyKeepsInactive(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 
 	updated, cmd := m.Update(logSourcesLoadedMsg{sources: nil})
 	assert.Nil(t, cmd)
@@ -149,7 +149,7 @@ func TestInstanceModel_SourcesLoadedMsg_EmptyKeepsInactive(t *testing.T) {
 }
 
 func TestInstanceModel_CursorNavigation(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.sources = []logSource{{name: "a"}, {name: "b"}, {name: "c"}}
 	m.cursor = 0
 
@@ -178,7 +178,7 @@ func TestInstanceModel_CursorNavigation_FollowsVisualGroupOrder(t *testing.T) {
 	// added at runtime. The sidebar renders them grouped as containers,
 	// processes, files - so arrow keys must walk that visual order, not the
 	// raw slice order (otherwise the process appears unreachable).
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.sources = []logSource{
 		{name: "web", kind: sourceContainer},
 		{name: "worker", kind: sourceContainer},
@@ -211,7 +211,7 @@ func TestInstanceModel_CursorNavigation_FollowsVisualGroupOrder(t *testing.T) {
 }
 
 func TestInstanceModel_EnterFocusesAndFollows(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "a", filePath: "/nonexistent/a.log"},
@@ -233,7 +233,7 @@ func TestInstanceModel_EnterFocusesAndFollows(t *testing.T) {
 func TestInstanceModel_EnterPreservesEachSourceBuffer(t *testing.T) {
 	// Switching between sources must keep each source's own scrollback so
 	// returning to a source shows its previous log output.
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "a", lines: []string{"a-1", "a-2"}},
@@ -259,7 +259,7 @@ func TestInstanceModel_EnterPreservesEachSourceBuffer(t *testing.T) {
 }
 
 func TestInstanceModel_EnterNoChangeWhenCursorEqualsActive(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.sources = []logSource{{name: "a", lines: []string{"keep"}}}
 	m.active = 0
 	m.cursor = 0
@@ -271,7 +271,7 @@ func TestInstanceModel_EnterNoChangeWhenCursorEqualsActive(t *testing.T) {
 }
 
 func TestInstanceModel_StopStreamingCancelsAllSources(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	aCancelled, bCancelled := false, false
 	m.cancels["a"] = func() { aCancelled = true }
 	m.cancels["b"] = func() { bCancelled = true }
@@ -289,7 +289,7 @@ func TestInstanceModel_StopStreamingCancelsAllSources(t *testing.T) {
 }
 
 func TestInstanceModel_RemoveSource_DropsActiveAndReselects(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "worker", lines: []string{"w-1"}},
@@ -313,7 +313,7 @@ func TestInstanceModel_RemoveSource_DropsActiveAndReselects(t *testing.T) {
 }
 
 func TestInstanceModel_RemoveSource_KeepsActiveWhenRemovingOther(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "worker"},
@@ -332,7 +332,7 @@ func TestInstanceModel_RemoveSource_KeepsActiveWhenRemovingOther(t *testing.T) {
 }
 
 func TestInstanceModel_RemoveSource_LastSourceGoesInactive(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "Admin Watcher", kind: sourceProcess}}
 	m.active = 0
@@ -345,7 +345,7 @@ func TestInstanceModel_RemoveSource_LastSourceGoesInactive(t *testing.T) {
 }
 
 func TestInstanceModel_RemoveSource_UnknownIsNoOp(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.sources = []logSource{{name: "worker"}}
 	m.active = 0
 
@@ -355,14 +355,14 @@ func TestInstanceModel_RemoveSource_UnknownIsNoOp(t *testing.T) {
 }
 
 func TestInstanceModel_StopStreaming_NoState(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	assert.NotPanics(t, func() {
 		m.StopStreaming()
 	})
 }
 
 func TestInstanceModel_View_NoSourceSelected(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 
 	view := m.View()
@@ -370,7 +370,7 @@ func TestInstanceModel_View_NoSourceSelected(t *testing.T) {
 }
 
 func TestInstanceModel_View_ShowsActiveSourceAndLive(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "varnish"}, {name: "mysql"}}
 	m.active = 0
@@ -384,7 +384,7 @@ func TestInstanceModel_View_ShowsActiveSourceAndLive(t *testing.T) {
 
 func TestInstanceModel_View_RunningProcessUsesHollowDot(t *testing.T) {
 	ch := make(chan string)
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "worker", kind: sourceContainer},
@@ -415,7 +415,7 @@ func TestInstanceModel_View_RendersAtVariousSizes(t *testing.T) {
 	}
 
 	for _, sz := range sizes {
-		m := NewInstanceModel("/tmp", false)
+		m := NewInstanceModel(t.Context(), "/tmp", false)
 		m.SetSize(sz.w, sz.h)
 		assert.NotPanics(t, func() {
 			_ = m.View()
@@ -424,7 +424,7 @@ func TestInstanceModel_View_RendersAtVariousSizes(t *testing.T) {
 }
 
 func TestInstanceModel_View_NoSourcesShowsHelp(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 
 	view := m.View()
@@ -432,7 +432,7 @@ func TestInstanceModel_View_NoSourcesShowsHelp(t *testing.T) {
 }
 
 func TestInstanceModel_LogLineMsg_RendersInViewport(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "web"}}
 	m.active = 0
@@ -444,6 +444,6 @@ func TestInstanceModel_LogLineMsg_RendersInViewport(t *testing.T) {
 }
 
 func TestInstanceModel_Init(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
+	m := NewInstanceModel(t.Context(), "/tmp", false)
 	assert.Nil(t, m.Init())
 }

--- a/internal/tui/dev/tab_overview.go
+++ b/internal/tui/dev/tab_overview.go
@@ -39,6 +39,10 @@ import (
 // return nothing or only a tea.Cmd (SetSize, start*/stop* streaming helpers)
 // use pointer receivers.
 type OverviewModel struct {
+	// ctx is the CLI command context; tea.Cmd closures built by this model
+	// derive their subprocess and HTTP contexts from it. See Model.ctx for why
+	// bubbletea forces it onto the struct.
+	ctx                context.Context //nolint:containedctx
 	envType            string
 	shopURL            string
 	adminURL           string
@@ -226,10 +230,10 @@ var watcherProbeClient = &http.Client{
 
 // probeWatcher polls url once after a short delay and reports whether the
 // watcher is serving yet, so the UI can hold back its URL until then.
-func probeWatcher(name, url string) tea.Cmd {
+func probeWatcher(ctx context.Context, name, url string) tea.Cmd {
 	return tea.Tick(watcherProbeInterval, func(time.Time) tea.Msg {
 		ready := false
-		if req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil); err == nil {
+		if req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil); err == nil {
 			if resp, err := watcherProbeClient.Do(req); err == nil {
 				_ = resp.Body.Close()
 				ready = resp.StatusCode < 500
@@ -311,8 +315,12 @@ func deriveAdminURL(shopURL string) string {
 	return adminURL + "admin"
 }
 
-func NewOverviewModel(envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) OverviewModel {
+func NewOverviewModel(ctx context.Context, envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) OverviewModel {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return OverviewModel{
+		ctx:              ctx,
 		envType:          envType,
 		shopURL:          shopURL,
 		adminURL:         deriveAdminURL(shopURL),
@@ -384,12 +392,12 @@ func resolveStorefrontWatchURL(projectRoot string) string {
 
 func (m OverviewModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{
-		discoverServices(m.projectRoot),
+		discoverServices(m.ctx, m.projectRoot),
 		loadShopwareVersion(m.projectRoot),
-		loadSetupHealth(context.Background(), m.projectRoot, m.executor),
+		loadSetupHealth(m.ctx, m.projectRoot, m.executor),
 	}
 	if m.proxyHost != "" {
-		cmds = append(cmds, loadInstances())
+		cmds = append(cmds, loadInstances(m.ctx))
 	}
 	return tea.Batch(cmds...)
 }
@@ -413,9 +421,9 @@ const instancesTimeout = 10 * time.Second
 // the overview is open.
 const instancesRefreshInterval = 5 * time.Second
 
-func loadInstances() tea.Cmd {
+func loadInstances(parent context.Context) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), instancesTimeout)
+		ctx, cancel := context.WithTimeout(parent, instancesTimeout)
 		defer cancel()
 		instances, combinedMem, _ := proxy.InstanceStats(ctx)
 		return instancesLoadedMsg{instances: instances, combinedMem: combinedMem}
@@ -468,7 +476,7 @@ func (m OverviewModel) Update(msg tea.Msg) (OverviewModel, tea.Cmd) {
 	case shopwareVersionLoadedMsg:
 		m.shopwareVersion = msg.version
 		if msg.version != "" {
-			return m, loadSecurityEnd(msg.version)
+			return m, loadSecurityEnd(m.ctx, msg.version)
 		}
 	case securityEndLoadedMsg:
 		m.securityEnd = msg.securityEnd
@@ -481,7 +489,7 @@ func (m OverviewModel) Update(msg tea.Msg) (OverviewModel, tea.Cmd) {
 		m.instancesCombinedMem = msg.combinedMem
 		return m, scheduleInstancesRefresh()
 	case instancesTickMsg:
-		return m, loadInstances()
+		return m, loadInstances(m.ctx)
 	case tea.MouseWheelMsg:
 		return m.handleWheel(msg), nil
 	case tea.KeyPressMsg:
@@ -573,9 +581,9 @@ func (m OverviewModel) activate() (OverviewModel, tea.Cmd) {
 	return m, nil
 }
 
-func openInBrowser(url string) tea.Cmd {
+func openInBrowser(ctx context.Context, url string) tea.Cmd {
 	return func() tea.Msg {
-		_ = system.OpenURL(context.Background(), url)
+		_ = system.OpenURL(ctx, url)
 		return browserOpenedMsg{}
 	}
 }
@@ -1001,7 +1009,7 @@ func (m OverviewModel) startAdminWatch() tea.Cmd {
 	projectRoot := m.projectRoot
 	shopCfg := m.shopCfg
 
-	return startWatcher(watcherAdmin, context.Background(), func(ctx context.Context, out io.Writer) (*executor.Process, error) {
+	return startWatcher(watcherAdmin, m.ctx, func(ctx context.Context, out io.Writer) (*executor.Process, error) {
 		logStep(out, "Preparing plugins.json...")
 		if err := extension.WriteProjectPluginJson(ctx, projectRoot, shopCfg, e); err != nil {
 			return nil, fmt.Errorf("preparing plugins.json: %w", err)
@@ -1027,7 +1035,7 @@ func (m OverviewModel) startStorefrontWatch(opts extension.StorefrontWatcherOpti
 		opts.ProxyHostname = "storefront-watch." + host
 	}
 
-	return startWatcher(watcherStorefront, context.Background(), func(ctx context.Context, out io.Writer) (*executor.Process, error) {
+	return startWatcher(watcherStorefront, m.ctx, func(ctx context.Context, out io.Writer) (*executor.Process, error) {
 		logStep(out, "Preparing plugins.json...")
 		if err := extension.WriteProjectPluginJson(ctx, projectRoot, shopCfg, e); err != nil {
 			return nil, fmt.Errorf("preparing plugins.json: %w", err)
@@ -1092,9 +1100,10 @@ func startWatcher(name string, parent context.Context, prepare func(ctx context.
 			}
 
 			// If the user stopped the watcher while prepare was running, do not
-			// keep the freshly started dev server around as an orphan.
+			// keep the freshly started dev server around as an orphan. Cleanup
+			// must still run when the command context is already cancelled.
 			if handle.set(process) {
-				stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				stopCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), 3*time.Second)
 				_ = process.Stop(stopCtx)
 				cancel()
 				running <- errors.New("watcher stopped")
@@ -1311,9 +1320,9 @@ func ResolveShopURL(shopURL string, webPort int) string {
 	return u.String()
 }
 
-func discoverServices(projectRoot string) tea.Cmd {
+func discoverServices(ctx context.Context, projectRoot string) tea.Cmd {
 	return func() tea.Msg {
-		services, background, webPort, err := discoverCompose(context.Background(), projectRoot)
+		services, background, webPort, err := discoverCompose(ctx, projectRoot)
 		return servicesLoadedMsg{services: services, background: background, webPort: webPort, err: err}
 	}
 }
@@ -1328,9 +1337,9 @@ func loadShopwareVersion(projectRoot string) tea.Cmd {
 // date until which security updates are provided (the end-of-life date reported
 // by endoflife.date). It resolves to an empty string when the version cannot be
 // reduced to a major.minor cycle or the release is unknown to the API.
-func loadSecurityEnd(version string) tea.Cmd {
+func loadSecurityEnd(parent context.Context, version string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), securityEndTimeout)
+		ctx, cancel := context.WithTimeout(parent, securityEndTimeout)
 		defer cancel()
 		return securityEndLoadedMsg{securityEnd: fetchSecurityEnd(ctx, version)}
 	}

--- a/internal/tui/dev/tab_overview_health_test.go
+++ b/internal/tui/dev/tab_overview_health_test.go
@@ -123,7 +123,7 @@ func TestCollectSetupHealth_WithoutExecutor(t *testing.T) {
 }
 
 func TestOverviewViewShowsSetupHealth(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 	m.loading = false
 	m.healthLoading = false
 	m.health = []healthCheck{
@@ -149,7 +149,7 @@ func TestOverviewViewShowsSetupHealth(t *testing.T) {
 }
 
 func TestSetupHealthLinksAreZeroWidth(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 	m.loading = false
 	m.healthLoading = false
 	m.health = []healthCheck{
@@ -183,7 +183,7 @@ func stripANSI(s string) string {
 }
 
 func TestOverviewViewSetupHealthLoading(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 	m.loading = false
 
 	assert.Contains(t, m.View(120, 40), "CHECKING")

--- a/internal/tui/dev/tab_overview_test.go
+++ b/internal/tui/dev/tab_overview_test.go
@@ -34,7 +34,7 @@ func TestSecurityEndRemaining(t *testing.T) {
 }
 
 func TestOverviewBackgroundProcessesSection(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 	m.loading = false
 	m.width = 80
 	m.height = 40
@@ -60,7 +60,7 @@ func TestOverviewBackgroundProcessesSection(t *testing.T) {
 }
 
 func TestNewOverviewModel(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "docker", m.envType)
 	assert.Equal(t, "http://localhost:8000", m.shopURL)
@@ -72,19 +72,19 @@ func TestNewOverviewModel(t *testing.T) {
 }
 
 func TestNewOverviewModel_AdminURLTrailingSlash(t *testing.T) {
-	m := NewOverviewModel("local", "http://localhost:8000/", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "local", "http://localhost:8000/", "", "", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "http://localhost:8000/admin", m.adminURL)
 }
 
 func TestNewOverviewModel_EmptyURL(t *testing.T) {
-	m := NewOverviewModel("local", "", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "local", "", "", "", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "admin", m.adminURL)
 }
 
 func TestServicesLoadedMsg(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 
 	services := []DiscoveredService{
 		{Name: "Adminer", URL: "http://127.0.0.1:9080", Username: "root", Password: "root"},
@@ -102,7 +102,7 @@ func TestServicesLoadedMsg(t *testing.T) {
 }
 
 func TestServicesLoadedMsg_UpdatesPortFromWebService(t *testing.T) {
-	m := NewOverviewModel("docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
 
 	updated, _ := m.Update(servicesLoadedMsg{webPort: 8002})
 	assert.Equal(t, "http://127.0.0.1:8002", updated.shopURL)
@@ -110,7 +110,7 @@ func TestServicesLoadedMsg_UpdatesPortFromWebService(t *testing.T) {
 }
 
 func TestServicesLoadedMsg_KeepsCustomHostWhenUpdatingPort(t *testing.T) {
-	m := NewOverviewModel("docker", "http://foo.localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://foo.localhost:8000", "", "", "/tmp/project", nil, nil)
 
 	updated, _ := m.Update(servicesLoadedMsg{webPort: 8002})
 	assert.Equal(t, "http://foo.localhost:8002", updated.shopURL)
@@ -118,7 +118,7 @@ func TestServicesLoadedMsg_KeepsCustomHostWhenUpdatingPort(t *testing.T) {
 }
 
 func TestServicesLoadedMsg_NoWebPortKeepsURL(t *testing.T) {
-	m := NewOverviewModel("docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
 
 	updated, _ := m.Update(servicesLoadedMsg{})
 	assert.Equal(t, "http://127.0.0.1:8000", updated.shopURL)
@@ -139,7 +139,7 @@ func TestResolveShopURL(t *testing.T) {
 }
 
 func TestServicesLoadedMsg_WithError(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 
 	updated, _ := m.Update(servicesLoadedMsg{err: assert.AnError})
 	assert.False(t, updated.loading)
@@ -168,7 +168,7 @@ func TestKnownServices(t *testing.T) {
 }
 
 func TestViewShowsAccessTable(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 	m.loading = false
 	m.services = []DiscoveredService{
 		{Name: "Adminer", URL: "http://127.0.0.1:9080", Username: "root", Password: "root"},
@@ -191,7 +191,7 @@ func TestViewShowsAccessTable(t *testing.T) {
 }
 
 func TestViewAccessTableWithoutInstallation(t *testing.T) {
-	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel(t.Context(), "docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 	m.loading = false
 
 	view := m.View(120, 40)

--- a/internal/tui/dev/task_runner.go
+++ b/internal/tui/dev/task_runner.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"context"
 	"os"
 	"os/exec"
 
@@ -25,6 +24,7 @@ func (m *Model) runStorefrontBuild() tea.Cmd {
 }
 
 func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
+	ctx := m.commandContext()
 	projectRoot := m.projectRoot
 	dockerMode := m.dockerMode
 
@@ -33,7 +33,7 @@ func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
 		if err != nil {
 			return nil, err
 		}
-		cmd := exec.CommandContext(context.Background(), selfBin, append(args, projectRoot)...)
+		cmd := exec.CommandContext(ctx, selfBin, append(args, projectRoot)...)
 		if dockerMode {
 			cmd.Dir = projectRoot
 		}
@@ -42,8 +42,9 @@ func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
 }
 
 func (m *Model) runCacheClear() tea.Cmd {
+	ctx := m.commandContext()
 	e := m.executor
 	return m.runTask("Clearing Cache...", func() (*exec.Cmd, error) {
-		return e.ConsoleCommand(context.Background(), "cache:clear").Cmd, nil
+		return e.ConsoleCommand(ctx, "cache:clear").Cmd, nil
 	})
 }

--- a/internal/tui/dev/telemetry.go
+++ b/internal/tui/dev/telemetry.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopware/shopware-cli/internal/shop/install"
 	"github.com/shopware/shopware-cli/internal/tracking"
 )
 
@@ -75,7 +76,9 @@ func trackEvent(name string, tags map[string]string) {
 }
 
 // trackEventNow sends synchronously. Quit paths must use it — a goroutine
-// started right before tea.Quit would race the process exit.
+// started right before tea.Quit would race the process exit. It deliberately
+// uses context.Background(): quit-path events must still send when the
+// command context was already cancelled by a signal.
 func trackEventNow(name string, tags map[string]string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
@@ -162,9 +165,10 @@ func (t *telemetryState) installTags(result string, w installWizard) map[string]
 		tags[tracking.TagCurrency] = w.currency
 	}
 	if w.step == installStepCredentials || result == tracking.ResultSuccess || result == tracking.ResultFailure {
-		custom := w.Username() != defaultUsername || w.Password() != "shopware"
+		custom := w.Username() != install.DefaultAdminUsername || w.Password() != install.DefaultAdminPassword
 		tags[tracking.TagCustomCredentials] = strconv.FormatBool(custom)
 	}
+	tags[tracking.TagInteractive] = "true"
 	return tags
 }
 
@@ -311,16 +315,6 @@ func (t *telemetryState) watcherEndTags(name, result string) (map[string]string,
 		tracking.TagResult:     result,
 		tracking.TagDurationMS: durationMS(time.Since(started)),
 	}, true
-}
-
-// installFailedStep names the last deployment-helper step that had started
-// when the install failed. Failures before the first recognized step report
-// the first step.
-func installFailedStep(currentStep int) string {
-	if currentStep >= len(installStepPatterns) {
-		currentStep = len(installStepPatterns) - 1
-	}
-	return installStepPatterns[currentStep].pattern
 }
 
 func watcherTagName(name string) string {

--- a/internal/tui/dev/telemetry_test.go
+++ b/internal/tui/dev/telemetry_test.go
@@ -58,11 +58,6 @@ func TestInstallTagsDefaultCredentials(t *testing.T) {
 	assert.Equal(t, "false", tags["custom_credentials"])
 }
 
-func TestInstallFailedStepClampsToLastPattern(t *testing.T) {
-	assert.Equal(t, "system:install", installFailedStep(0))
-	assert.Equal(t, "plugin:refresh", installFailedStep(len(installStepPatterns)+5))
-}
-
 func TestMigrationWizardTagsCancelledOnWelcome(t *testing.T) {
 	sg := migrationWizard{step: migrationStepWelcome, phpVersions: []string{"8.2"}}
 	tags := migrationWizardTags("cancelled", sg)

--- a/internal/tui/upgrade/model.go
+++ b/internal/tui/upgrade/model.go
@@ -7,6 +7,8 @@
 package upgrade
 
 import (
+	"context"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/shopware/shopware-cli/internal/executor"
@@ -36,6 +38,12 @@ type Options struct {
 
 // Model is the wizard screen hosted by the app shell.
 type Model struct {
+	// ctx is the command context of the CLI invocation (cancelled on
+	// SIGINT/SIGTERM, carries the logger). tea.Cmd closures derive their
+	// backend and subprocess contexts from it. Bubbletea's fixed Update(msg)
+	// signature offers no parameter path into command builders, so the model
+	// has to carry it.
+	ctx      context.Context //nolint:containedctx
 	opts     Options
 	host     app.Host
 	upgrader *backend.ProjectUpgrader
@@ -57,9 +65,20 @@ type Model struct {
 	prepareGen int
 }
 
+// commandContext returns the context tea.Cmd closures should derive from.
+// Tests construct Model literals without New, so a nil ctx falls back to
+// Background.
+func (m *Model) commandContext() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
 // New creates the wizard model starting at the intro panel.
-func New(opts Options) *Model {
+func New(ctx context.Context, opts Options) *Model {
 	return &Model{
+		ctx:      ctx,
 		opts:     opts,
 		upgrader: backend.NewProjectUpgrader(opts.ProjectRoot, opts.Executor),
 		header:   tui.NewHeader(),
@@ -71,15 +90,15 @@ func New(opts Options) *Model {
 
 // NewApp assembles the wizard inside the application shell: wizard header as
 // chrome, ctrl+c interception while the upgrade runs, and window titles.
-func NewApp(opts Options) *app.App {
-	shell, _ := newAppWithModel(opts)
+func NewApp(ctx context.Context, opts Options) *app.App {
+	shell, _ := newAppWithModel(ctx, opts)
 	return shell
 }
 
 // newAppWithModel wires the model into the shell and also returns the model,
 // so tests can inspect wizard state.
-func newAppWithModel(opts Options) (*app.App, *Model) {
-	m := New(opts)
+func newAppWithModel(ctx context.Context, opts Options) (*app.App, *Model) {
+	m := New(ctx, opts)
 
 	shell := app.New(app.Options{
 		Content:           m,

--- a/internal/tui/upgrade/model_test.go
+++ b/internal/tui/upgrade/model_test.go
@@ -35,7 +35,7 @@ type wizard struct {
 
 func newTestWizard(t *testing.T) *wizard {
 	t.Helper()
-	shell, m := newAppWithModel(Options{ProjectRoot: "/projects/acme-shop", EnvName: "local"})
+	shell, m := newAppWithModel(t.Context(), Options{ProjectRoot: "/projects/acme-shop", EnvName: "local"})
 	h := &app.Harness{App: shell}
 	h.Send(tea.WindowSizeMsg{Width: 110, Height: 34})
 	return &wizard{Harness: h, m: m}

--- a/internal/tui/upgrade/panel_check.go
+++ b/internal/tui/upgrade/panel_check.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -65,7 +64,7 @@ func (m *Model) updateCheck(msg tea.Msg) (app.Content, tea.Cmd) {
 	case checksDoneMsg:
 		m.check.loading = false
 		m.check.readiness = msg.readiness
-		return m, loadCatalogCmd(context.Background(), m.upgrader, msg.readiness)
+		return m, loadCatalogCmd(m.commandContext(), m.upgrader, msg.readiness)
 
 	case catalogLoadedMsg:
 		m.check.catalog = msg.catalog
@@ -125,7 +124,7 @@ func (m *Model) updateCheckKeys(msg tea.KeyPressMsg) (app.Content, tea.Cmd) {
 
 func (m *Model) recheck() (app.Content, tea.Cmd) {
 	m.check.loading = true
-	return m, runChecksCmd(context.Background(), m.upgrader)
+	return m, runChecksCmd(m.commandContext(), m.upgrader)
 }
 
 func (m *Model) openVersionPicker() (app.Content, tea.Cmd) {

--- a/internal/tui/upgrade/panel_done.go
+++ b/internal/tui/upgrade/panel_done.go
@@ -48,6 +48,8 @@ func (m *Model) trackUpgradeCmd() tea.Cmd {
 	}
 
 	return func() tea.Msg {
+		// Deliberately context.Background(): the outcome event must still send
+		// when the command context was already cancelled by a signal.
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 		defer cancel()
 		tracking.Track(ctx, tracking.EventProjectUpgrade, map[string]string{

--- a/internal/tui/upgrade/panel_intro.go
+++ b/internal/tui/upgrade/panel_intro.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"context"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -45,7 +44,7 @@ func (m *Model) beginChecks() (app.Content, tea.Cmd) {
 	m.panel = panelCheck
 	m.check = newCheckState()
 	m.check.loading = true
-	return m, runChecksCmd(context.Background(), m.upgrader)
+	return m, runChecksCmd(m.commandContext(), m.upgrader)
 }
 
 func (m *Model) viewIntro() (title, status, body string) {

--- a/internal/tui/upgrade/panel_prepare.go
+++ b/internal/tui/upgrade/panel_prepare.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -57,11 +56,11 @@ func (m *Model) beginPrepare() (app.Content, tea.Cmd) {
 	m.prepare = prepareState{gen: m.prepareGen}
 	target := m.check.target()
 	return m, tea.Batch(
-		envStatusCmd(context.Background(), m.opts.Executor, m.prepareGen),
-		packagistCmd(context.Background(), m.upgrader, m.prepareGen),
-		resolveCmd(context.Background(), m.upgrader, target.Version.String(), m.prepareGen),
-		compatCmd(context.Background(), m.upgrader, m.check.readiness.CurrentVersion, target.Version, m.check.readiness.Extensions, m.prepareGen),
-		phpInfoCmd(context.Background(), m.upgrader, target.Version, m.prepareGen),
+		envStatusCmd(m.commandContext(), m.opts.Executor, m.prepareGen),
+		packagistCmd(m.commandContext(), m.upgrader, m.prepareGen),
+		resolveCmd(m.commandContext(), m.upgrader, target.Version.String(), m.prepareGen),
+		compatCmd(m.commandContext(), m.upgrader, m.check.readiness.CurrentVersion, target.Version, m.check.readiness.Extensions, m.prepareGen),
+		phpInfoCmd(m.commandContext(), m.upgrader, target.Version, m.prepareGen),
 	)
 }
 
@@ -114,7 +113,7 @@ func (m *Model) maybeLoadChangelogs() tea.Cmd {
 		return nil
 	}
 	m.prepare.changelogsRequested = true
-	return changelogsCmd(context.Background(), m.upgrader, target.Version.String(), m.prepare.results, m.prepare.gen)
+	return changelogsCmd(m.commandContext(), m.upgrader, target.Version.String(), m.prepare.results, m.prepare.gen)
 }
 
 // deploymentHelperMissing reports whether the upgrade will add

--- a/internal/tui/upgrade/panel_run.go
+++ b/internal/tui/upgrade/panel_run.go
@@ -35,7 +35,7 @@ func (m *Model) beginRun() (app.Content, tea.Cmd) {
 		return m, nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(m.commandContext())
 	opts := backend.RunOptions{
 		Target: target.Version.String(),
 		Report: m.reportData(),


### PR DESCRIPTION
## What

Adds `shopware-cli project dev install` — a non-interactive counterpart to the dev TUI's install wizard, for CI, scripts and agents:

```bash
shopware-cli project dev install \
  --locale de-DE --currency EUR \
  --admin-username admin --admin-password mysecret123
```

- Starts the dev environment, runs `vendor/bin/shopware-deployment-helper run` with the `INSTALL_*` env vars, streams step labels (`▸ Installing Shopware`, …) plus the full helper log, and saves the admin credentials to `.shopware-project.yml`.
- Flag defaults match the TUI wizard (`en-GB`, `EUR`, `admin`/`shopware`); locale/currency are validated against the wizard's allow-lists (with shell completions) and validation fails before Docker is touched.
- Idempotent: re-running on an installed shop prints a notice and exits 0.
- Non-TTY `project dev` now hints at the new command when Shopware isn't installed.

## How

The install logic moves out of the bubbletea model into a new **`internal/shop/install`** package, mirroring `internal/shop/upgrade`'s TUI/headless split, so the wizard and the command share one implementation (options + validation, deployment-helper run, step matching, credential persistence, telemetry — new `interactive` tag, documented in `TELEMETRY.md`).

Two fixes fall out of the extraction:

- Credentials written after a TUI install no longer vanish for configs using the deprecated top-level `url`/`admin_api` form (`ResolveEnvironment` returns a copy there).
- The previously swallowed `WriteConfig` error is surfaced in both paths.

## Context propagation

The dev and upgrade TUIs now propagate the CLI command context into their `tea.Cmd` closures instead of `context.Background()`, so SIGTERM cancels in-flight subprocesses (installs, compose commands, log tails, watchers, the upgrade runner via its existing cancel-and-rollback path). The models carry the context with `//nolint:containedctx` (same precedent as `internal/admin-api`'s `ApiContext`) since bubbletea's fixed `Update(msg)` signature offers no parameter path. Teardown derives from `context.WithoutCancel` and quit-path telemetry deliberately stays on `Background`, so both still run after a signal.

## Testing

- New unit tests for the install package: option validation/defaults, `INSTALL_*` env construction, step matching, and all three headless paths (skip / success + persist / failure), including the top-level-env persistence fix.
- `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint run` (0 issues), full `go test ./cmd/... ./internal/...` green.
- Manual: `project dev install --help`, flag validation errors, idempotent skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `project dev install` for non-interactive Shopware installation.
  * Added configurable locale, currency, administrator credentials, and shell completion.
  * Installation progress, errors, and completion details are now displayed in command output.
  * Existing installations are detected and skipped safely.
* **Bug Fixes**
  * Improved cancellation and cleanup behavior across development and upgrade workflows.
  * Installation credentials are persisted consistently after successful setup.
  * Installation failures now report the relevant step more accurately.
* **Documentation**
  * Updated installation telemetry documentation to distinguish interactive and non-interactive runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->