### PR TITLE
fix: reject extra arguments in extension commands and refresh before lifecycle lookup

### DIFF
--- a/cmd/extension/extension_admin_watch.go
+++ b/cmd/extension/extension_admin_watch.go
@@ -53,7 +53,7 @@ var (
 )
 
 var extensionAdminWatchCmd = &cobra.Command{
-	Use:   "admin-watch [path] [host]",
+	Use:   "admin-watch path... host",
 	Short: "Extremely fast ESBuild powered Shopware 6 Administration watcher",
 	Args:  cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/extension/extension_args_test.go
+++ b/cmd/extension/extension_args_test.go
@@ -1,0 +1,33 @@
+package extension
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The single-path commands process exactly one extension, so extra paths must
+// be rejected instead of silently ignored.
+func TestSinglePathCommandsRejectExtraArgs(t *testing.T) {
+	commands := []string{"fix", "validate", "get-name", "get-version", "get-changelog"}
+
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			extensionRootCmd.SetOut(out)
+			extensionRootCmd.SetErr(out)
+			extensionRootCmd.SetArgs([]string{command, t.TempDir(), t.TempDir()})
+			t.Cleanup(func() {
+				extensionRootCmd.SetArgs(nil)
+				extensionRootCmd.SetOut(nil)
+				extensionRootCmd.SetErr(nil)
+			})
+
+			err := extensionRootCmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "accepts 1 arg(s), received 2")
+		})
+	}
+}

--- a/cmd/extension/extension_args_test.go
+++ b/cmd/extension/extension_args_test.go
@@ -31,3 +31,21 @@ func TestSinglePathCommandsRejectExtraArgs(t *testing.T) {
 		})
 	}
 }
+
+// package takes a path and an optional branch, so a third argument must be
+// rejected instead of silently ignored.
+func TestPackageRejectsMoreThanTwoArgs(t *testing.T) {
+	out := new(bytes.Buffer)
+	extensionRootCmd.SetOut(out)
+	extensionRootCmd.SetErr(out)
+	extensionRootCmd.SetArgs([]string{"package", t.TempDir(), "branch", "extra"})
+	t.Cleanup(func() {
+		extensionRootCmd.SetArgs(nil)
+		extensionRootCmd.SetOut(nil)
+		extensionRootCmd.SetErr(nil)
+	})
+
+	err := extensionRootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts between 1 and 2 arg(s), received 3")
+}

