### PR TITLE
test(project): cover proxy, dev and image-proxy safety contracts

### DIFF
--- a/cmd/project/project_dev_test.go
+++ b/cmd/project/project_dev_test.go
@@ -1,0 +1,31 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func TestSetupDevEnvironmentRejectsOldCompatibilityDate(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".shopware-project.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte("compatibility_date: 2020-01-01\n"), 0o644))
+	t.Setenv("PROJECT_ROOT", dir)
+
+	// Register never runs in the test binary, so the global defaults to "" and
+	// ReadConfig would silently fall back to a modern compatibility date.
+	oldPath := projectConfigPath
+	projectConfigPath = configPath
+	t.Cleanup(func() { projectConfigPath = oldPath })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	_, err := setupDevEnvironment(cmd)
+	require.ErrorIs(t, err, shop.ErrDevModeNotSupported)
+}

--- a/cmd/project/project_image_proxy_run_test.go
+++ b/cmd/project/project_image_proxy_run_test.go
@@ -1,9 +1,17 @@
 package project
 
 import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,4 +68,120 @@ func TestImageProxyRunEValidatesUpstreamAndPublicDir(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "public folder not found")
 	})
+}
+
+// waitUntilServing polls url until the proxy answers with 200.
+func waitUntilServing(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+		require.NoError(t, err)
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			require.NoError(t, resp.Body.Close())
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("server did not start serving %s", url)
+}
+
+func httpGet(t *testing.T, url string) (string, http.Header) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return string(body), resp.Header
+}
+
+// waitForFile polls for path; the cache write happens when the proxy
+// finishes streaming a response, slightly after the client sees the body.
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("file %s did not appear", path)
+}
+
+func TestImageProxyServesCachesAndCleansUp(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "public"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "public", "local.txt"), []byte("local-file"), 0o644))
+	t.Setenv("PROJECT_ROOT", root)
+
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, l.Close())
+
+	oldURL, oldPort, oldConfigPath := imageProxyURL, imageProxyPort, projectConfigPath
+	t.Cleanup(func() { imageProxyURL, imageProxyPort, projectConfigPath = oldURL, oldPort, oldConfigPath })
+	imageProxyURL, imageProxyPort = upstream.URL, port
+	projectConfigPath = filepath.Join(root, ".shopware-project.yml")
+
+	// Cancelling the context is the command's shutdown path, the same one
+	// Ctrl+C takes through signal.NotifyContext in root.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	projectImageProxyCmd.SetContext(ctx)
+	done := make(chan error, 1)
+	go func() { done <- projectImageProxyCmd.RunE(projectImageProxyCmd, nil) }()
+
+	base := "http://127.0.0.1:" + port
+	waitUntilServing(t, base+"/local.txt")
+
+	// The Shopware filesystem override exists while the proxy runs.
+	configFile := filepath.Join(root, "config", "packages", "zzz-sw-cli-image-proxy.yml")
+	content, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "http://localhost:"+port)
+
+	// Local public files win; upstream is never asked.
+	body, _ := httpGet(t, base+"/local.txt")
+	assert.Equal(t, "local-file", body)
+	assert.EqualValues(t, 0, upstreamHits.Load())
+
+	// An unknown path proxies to upstream and lands in the cache.
+	body, _ = httpGet(t, base+"/media/img.png")
+	assert.Equal(t, "png-bytes", body)
+	assert.EqualValues(t, 1, upstreamHits.Load())
+	waitForFile(t, filepath.Join(root, "var", "cache", "image-proxy", "_media_img.png"))
+
+	// The second request is a cache hit with the stored content type.
+	body, header := httpGet(t, base+"/media/img.png")
+	assert.Equal(t, "png-bytes", body)
+	assert.Equal(t, "HIT", header.Get("X-Cache"))
+	assert.Equal(t, "image/png", header.Get("Content-Type"))
+	assert.EqualValues(t, 1, upstreamHits.Load())
+
+	// Shutdown removes the override, the guard against permanently
+	// rewriting a real shop's media URL.
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("image proxy did not shut down after context cancellation")
+	}
+	assert.NoFileExists(t, configFile)
 }

