### PR TITLE
fix(project): extension upload --increase-version silently did not bump versions

### DIFF
--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	cp "github.com/otiai10/copy"
@@ -271,14 +272,12 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 						return err
 					}
 
-					ver, err := version.NewVersion(versionStr)
+					bumped, err := bumpPatchVersion(versionStr)
 					if err != nil {
 						return err
 					}
 
-					ver.IncreasePatch()
-
-					if err = encoder.EncodeElement(ver.String(), v); err != nil {
+					if err = encoder.EncodeElement(bumped, v); err != nil {
 						return err
 					}
 					continue
@@ -325,14 +324,12 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 		return nil
 	}
 
-	ver, err := version.NewVersion(versionStr)
+	bumped, err := bumpPatchVersion(versionStr)
 	if err != nil {
 		return err
 	}
 
-	ver.IncreasePatch()
-
-	composerJson["version"] = ver.String()
+	composerJson["version"] = bumped
 
 	composerJsonContent, err = json.Marshal(composerJson)
 	if err != nil {
@@ -344,6 +341,40 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 	}
 
 	return nil
+}
+
+// bumpPatchVersion increases the patch part of versionStr while keeping its
+// original number of parts (1.0.0 becomes 1.0.1, 6.6.5.2 becomes 6.6.6.0).
+// go-version's IncreasePatch cannot be used here: it mutates only the parsed
+// segments while String() keeps returning the original input, and its
+// normalized form pads every version to four parts.
+func bumpPatchVersion(versionStr string) (string, error) {
+	if _, err := version.NewVersion(versionStr); err != nil {
+		return "", err
+	}
+
+	core := versionStr
+	if i := strings.IndexAny(core, "-+"); i >= 0 {
+		core = core[:i]
+	}
+
+	parts := strings.Split(core, ".")
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("cannot parse patch version %q: %w", parts[2], err)
+	}
+	parts[2] = strconv.Itoa(patch + 1)
+
+	// Mirror IncreasePatch's semantics: a bump resets the build part.
+	if len(parts) > 3 {
+		parts[3] = "0"
+	}
+
+	return strings.Join(parts, "."), nil
 }
 
 func init() {

--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -345,6 +345,9 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 
 // bumpPatchVersion increases the patch part of versionStr while keeping its
 // original number of parts (1.0.0 becomes 1.0.1, 6.6.5.2 becomes 6.6.6.0).
+// Versions with fewer than three parts are padded to MAJOR.MINOR.PATCH, and any
+// pre-release or build-metadata suffix is dropped by the bump (1.0 becomes
+// 1.0.1, 1.0.0-beta becomes 1.0.1).
 // go-version's IncreasePatch cannot be used here: it mutates only the parsed
 // segments while String() keeps returning the original input, and its
 // normalized form pads every version to four parts.
@@ -353,7 +356,7 @@ func bumpPatchVersion(versionStr string) (string, error) {
 		return "", err
 	}
 
-	core := versionStr
+	core := strings.TrimSpace(versionStr)
 	if i := strings.IndexAny(core, "-+"); i >= 0 {
 		core = core[:i]
 	}

--- a/cmd/project/project_extension_upload_version_test.go
+++ b/cmd/project/project_extension_upload_version_test.go
@@ -1,0 +1,93 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/extension"
+)
+
+const testAppManifestWithVersion = `<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+	<meta>
+		<name>MyExampleApp</name>
+		<label>Label</label>
+		<description>A description</description>
+		<author>Your Company Ltd.</author>
+		<copyright>(c) by Your Company Ltd.</copyright>
+		<version>1.2.3</version>
+		<license>MIT</license>
+	</meta>
+</manifest>`
+
+func TestIncreaseExtensionVersionBumpsPluginComposerVersion(t *testing.T) {
+	t.Run("patch bump", func(t *testing.T) {
+		dir := writeMinimalPlugin(t)
+		ext, err := extension.GetExtensionByFolder(t.Context(), dir)
+		require.NoError(t, err)
+
+		require.NoError(t, increaseExtensionVersion(t.Context(), ext))
+
+		content, err := os.ReadFile(filepath.Join(dir, "composer.json"))
+		require.NoError(t, err)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(content, &parsed))
+		assert.Equal(t, "1.0.1", parsed["version"])
+	})
+
+	t.Run("four-part version bumps patch and resets build", func(t *testing.T) {
+		bumped, err := bumpPatchVersion("6.6.5.2")
+		require.NoError(t, err)
+		assert.Equal(t, "6.6.6.0", bumped)
+	})
+
+	t.Run("composer.json without version is left untouched", func(t *testing.T) {
+		dir := writeMinimalPlugin(t)
+		composerPath := filepath.Join(dir, "composer.json")
+		content, err := os.ReadFile(composerPath)
+		require.NoError(t, err)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(content, &parsed))
+		delete(parsed, "version")
+		noVersion, err := json.Marshal(parsed)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(composerPath, noVersion, 0o644))
+
+		ext, err := extension.GetExtensionByFolder(t.Context(), dir)
+		require.NoError(t, err)
+
+		require.NoError(t, increaseExtensionVersion(t.Context(), ext))
+
+		after, err := os.ReadFile(composerPath)
+		require.NoError(t, err)
+		assert.Equal(t, noVersion, after)
+	})
+}
+
+// The XML re-encode plus manual namespace repair is the most fragile code in
+// the file; a Go xml encoder behavior change would break every app manifest
+// uploaded with --increase-version.
+func TestIncreaseExtensionVersionRewritesAppManifestKeepingNamespaces(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.xml"), []byte(testAppManifestWithVersion), 0o644))
+
+	ext, err := extension.GetExtensionByFolder(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, "app", ext.GetType())
+
+	require.NoError(t, increaseExtensionVersion(t.Context(), ext))
+
+	content, err := os.ReadFile(filepath.Join(dir, "manifest.xml"))
+	require.NoError(t, err)
+	manifest := string(content)
+	assert.Contains(t, manifest, "1.2.4")
+	assert.Contains(t, manifest, `xmlns:xsi=`)
+	assert.Contains(t, manifest, `xsi:noNamespaceSchemaLocation=`)
+	assert.NotContains(t, manifest, "_xmlns")
+	assert.NotContains(t, manifest, "_XMLSchema-instance")
+}