--- a/cmd/extension/extension_build.go
+++ b/cmd/extension/extension_build.go
@@ -12,7 +12,7 @@ import (
 )
 
 var extensionAssetBundleCmd = &cobra.Command{
-	Use:   "build [path]",
+	Use:   "build path...",
 	Short: "Builds assets for extensions",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/extension/extension_changelog.go
+++ b/cmd/extension/extension_changelog.go
@@ -12,9 +12,9 @@ import (
 )
 
 var extensionChangelogCmd = &cobra.Command{
-	Use:   "get-changelog [path]",
+	Use:   "get-changelog path",
 	Short: "Get the changelog",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/extension/extension_fix.go
+++ b/cmd/extension/extension_fix.go
@@ -15,9 +15,9 @@ import (
 )
 
 var extensionFixCmd = &cobra.Command{
-	Use:   "fix [path]",
+	Use:   "fix path",
 	Short: "Fix an extension",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},

--- a/cmd/extension/extension_format.go
+++ b/cmd/extension/extension_format.go
@@ -13,7 +13,7 @@ import (
 )
 
 var extensionFormat = &cobra.Command{
-	Use:   "format [path]",
+	Use:   "format path",
 	Short: "Format an extension",
 	Args:  cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/extension/extension_name.go
+++ b/cmd/extension/extension_name.go
@@ -11,9 +11,9 @@ import (
 )
 
 var extensionNameCmd = &cobra.Command{
-	Use:   "get-name [path]",
+	Use:   "get-name path",
 	Short: "Get the name of the given extension",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/extension/extension_package.go
+++ b/cmd/extension/extension_package.go
@@ -28,7 +28,7 @@ var extensionPackageCmd = &cobra.Command{
 	Use:     "package path [branch]",
 	Short:   "Package an extension",
 	Aliases: []string{"zip"},
-	Args:    cobra.MinimumNArgs(1),
+	Args:    cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.CalledAs() == "zip" {
 			logging.FromContext(cmd.Context()).Warnf("`extension zip` is deprecated, use `extension package` instead")

--- a/cmd/extension/extension_package.go
+++ b/cmd/extension/extension_package.go
@@ -25,7 +25,7 @@ var (
 )
 
 var extensionPackageCmd = &cobra.Command{
-	Use:     "package [path] [branch]",
+	Use:     "package path [branch]",
 	Short:   "Package an extension",
 	Aliases: []string{"zip"},
 	Args:    cobra.MinimumNArgs(1),

--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -17,9 +17,9 @@ import (
 )
 
 var extensionValidateCmd = &cobra.Command{
-	Use:   "validate [path]",
+	Use:   "validate path",
 	Short: "Validate an extension",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		isFull, _ := cmd.Flags().GetBool("full")
 		storeCompliance, _ := cmd.Flags().GetBool("store-compliance")

--- a/cmd/extension/extension_version.go
+++ b/cmd/extension/extension_version.go
@@ -11,9 +11,9 @@ import (
 )
 
 var extensionVersionCmd = &cobra.Command{
-	Use:   "get-version [path]",
+	Use:   "get-version path",
 	Short: "Get the version of the given extension",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/project/project_args_test.go
+++ b/cmd/project/project_args_test.go
@@ -1,0 +1,33 @@
+package project
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// format, validate and fix take at most one optional path, so extra paths
+// must be rejected instead of silently ignored.
+func TestOptionalPathCommandsRejectExtraArgs(t *testing.T) {
+	commands := []string{"format", "validate", "fix"}
+
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			projectRootCmd.SetOut(out)
+			projectRootCmd.SetErr(out)
+			projectRootCmd.SetArgs([]string{command, t.TempDir(), t.TempDir()})
+			t.Cleanup(func() {
+				projectRootCmd.SetArgs(nil)
+				projectRootCmd.SetOut(nil)
+				projectRootCmd.SetErr(nil)
+			})
+
+			err := projectRootCmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "accepts at most 1 arg(s), received 2")
+		})
+	}
+}

--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -167,11 +167,6 @@ var projectExtensionUploadCmd = &cobra.Command{
 
 				return fmt.Errorf("cannot upload extension update: %s", string(str))
 			}
-
-			extensions, _, err = client.ExtensionManager.ListAvailableExtensions(adminCtx)
-			if err != nil {
-				return err
-			}
 		} else {
 			if uploadResponse, err := client.ExtensionManager.UploadExtensionUpdateToCloud(adminCtx, name, &buf); err != nil {
 				return fmt.Errorf("cannot upload extension update: %w", err)
@@ -194,6 +189,11 @@ var projectExtensionUploadCmd = &cobra.Command{
 		logging.FromContext(cmd.Context()).Infof("Refreshed extension list")
 
 		if doLifecycleEvents {
+			extensions, _, err = client.ExtensionManager.ListAvailableExtensions(adminCtx)
+			if err != nil {
+				return err
+			}
+
 			remoteExtension := extensions.GetByName(name)
 			if remoteExtension == nil {
 				return fmt.Errorf("cannot run lifecycle events: uploaded extension %s is not listed by the shop yet. Re-run the command to retry", name)

--- a/cmd/project/project_extension_upload_test.go
+++ b/cmd/project/project_extension_upload_test.go
@@ -12,17 +12,24 @@ import (
 
 // newEmptyExtensionListShop fakes the minimal Admin API surface the upload
 // command touches, always reporting an empty installed-extension list, and
-// records every request as "METHOD path". Requests outside that surface get
+// records every request as "METHOD path". With failSecondList the second
+// installed-list request returns a 500. Requests outside that surface get
 // a 404 so they surface as command errors.
-func newEmptyExtensionListShop(t *testing.T) (*httptest.Server, func() []string) {
+func newEmptyExtensionListShop(t *testing.T, failSecondList bool) (*httptest.Server, func() []string) {
 	t.Helper()
 
 	var mu sync.Mutex
 	var calls []string
+	listCalls := 0
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		calls = append(calls, r.Method+" "+r.URL.Path)
+		isList := r.Method == http.MethodGet && r.URL.Path == "/api/_action/extension/installed"
+		if isList {
+			listCalls++
+		}
+		failList := isList && failSecondList && listCalls > 1
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -31,7 +38,11 @@ func newEmptyExtensionListShop(t *testing.T) (*httptest.Server, func() []string)
 			_, _ = w.Write([]byte(`{"access_token":"token","token_type":"Bearer","expires_in":3600}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/api/_info/config":
 			_, _ = w.Write([]byte(`{"version":"6.6.5.0","bundles":{}}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/api/_action/extension/installed":
+		case isList:
+			if failList {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			_, _ = w.Write([]byte(`[]`))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/_action/extension/upload":
 			w.WriteHeader(http.StatusNoContent)
@@ -50,13 +61,14 @@ func newEmptyExtensionListShop(t *testing.T) (*httptest.Server, func() []string)
 	}
 }
 
-func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) {
-	srv, calls := newEmptyExtensionListShop(t)
-	pluginDir := writeMinimalPlugin(t)
+// setupUploadActivateEnv points the upload command at the fake shop and turns
+// the activate flag on, restoring the shared flag state afterwards.
+func setupUploadActivateEnv(t *testing.T, srvURL string) {
+	t.Helper()
 
 	clearShopClientEnv(t)
 	t.Setenv("PROJECT_ROOT", t.TempDir())
-	t.Setenv("SHOPWARE_CLI_API_URL", srv.URL)
+	t.Setenv("SHOPWARE_CLI_API_URL", srvURL)
 	t.Setenv("SHOPWARE_CLI_API_CLIENT_ID", "test")
 	t.Setenv("SHOPWARE_CLI_API_CLIENT_SECRET", "test")
 	t.Setenv("SHOPWARE_CLI_NO_SYMFONY_CLI", "1")
@@ -66,6 +78,12 @@ func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) 
 		require.NoError(t, projectExtensionUploadCmd.PersistentFlags().Set("activate", "false"))
 		projectExtensionUploadCmd.PersistentFlags().Lookup("activate").Changed = false
 	})
+}
+
+func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) {
+	srv, calls := newEmptyExtensionListShop(t, false)
+	pluginDir := writeMinimalPlugin(t)
+	setupUploadActivateEnv(t, srv.URL)
 
 	projectExtensionUploadCmd.SetContext(t.Context())
 	err := projectExtensionUploadCmd.RunE(projectExtensionUploadCmd, []string{pluginDir})
@@ -88,4 +106,16 @@ func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) 
 	require.NotEqual(t, -1, refreshIdx)
 	require.NotEqual(t, -1, lastListIdx)
 	assert.Greater(t, lastListIdx, refreshIdx)
+}
+
+func TestExtensionUploadActivateSurfacesListFetchError(t *testing.T) {
+	srv, _ := newEmptyExtensionListShop(t, true)
+	pluginDir := writeMinimalPlugin(t)
+	setupUploadActivateEnv(t, srv.URL)
+
+	projectExtensionUploadCmd.SetContext(t.Context())
+	err := projectExtensionUploadCmd.RunE(projectExtensionUploadCmd, []string{pluginDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "got http code 500")
+	assert.NotContains(t, err.Error(), "cannot run lifecycle events")
 }

--- a/cmd/project/project_extension_upload_test.go
+++ b/cmd/project/project_extension_upload_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,12 +11,20 @@ import (
 )
 
 // newEmptyExtensionListShop fakes the minimal Admin API surface the upload
-// command touches, always reporting an empty installed-extension list.
-// Requests outside that surface get a 404 so they surface as command errors.
-func newEmptyExtensionListShop(t *testing.T) *httptest.Server {
+// command touches, always reporting an empty installed-extension list, and
+// records every request as "METHOD path". Requests outside that surface get
+// a 404 so they surface as command errors.
+func newEmptyExtensionListShop(t *testing.T) (*httptest.Server, func() []string) {
 	t.Helper()
 
+	var mu sync.Mutex
+	var calls []string
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/oauth/token":
@@ -34,11 +43,15 @@ func newEmptyExtensionListShop(t *testing.T) *httptest.Server {
 	}))
 	t.Cleanup(srv.Close)
 
-	return srv
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), calls...)
+	}
 }
 
 func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) {
-	srv := newEmptyExtensionListShop(t)
+	srv, calls := newEmptyExtensionListShop(t)
 	pluginDir := writeMinimalPlugin(t)
 
 	clearShopClientEnv(t)
@@ -59,4 +72,20 @@ func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot run lifecycle events")
 	assert.Contains(t, err.Error(), "FroshTest")
+
+	// The lifecycle lookup must run against a list fetched after the refresh
+	// call, or fresh uploads are invisible to it on real shops.
+	got := calls()
+	refreshIdx, lastListIdx := -1, -1
+	for i, call := range got {
+		switch call {
+		case "POST /api/_action/extension/refresh":
+			refreshIdx = i
+		case "GET /api/_action/extension/installed":
+			lastListIdx = i
+		}
+	}
+	require.NotEqual(t, -1, refreshIdx)
+	require.NotEqual(t, -1, lastListIdx)
+	assert.Greater(t, lastListIdx, refreshIdx)
 }

--- a/cmd/project/project_fix.go
+++ b/cmd/project/project_fix.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ var projectFixCmd = &cobra.Command{
 		allowNonGit, _ := cmd.Flags().GetBool("allow-non-git")
 		if !allowNonGit {
 			if stat, err := os.Stat(filepath.Join(projectPath, ".git")); err != nil || !stat.IsDir() {
-				return errors.New("provided folder is not a git repository. Use --allow-non-git flag to run anyway")
+				return fmt.Errorf("%s is not a git repository. Use --allow-non-git flag to run anyway", projectPath)
 			}
 		}
 

--- a/cmd/project/project_fix.go
+++ b/cmd/project/project_fix.go
@@ -14,6 +14,7 @@ import (
 var projectFixCmd = &cobra.Command{
 	Use:   "fix [path]",
 	Short: "Fix project",
+	Args:  cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},

--- a/cmd/project/project_fix_test.go
+++ b/cmd/project/project_fix_test.go
@@ -32,13 +32,16 @@ func TestProjectFixNoArgsAppliesGitGuardToResolvedProject(t *testing.T) {
 	err := projectFixCmd.RunE(projectFixCmd, []string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a git repository")
+	assert.Contains(t, err.Error(), dir)
 }
 
 func TestProjectFixRejectsNonGitDirectory(t *testing.T) {
+	dir := t.TempDir()
 	projectFixCmd.SetContext(t.Context())
-	err := projectFixCmd.RunE(projectFixCmd, []string{t.TempDir()})
+	err := projectFixCmd.RunE(projectFixCmd, []string{dir})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a git repository")
+	assert.Contains(t, err.Error(), dir)
 }
 
 func TestProjectFixPassesGitGuardWithGitDirectory(t *testing.T) {

--- a/cmd/project/project_format.go
+++ b/cmd/project/project_format.go
@@ -11,7 +11,7 @@ import (
 )
 
 var projectFormatCmd = &cobra.Command{
-	Use:   "format",
+	Use:   "format [path]",
 	Short: "Format project",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)

--- a/cmd/project/project_format.go
+++ b/cmd/project/project_format.go
@@ -13,6 +13,7 @@ import (
 var projectFormatCmd = &cobra.Command{
 	Use:   "format [path]",
 	Short: "Format project",
+	Args:  cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -17,6 +17,7 @@ import (
 var projectValidateCmd = &cobra.Command{
 	Use:   "validate [path]",
 	Short: "Validate project",
+	Args:  cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -15,7 +15,7 @@ import (
 )
 
 var projectValidateCmd = &cobra.Command{
-	Use:   "validate",
+	Use:   "validate [path]",
 	Short: "Validate project",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)


### PR DESCRIPTION
## What

Follow-ups from the review of #1447:

- `extension fix`, `validate`, `get-name`, `get-version`, and `get-changelog` now use `cobra.ExactArgs(1)`. They process exactly one path, so extra arguments were silently ignored; `format` got the same fix in #1447.
- Use strings now tell the truth about arguments: bare `path` for required single-path commands, `build path...` for the variadic build, `package path [branch]`, `admin-watch path... host`, and `[path]` added to `project format` and `project validate`, where the argument really is optional.
- `project extension upload` fetches the extension list after `Refresh` instead of before it, so a first-time upload is visible to the `--activate` lifecycle lookup. The nil guard from #1447 stays as a backstop. The list is now only fetched again when `--activate` is set.
- The `project fix` git guard error names the resolved project path, which matters now that the guard also applies when no path was given.

## Notes for review

- Behavior change: passing extra paths to the five single-path extension commands is now an error instead of being silently dropped. Anyone relying on the old tolerance will see "accepts 1 arg(s), received 2".
- `extension prepare` (deprecated, removal announced for October 2026) and `extension config init` (argument genuinely optional) were deliberately left untouched.

## Tests

New table test covering the extra-argument rejection for all five commands. The upload test now records the fake shop's request order and asserts the lifecycle list fetch happens after the refresh call. The `project fix` tests additionally pin the resolved path in the guard message. `go test ./cmd/...` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project formatting and validation commands now accept an optional project path.
  * Command help clearly distinguishes required, optional, and multiple path arguments.
* **Bug Fixes**
  * Extension and project commands now reject unsupported extra arguments.
  * Project fix errors identify the affected project directory.
  * Extension uploads avoid unnecessary extension-list requests when lifecycle events are disabled and report refresh errors correctly.
* **Documentation**
  * Updated command usage text to accurately reflect supported argument patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->