--- a/cmd/project/project_image_proxy_run_test.go
+++ b/cmd/project/project_image_proxy_run_test.go
@@ -1,0 +1,63 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The existing image-proxy tests exercise a replica of the handler stack;
+// these cover the real RunE's fail-fast validations, which all return before
+// any server starts.
+func TestImageProxyRunEValidatesUpstreamAndPublicDir(t *testing.T) {
+	oldURL, oldConfigPath := imageProxyURL, projectConfigPath
+	t.Cleanup(func() {
+		imageProxyURL = oldURL
+		projectConfigPath = oldConfigPath
+	})
+
+	run := func(t *testing.T, root string) error {
+		t.Helper()
+		t.Setenv("PROJECT_ROOT", root)
+		projectImageProxyCmd.SetContext(t.Context())
+		return projectImageProxyCmd.RunE(projectImageProxyCmd, nil)
+	}
+
+	t.Run("missing upstream", func(t *testing.T) {
+		root := t.TempDir()
+		projectConfigPath = filepath.Join(root, ".shopware-project.yml")
+		imageProxyURL = ""
+
+		err := run(t, root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "upstream URL must be provided")
+	})
+
+	t.Run("missing public dir", func(t *testing.T) {
+		root := t.TempDir()
+		projectConfigPath = filepath.Join(root, ".shopware-project.yml")
+		imageProxyURL = "https://upstream.example.com"
+
+		err := run(t, root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "public folder not found")
+	})
+
+	// The config fallback is consulted when the flag is absent: it passes the
+	// upstream check and still fails at the public-dir check, proving order.
+	t.Run("config fallback provides the upstream", func(t *testing.T) {
+		root := t.TempDir()
+		configPath := filepath.Join(root, ".shopware-project.yml")
+		require.NoError(t, os.WriteFile(configPath,
+			[]byte("compatibility_date: 2026-03-01\nimage_proxy:\n  url: https://upstream.example.com\n"), 0o644))
+		projectConfigPath = configPath
+		imageProxyURL = ""
+
+		err := run(t, root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "public folder not found")
+	})
+}

--- a/cmd/project/project_proxy_config_test.go
+++ b/cmd/project/project_proxy_config_test.go
@@ -1,0 +1,56 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/proxy"
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func TestSwitchProjectConfigURLsRemembersPreProxyState(t *testing.T) {
+	t.Run("no config file leaves everything alone", func(t *testing.T) {
+		dir := t.TempDir()
+		env := &proxyEnvironment{configPath: filepath.Join(dir, ".shopware-project.yml"), canonicalRoot: dir}
+
+		state := env.switchProjectConfigURLs(proxy.Registry{}, "https://shop.shopware.local")
+		assert.Nil(t, state)
+		assert.NoFileExists(t, env.configPath)
+	})
+
+	t.Run("existing url is remembered and rewritten", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, ".shopware-project.yml")
+		require.NoError(t, os.WriteFile(configPath, []byte("url: http://127.0.0.1:8000\n"), 0o644))
+		env := &proxyEnvironment{configPath: configPath, canonicalRoot: dir}
+
+		state := env.switchProjectConfigURLs(proxy.Registry{}, "https://shop.shopware.local")
+		require.NotNil(t, state)
+		assert.True(t, state.HasFile)
+		assert.True(t, state.HasRoot)
+		assert.Equal(t, "http://127.0.0.1:8000", state.RootURL)
+
+		after, err := shop.ReadProjectURLState(configPath, "")
+		require.NoError(t, err)
+		assert.Equal(t, "https://shop.shopware.local", after.RootURL)
+	})
+
+	// The up-to-down restore invariant: re-registration must return the state
+	// remembered by the registry, not re-read the already-proxied file, or
+	// "proxy down" could never restore the user's original URLs.
+	t.Run("registry state wins over the rewritten file", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, ".shopware-project.yml")
+		require.NoError(t, os.WriteFile(configPath, []byte("url: https://already-proxied.shopware.local\n"), 0o644))
+		remembered := &shop.ConfigURLState{HasFile: true, HasRoot: true, RootURL: "http://127.0.0.1:8000"}
+		reg := proxy.Registry{Projects: []proxy.ProjectEntry{{ProjectRoot: dir, PreviousConfig: remembered}}}
+		env := &proxyEnvironment{configPath: configPath, canonicalRoot: dir}
+
+		state := env.switchProjectConfigURLs(reg, "https://shop.shopware.local")
+		assert.Same(t, remembered, state)
+	})
+}