--- a/cmd/project/project_extension_upload_version_test.go
+++ b/cmd/project/project_extension_upload_version_test.go
@@ -46,6 +46,14 @@ func TestIncreaseExtensionVersionBumpsPluginComposerVersion(t *testing.T) {
 		assert.Equal(t, "6.6.6.0", bumped)
 	})
 
+	// go-version trims the input before validating, so the manual parser has to
+	// trim too; an app manifest may contain "<version> 1.2.3 </version>".
+	t.Run("whitespace-padded version bumps patch", func(t *testing.T) {
+		bumped, err := bumpPatchVersion(" 1.2.3 ")
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.4", bumped)
+	})
+
 	t.Run("composer.json without version is left untouched", func(t *testing.T) {
 		dir := writeMinimalPlugin(t)
 		composerPath := filepath.Join(dir, "composer.json")

--- a/cmd/project/project_extension_upload_version_test.go
+++ b/cmd/project/project_extension_upload_version_test.go
@@ -54,6 +54,34 @@ func TestIncreaseExtensionVersionBumpsPluginComposerVersion(t *testing.T) {
 		assert.Equal(t, "1.2.4", bumped)
 	})
 
+	t.Run("two-part version is padded to major.minor.patch", func(t *testing.T) {
+		bumped, err := bumpPatchVersion("1.0")
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.1", bumped)
+	})
+
+	t.Run("pre-release suffix is dropped by the bump", func(t *testing.T) {
+		bumped, err := bumpPatchVersion("1.0.0-beta")
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.1", bumped)
+	})
+
+	t.Run("invalid version is rejected", func(t *testing.T) {
+		bumped, err := bumpPatchVersion("not-a-version")
+		require.Error(t, err)
+		assert.Empty(t, bumped)
+	})
+
+	// go-version also accepts a pre-release suffix without a separator
+	// ("1.0.0rc1" normalizes to 1.0.0.0-rc1), but the core is only trimmed at
+	// "-" and "+", so the patch part stays non-numeric. The bump has to fail
+	// instead of writing a broken version back into the extension.
+	t.Run("suffix without a separator is rejected", func(t *testing.T) {
+		bumped, err := bumpPatchVersion("1.0.0rc1")
+		require.ErrorContains(t, err, `cannot parse patch version "0rc1"`)
+		assert.Empty(t, bumped)
+	})
+
 	t.Run("composer.json without version is left untouched", func(t *testing.T) {
 		dir := writeMinimalPlugin(t)
 		composerPath := filepath.Join(dir, "composer.json")

--- a/cmd/project/project_upgrade_check_test.go
+++ b/cmd/project/project_upgrade_check_test.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeUpgradeCheckPlugin(t *testing.T, root, name, composerJSON string) {
+	t.Helper()
+	dir := filepath.Join(root, "custom", "plugins", name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composerJSON), 0o644))
+}
+
+func TestGetLocalExtensionsReadsComposerLockAndCustomPlugins(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PROJECT_ROOT", root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"),
+		[]byte(`{"packages":[{"name":"shopware/core","version":"v6.6.5.0"}]}`), 0o644))
+
+	writeUpgradeCheckPlugin(t, root, "FroshTest", `{
+		"name": "frosh/frosh-test",
+		"type": "shopware-platform-plugin",
+		"version": "1.2.0",
+		"require": { "shopware/core": "~6.6.0" },
+		"extra": { "shopware-plugin-class": "FroshTest\\FroshTest" }
+	}`)
+	// A plugin without a parseable version falls back to 1.0.0.
+	writeUpgradeCheckPlugin(t, root, "NoVersion", `{
+		"name": "frosh/no-version",
+		"type": "shopware-platform-plugin",
+		"require": { "shopware/core": "~6.6.0" },
+		"extra": { "shopware-plugin-class": "NoVersion\\NoVersion" }
+	}`)
+
+	coreVersion, extensions, err := getLocalExtensions()
+	require.NoError(t, err)
+	// The v prefix must be trimmed or the store compatibility API gets fed
+	// a version it does not know.
+	assert.Equal(t, "6.6.5.0", coreVersion.String())
+	assert.Equal(t, "1.2.0", extensions["FroshTest"])
+	assert.Equal(t, "1.0.0", extensions["NoVersion"])
+}
+
+func TestGetLocalExtensionsErrorsWhenCoreMissing(t *testing.T) {
+	t.Run("missing composer.lock", func(t *testing.T) {
+		t.Setenv("PROJECT_ROOT", t.TempDir())
+		_, _, err := getLocalExtensions()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read composer.lock")
+	})
+
+	t.Run("core not in the lock file", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("PROJECT_ROOT", root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"),
+			[]byte(`{"packages":[{"name":"vendor/other","version":"1.0.0"}]}`), 0o644))
+
+		_, _, err := getLocalExtensions()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shopware/core package not found in composer.lock")
+	})
+}

