### PR TITLE
test(account): first tests for the account command package

### DIFF
--- a/cmd/account/account_logout_test.go
+++ b/cmd/account/account_logout_test.go
@@ -1,0 +1,29 @@
+package account
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountLogoutRemovesTokenCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", cacheDir)
+	t.Setenv("SHOPWARE_CLI_ACCOUNT_STAGING", "")
+
+	tokenFile := filepath.Join(cacheDir, "shopware-api-token.json")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("{}"), 0o600))
+
+	accountRootCmd.SetContext(t.Context())
+	accountRootCmd.SetArgs([]string{"logout"})
+	t.Cleanup(func() { accountRootCmd.SetArgs(nil) })
+
+	require.NoError(t, accountRootCmd.Execute())
+	assert.NoFileExists(t, tokenFile)
+
+	// A second logout without a cache file is a no-op.
+	require.NoError(t, accountRootCmd.Execute())
+}

--- a/cmd/account/account_producer_extension_info_test.go
+++ b/cmd/account/account_producer_extension_info_test.go
@@ -1,0 +1,61 @@
+package account
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Both commands resolve the extension before any Account API use, so these
+// error paths run fully offline with the services container left nil.
+
+func TestAccountProducerExtensionInfoPullRejectsInvalidExtension(t *testing.T) {
+	t.Run("empty dir", func(t *testing.T) {
+		accountRootCmd.SetContext(t.Context())
+		accountRootCmd.SetArgs([]string{"producer", "extension", "info", "pull", t.TempDir()})
+		t.Cleanup(func() { accountRootCmd.SetArgs(nil) })
+
+		err := accountRootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot open extension")
+		assert.Contains(t, err.Error(), "unknown extension type")
+	})
+
+	t.Run("shopware 5 plugin", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.xml"), []byte("<plugin/>"), 0o644))
+
+		accountRootCmd.SetContext(t.Context())
+		accountRootCmd.SetArgs([]string{"producer", "extension", "info", "pull", dir})
+		t.Cleanup(func() { accountRootCmd.SetArgs(nil) })
+
+		err := accountRootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shopware 5 is not supported")
+	})
+}
+
+func TestAccountProducerExtensionInfoPushPathErrors(t *testing.T) {
+	t.Run("nonexistent path", func(t *testing.T) {
+		accountRootCmd.SetContext(t.Context())
+		accountRootCmd.SetArgs([]string{"producer", "extension", "info", "push", filepath.Join(t.TempDir(), "missing.zip")})
+		t.Cleanup(func() { accountRootCmd.SetArgs(nil) })
+
+		err := accountRootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot open file")
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		accountRootCmd.SetContext(t.Context())
+		accountRootCmd.SetArgs([]string{"producer", "extension", "info", "push", t.TempDir()})
+		t.Cleanup(func() { accountRootCmd.SetArgs(nil) })
+
+		err := accountRootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot open extension")
+	})
+}

--- a/cmd/account/account_producer_extension_list_test.go
+++ b/cmd/account/account_producer_extension_list_test.go
@@ -1,0 +1,27 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountProducerExtensionListRejectsPluginAndApp(t *testing.T) {
+	accountRootCmd.SetContext(t.Context())
+	accountRootCmd.SetArgs([]string{"producer", "extension", "list", "--plugin", "--app"})
+	// pflag keeps Changed=true across Execute calls, so without this reset
+	// every later list execution in the test binary fails group validation.
+	t.Cleanup(func() {
+		accountRootCmd.SetArgs(nil)
+		flags := accountCompanyProducerExtensionListCmd.Flags()
+		for _, name := range []string{"plugin", "app"} {
+			require.NoError(t, flags.Set(name, "false"))
+			flags.Lookup(name).Changed = false
+		}
+	})
+
+	err := accountRootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none of the others can be")
+}

--- a/cmd/account/account_test.go
+++ b/cmd/account/account_test.go
@@ -1,0 +1,35 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterWiresServiceContainer(t *testing.T) {
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", t.TempDir())
+	t.Setenv("SHOPWARE_CLI_ACCOUNT_STAGING", "")
+
+	var gotCommand string
+	container := &ServiceContainer{}
+	root := &cobra.Command{Use: "shopware-cli"}
+	Register(root, func(commandName string) (*ServiceContainer, error) {
+		gotCommand = commandName
+		return container, nil
+	})
+	root.SetArgs([]string{"account", "logout"})
+	// Cobra routes any later Execute on accountRootCmd through its root, so
+	// the dummy parent must be detached again or it breaks the other tests.
+	t.Cleanup(func() {
+		root.SetArgs(nil)
+		root.RemoveCommand(accountRootCmd)
+		accountRootCmd.PersistentPreRunE = nil
+		services = nil
+	})
+
+	require.NoError(t, root.Execute())
+	assert.Equal(t, "logout", gotCommand)
+	assert.Same(t, container, services)
+}


### PR DESCRIPTION
## What

Second coverage PR in the series. cmd/account had zero test files; this adds 5 offline tests and takes the package from 0% to 46.7% with no production changes.

- `Register` wiring: the package's only DI seam. Verifies the `PersistentPreRunE` installed by `Register` passes the executed leaf command name to `onInit` and stores the returned container in the `services` var. A regression here breaks every account subcommand while unit tests of the subcommands keep passing.
- `account logout`: deletes `shopware-api-token.json` from the (isolated) cache dir and is a no-op when no cache file exists. A stale token surviving logout is a real security issue; the file content is irrelevant to the test, so it stays agnostic of the private cache format.
- `producer extension list`: `--plugin --app` fails via `MarkFlagsMutuallyExclusive` before RunE runs. Without the guard the combination would silently filter everything out.
- `producer extension info pull` and `push`: the argument and extension-detection error paths (`unknown extension type`, the Shopware 5 rejection, `cannot open file`), which all run before any Account API use.

## Notes for review

- Deliberately offline: no fake Account API server is introduced. API-backed happy paths (list output, upload wiring) stay untested at cmd level; the flows themselves are covered in `internal/account-api` against its fake producer.
- `account login` is deliberately untested here: its RunE is a banner plus one `accountApi.NewApi` call, and the token-cache functions are unexported, so a cmd test would have to hand-serialize the private cache format that `internal/account-api`'s own tests already pin.
- Cache-touching tests isolate `SHOPWARE_CLI_CACHE_DIR` (and blank the staging switch), so they can never read or delete a developer's real token.
- Two cleanup details matter: the Register test detaches the dummy parent again (cobra routes `Execute` through `Root()`), and the flag test resets pflag's `Changed` state, which persists across `Execute` calls in one process.

## Tests

5 tests (7 with subtests) across 4 files mirroring the source layout. `go test ./cmd/account/ -race -count=2 -shuffle=on` passes; package coverage 0% to 46.7%.