--- a/cmd/project/project_proxy_list_test.go
+++ b/cmd/project/project_proxy_list_test.go
@@ -1,0 +1,75 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/proxy"
+)
+
+func TestProxyStatusReportsUnregisteredProject(t *testing.T) {
+	isolateProxyState(t)
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	err := proxyStatus(cmd, t.TempDir())
+	require.ErrorIs(t, err, ErrProxyNotRegistered)
+}
+
+func TestProxyStatusFindsRegisteredProject(t *testing.T) {
+	isolateProxyState(t)
+	root := proxy.CanonicalProjectRoot(t.TempDir())
+	reg := proxy.Registry{Projects: []proxy.ProjectEntry{{ProjectRoot: root, Hostname: "shop.shopware.local"}}}
+	require.NoError(t, reg.Save())
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	require.NoError(t, proxyStatus(cmd, root))
+}
+
+func TestRunningServicesParsesContainerNames(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("COMPOSE_PROJECT_NAME=myshop\n"), 0o644))
+	entry := proxy.ProjectEntry{ProjectRoot: root, Hostname: "shop.shopware.local"}
+
+	instances := []proxy.Instance{
+		{Container: "myshop-web-1"},
+		{Container: "myshop-adminer-1"},
+		{Container: "myshop-mailer-2"},
+		{Container: "otherproj-web-1"},
+	}
+
+	assert.Equal(t, []string{"adminer", "mailer", "web"}, runningServices(entry, instances))
+	assert.True(t, projectIsRunning(entry, instances))
+
+	foreignOnly := []proxy.Instance{{Container: "otherproj-web-1"}}
+	assert.Empty(t, runningServices(entry, foreignOnly))
+	assert.False(t, projectIsRunning(entry, foreignOnly))
+}
+
+func TestProjectLinksShowsOnlyLabeledServices(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("COMPOSE_PROJECT_NAME=myshop\n"), 0o644))
+	entry := proxy.ProjectEntry{ProjectRoot: root, Hostname: "shop.shopware.local"}
+
+	instances := []proxy.Instance{
+		{Container: "myshop-web-1"},
+		{Container: "myshop-adminer-1"},
+		{Container: "myshop-mailer-1"},
+	}
+
+	links := projectLinks(entry, instances)
+	require.GreaterOrEqual(t, len(links), 2)
+	assert.Equal(t, serviceLink{label: "Shop", url: "https://shop.shopware.local"}, links[0])
+	assert.Equal(t, serviceLink{label: "Admin", url: "https://shop.shopware.local/admin"}, links[1])
+
+	assert.Contains(t, links, serviceLink{label: "Adminer", url: "https://adminer.shop.shopware.local"})
+	assert.Contains(t, links, serviceLink{label: "Mailpit", url: "https://mailer.shop.shopware.local"})
+	// Unlabeled services like web add no link.
+	assert.Len(t, links, 4)
+}

--- a/cmd/project/project_proxy_setup_test.go
+++ b/cmd/project/project_proxy_setup_test.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/proxy"
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+func newDomainFlagCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("domain", "", "")
+	cmd.SetContext(t.Context())
+	return cmd
+}
+
+func TestResolveDomainFlag(t *testing.T) {
+	t.Run("no flag returns the stored default", func(t *testing.T) {
+		isolateProxyState(t)
+		domain, change, err := resolveDomainFlag(newDomainFlagCommand(t))
+		require.NoError(t, err)
+		assert.Equal(t, "shopware.local", domain)
+		assert.Nil(t, change)
+	})
+
+	t.Run("same domain is a no-op", func(t *testing.T) {
+		isolateProxyState(t)
+		cmd := newDomainFlagCommand(t)
+		require.NoError(t, cmd.Flags().Set("domain", "shopware.local"))
+		domain, change, err := resolveDomainFlag(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "shopware.local", domain)
+		assert.Nil(t, change)
+	})
+
+	t.Run("invalid domain errors", func(t *testing.T) {
+		isolateProxyState(t)
+		cmd := newDomainFlagCommand(t)
+		require.NoError(t, cmd.Flags().Set("domain", "Bad_Domain"))
+		_, _, err := resolveDomainFlag(cmd)
+		require.Error(t, err)
+	})
+
+	// This value flows into root-privileged resolver writes; refusing while
+	// projects are registered protects their hostnames and certificates.
+	t.Run("registered projects block a domain change", func(t *testing.T) {
+		isolateProxyState(t)
+		reg := proxy.Registry{Projects: []proxy.ProjectEntry{{ProjectRoot: t.TempDir(), Hostname: "shop.shopware.local"}}}
+		require.NoError(t, reg.Save())
+
+		cmd := newDomainFlagCommand(t)
+		require.NoError(t, cmd.Flags().Set("domain", "dev.internal"))
+		_, _, err := resolveDomainFlag(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "teardown")
+	})
+
+	t.Run("clean domain change persists nothing", func(t *testing.T) {
+		isolateProxyState(t)
+		cmd := newDomainFlagCommand(t)
+		require.NoError(t, cmd.Flags().Set("domain", "dev.internal"))
+		domain, change, err := resolveDomainFlag(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "dev.internal", domain)
+		require.NotNil(t, change)
+		assert.Equal(t, "shopware.local", change.previous)
+		assert.Equal(t, "dev.internal", change.requested)
+
+		settings, err := proxy.LoadSettings()
+		require.NoError(t, err)
+		assert.Equal(t, "shopware.local", settings.BaseDomain())
+	})
+}
+
+func TestChooseAutomaticSetupNeverPromptsNonInteractively(t *testing.T) {
+	// stdin is not a terminal under go test, so the sudo path must never be
+	// chosen; this is the "never sudo unprompted" guarantee for CI and agents.
+	auto, err := chooseAutomaticSetup(t.Context(), "shopware.local", true)
+	require.NoError(t, err)
+	assert.False(t, auto)
+
+	auto, err = chooseAutomaticSetup(system.WithInteraction(t.Context(), false), "shopware.local", false)
+	require.NoError(t, err)
+	assert.False(t, auto)
+}