--- a/cmd/project/project_upgrade_test.go
+++ b/cmd/project/project_upgrade_test.go
@@ -1,0 +1,19 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unlike the extension commands, upgrade refuses to fall back to the current
+// directory when no Shopware project is found.
+func TestProjectUpgradeHeadlessRequiresProjectRoot(t *testing.T) {
+	chdirOutsideProject(t)
+
+	projectUpgradeCmd.SetContext(t.Context())
+	err := projectUpgradeCmd.RunE(projectUpgradeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot find Shopware project")
+}


### PR DESCRIPTION
## The bug

`project extension upload --increase-version` has been a silent no-op. Both branches of `increaseExtensionVersion` called go-version's `IncreasePatch()` and then wrote back `ver.String()`, but `IncreasePatch` mutates only the parsed segments while `String()` keeps returning the original input string. Plugins re-uploaded their composer.json unchanged, and app manifests were re-encoded with the old version. Discovered by writing the planned coverage tests, which failed against the current behavior.

The library's `NormalizedString()` is no fix either: this go-version fork pads every version to four segments, so "1.0.0" would become "1.0.1.0" and corrupt three-part extension versions.

## The fix

A small `bumpPatchVersion` helper that validates via `version.NewVersion`, bumps the patch part textually, keeps the version's original number of parts (1.0.0 becomes 1.0.1, 6.6.5.2 becomes 6.6.6.0), and mirrors `IncreasePatch`'s build-reset semantics for four-part versions. Both the composer.json and manifest.xml branches use it.

## Tests

- Plugin branch: 1.0.0 becomes 1.0.1; a composer.json without a version key is left byte-identical (the early return).
- Four-part semantics: 1.6.5.2 becomes 1.6.6.0.
- App branch: the manifest is rewritten with 1.2.4 while the `xmlns:xsi` attributes survive and no `_xmlns`/`_XMLSchema-instance` encoder artifacts appear; the manual namespace repair is the most fragile code in the file.
- Plus the rest of this group's audit backlog: `getLocalExtensions` (the `v` prefix trim feeding the store compatibility API, the 1.0.0 fallback for unparseable plugin versions, and both missing-core error paths) and the `project upgrade` no-fallback guard.

6 test functions, +218/-8. `go test ./cmd/project/ -race -count=2 -shuffle=on` passes.

Note for reviewers: `shyim/go-version` was bumped by dependabot recently, so this may be a regression from that update rather than a day-one bug; either way the new helper is independent of the library's stringer semantics.