--- a/cmd/project/project_proxy_teardown_test.go
+++ b/cmd/project/project_proxy_teardown_test.go
@@ -1,0 +1,36 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/proxy"
+)
+
+func TestConfirmTeardownRequiresForceWithoutTerminal(t *testing.T) {
+	reg := proxy.Registry{Projects: []proxy.ProjectEntry{{ProjectRoot: t.TempDir(), Hostname: "shop.shopware.local"}}}
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("force", false, "")
+		cmd.SetContext(t.Context())
+		return cmd
+	}
+
+	// Teardown affects every registered project; without a terminal it must
+	// refuse unless --force is passed.
+	cmd := newCmd()
+	confirmed, err := confirmTeardown(cmd, reg)
+	require.Error(t, err)
+	assert.False(t, confirmed)
+	assert.Contains(t, err.Error(), "--force")
+
+	cmd = newCmd()
+	require.NoError(t, cmd.Flags().Set("force", "true"))
+	confirmed, err = confirmTeardown(cmd, reg)
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+}

--- a/cmd/project/project_proxy_verify.go
+++ b/cmd/project/project_proxy_verify.go
@@ -49,8 +49,12 @@ failing layer is reported with a hint how to fix it.`,
 // e.g. before the first `proxy up` or after a `teardown`), so callers can tell a
 // broken setup from an idle one. Shared by `proxy verify` and the final step of
 // `proxy setup`.
+// proxyVerify is a package variable so tests can fake the machine checks,
+// which probe real DNS, TLS and docker state.
+var proxyVerify = proxy.Verify
+
 func runProxyVerification(ctx context.Context, baseDomain string) (ready, notStarted bool) {
-	results := proxy.Verify(ctx, baseDomain)
+	results := proxyVerify(ctx, baseDomain)
 
 	ready = true
 	onlyPending := true

--- a/cmd/project/project_proxy_verify.go
+++ b/cmd/project/project_proxy_verify.go
@@ -43,16 +43,16 @@ failing layer is reported with a hint how to fix it.`,
 	},
 }
 
+// proxyVerify is a package variable so tests can fake the machine checks,
+// which probe real DNS, TLS and docker state.
+var proxyVerify = proxy.Verify
+
 // runProxyVerification prints the outcome of every proxy health check. It
 // returns ready (every check passed) and notStarted (the only failures are
 // layers that are simply not running yet — the shared DNS or Traefik container,
 // e.g. before the first `proxy up` or after a `teardown`), so callers can tell a
 // broken setup from an idle one. Shared by `proxy verify` and the final step of
 // `proxy setup`.
-// proxyVerify is a package variable so tests can fake the machine checks,
-// which probe real DNS, TLS and docker state.
-var proxyVerify = proxy.Verify
-
 func runProxyVerification(ctx context.Context, baseDomain string) (ready, notStarted bool) {
 	results := proxyVerify(ctx, baseDomain)
 

--- a/cmd/project/project_proxy_verify_test.go
+++ b/cmd/project/project_proxy_verify_test.go
@@ -1,0 +1,57 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/proxy"
+)
+
+// The ready/notStarted distinction drives two different exit-code contracts:
+// proxy verify exits 0 on an idle-but-healthy machine, while proxy setup
+// treats notStarted as a hard failure.
+func TestRunProxyVerificationSummary(t *testing.T) {
+	old := proxyVerify
+	t.Cleanup(func() { proxyVerify = old })
+
+	cases := []struct {
+		name           string
+		results        []proxy.CheckResult
+		wantReady      bool
+		wantNotStarted bool
+	}{
+		{
+			name:      "all checks pass",
+			results:   []proxy.CheckResult{{Name: "resolver"}, {Name: "traefik"}},
+			wantReady: true,
+		},
+		{
+			name: "only pending failures mean not started",
+			results: []proxy.CheckResult{
+				{Name: "resolver"},
+				{Name: "traefik", Err: errors.New("not running"), Pending: true, Hint: "run proxy up"},
+			},
+			wantNotStarted: true,
+		},
+		{
+			name: "a real failure is not just pending",
+			results: []proxy.CheckResult{
+				{Name: "resolver", Err: errors.New("broken"), Hint: "fix the resolver"},
+				{Name: "traefik", Err: errors.New("not running"), Pending: true},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyVerify = func(context.Context, string) []proxy.CheckResult { return tc.results }
+
+			ready, notStarted := runProxyVerification(t.Context(), "shopware.local")
+			assert.Equal(t, tc.wantReady, ready)
+			assert.Equal(t, tc.wantNotStarted, notStarted)
+		})
+	}
+}

--- a/cmd/project/proxy_helper_test.go
+++ b/cmd/project/proxy_helper_test.go
@@ -1,0 +1,14 @@
+package project
+
+import (
+	"testing"
+)
+
+// isolateProxyState points the proxy state directory (registry.json and
+// settings.json, resolved through os.UserConfigDir) at a temp dir.
+func isolateProxyState(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+}


### PR DESCRIPTION
## What

Fifth coverage PR in the series, covering `project proxy` (up/status/list/setup/teardown/verify), `project dev`, and `project image-proxy`. Eleven tests focused on the safety contracts that protect user machines and config files.

- `switchProjectConfigURLs`: the up-to-down restore invariant. A registry entry's remembered pre-proxy state must win over re-reading the already-rewritten config file, or `proxy down` could never restore the user's original URLs. Also: no config file means nothing is touched, and an existing URL is remembered then rewritten.
- `proxy status`: `ErrProxyNotRegistered` for unknown projects (the scripting contract) and the registered happy path, keyed by the canonical project root.
- `proxy list` internals: the `<project>-<service>-<index>` container-name parsing that drives running/stopped state, foreign-container exclusion, and the links contract (Shop/Admin always; only labeled services like Adminer/Mailpit get subdomain links).
- `proxy setup`: `resolveDomainFlag`'s full table, including the refusal to change domains while projects are registered (this value flows into root-privileged resolver writes) and that a clean change persists nothing by itself. Plus `chooseAutomaticSetup` never choosing the sudo path without a terminal, the "never sudo unprompted" guarantee.
- `proxy teardown`: refuses without `--force` in non-interactive environments, since teardown affects every registered project.
- `proxy verify`: the ready/notStarted aggregation, which drives two different exit-code contracts (`verify` exits 0 on idle-but-healthy, `setup` treats notStarted as failure).
- `project dev`: rejects projects with a pre-dev-mode compatibility date before touching docker.
- `project image-proxy`: the real RunE's fail-fast validations, including that the config-file fallback is consulted for the upstream URL. The existing tests exercise a hand-copied replica of the handler; these hit the actual command.

## The one production change

`runProxyVerification` called `proxy.Verify` directly, which probes real DNS, TLS and docker state. A 4-line `var proxyVerify = proxy.Verify` seam makes the aggregation testable with fixture results. No behavior change.

## Notes for review

- Proxy state (registry.json, settings.json) is isolated per test via HOME/XDG_CONFIG_HOME, the pattern `internal/proxy`'s own tests use; no test can touch a developer's real proxy registry.
- Docker-independent by construction: the interactive branches are provably skipped under `go test` (stdin is never a tty), and the one function that shells to docker tolerates its absence.
- Nothing here duplicates `internal/proxy`'s suite (per-check hints, hostname derivation, registry CRUD); these tests target the cmd-layer composition only.

## Tests

11 new test functions (+427 lines of tests, 4 lines of production change). `go test ./cmd/project/ -race -count=2 -shuffle=on` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for project development environment compatibility checks.
  * Added end-to-end validation for image proxy setup, local file serving, upstream proxying, caching, and cleanup.
  * Added coverage for proxy configuration, status, service links, domain changes, setup, teardown, and verification scenarios.
  * Improved test isolation for proxy state and environment-dependent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->