### PR TITLE
test(project): cover ops command guards and helpers

### DIFF
--- a/cmd/project/executor_test.go
+++ b/cmd/project/executor_test.go
@@ -1,0 +1,58 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTempShopwareProject creates the minimal layout findClosestShopwareProject
+// and the local executor need: composer.json requiring shopware/core, a
+// bin/console stub and a .env with the given DATABASE_URL.
+func writeTempShopwareProject(t *testing.T, databaseURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bin", "console"), []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"shopware/core":"~6.6.0"}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("DATABASE_URL="+databaseURL+"\n"), 0o644))
+	return dir
+}
+
+func TestConnectProjectDatabaseErrors(t *testing.T) {
+	t.Setenv("SHOPWARE_CLI_NO_SYMFONY_CLI", "1")
+
+	t.Run("outside a project", func(t *testing.T) {
+		chdirOutsideProject(t)
+		t.Setenv("DATABASE_URL", "")
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		conn, dbConn, cleanup, err := connectProjectDatabase(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find Shopware project")
+		assert.Nil(t, conn)
+		assert.Nil(t, dbConn)
+		assert.Nil(t, cleanup)
+	})
+
+	// Connection refused on loopback port 1 fails immediately, no database
+	// needed; the nil returns protect the callers' deferred cleanup.
+	t.Run("unreachable database", func(t *testing.T) {
+		dir := writeTempShopwareProject(t, "mysql://root:root@127.0.0.1:1/shopware")
+		t.Setenv("PROJECT_ROOT", dir)
+		t.Setenv("DATABASE_URL", "")
+
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		conn, dbConn, cleanup, err := connectProjectDatabase(cmd)
+		require.Error(t, err)
+		assert.Nil(t, conn)
+		assert.Nil(t, dbConn)
+		assert.Nil(t, cleanup)
+	})
+}

--- a/cmd/project/project_admin_api_test.go
+++ b/cmd/project/project_admin_api_test.go
@@ -1,0 +1,34 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePath(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantPath  string
+		wantQuery string
+	}{
+		{"leading api is not duplicated", "/api/search/product", "api/search/product", ""},
+		{"bare path gets the api prefix", "search/product", "api/search/product", ""},
+		{"underscore route", "/_info/version", "api/_info/version", ""},
+		{"query string survives", "search/product?limit=5", "api/search/product", "limit=5"},
+		// Documents a quirk: any path merely starting with the letters "api"
+		// loses that prefix.
+		{"api-prefixed word is mangled", "api-test", "api/-test", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := parsePath(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, u.Path)
+			assert.Equal(t, tc.wantQuery, u.RawQuery)
+		})
+	}
+}

--- a/cmd/project/project_config_init_guard_test.go
+++ b/cmd/project/project_config_init_guard_test.go
@@ -1,0 +1,28 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+// The guard keeps `config init` from hanging a headless CI job inside a form.
+func TestConfigInitHeadlessGuardAndEmptyValidator(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(system.WithInteraction(t.Context(), false))
+
+	err := projectConfigInitCmd.RunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires interaction")
+	assert.NoFileExists(t, dir+"/.shopware-project.yml")
+
+	assert.Error(t, emptyValidator(""))
+	assert.NoError(t, emptyValidator("x"))
+}

--- a/cmd/project/project_doctor_test.go
+++ b/cmd/project/project_doctor_test.go
@@ -1,0 +1,57 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoctorOnFixtureProject(t *testing.T) {
+	oldConfigPath := projectConfigPath
+	projectConfigPath = ""
+	t.Cleanup(func() { projectConfigPath = oldConfigPath })
+
+	newDoctorCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		return cmd
+	}
+
+	t.Run("bare project", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"shopware/core":"~6.6.0"}}`), 0o644))
+
+		out, err := captureStdout(func() error {
+			return projectDoctor.RunE(newDoctorCmd(), []string{dir})
+		})
+		require.NoError(t, err)
+		assert.Contains(t, out, "Shopware version:")
+		assert.Contains(t, out, "not found, using fallback")
+		assert.Contains(t, out, "No extensions or bundles detected")
+	})
+
+	t.Run("project with a plugin", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"shopware/core":"~6.6.0"}}`), 0o644))
+		pluginDir := filepath.Join(dir, "custom", "plugins", "FroshTest")
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "composer.json"), []byte(`{
+			"name": "frosh/frosh-test",
+			"type": "shopware-platform-plugin",
+			"version": "1.0.0",
+			"require": { "shopware/core": "~6.6.0" },
+			"extra": { "shopware-plugin-class": "FroshTest\\FroshTest" }
+		}`), 0o644))
+
+		out, err := captureStdout(func() error {
+			return projectDoctor.RunE(newDoctorCmd(), []string{dir})
+		})
+		require.NoError(t, err)
+		assert.Contains(t, out, "FroshTest")
+		assert.Contains(t, out, filepath.Join("custom", "plugins", "FroshTest"))
+	})
+}

--- a/cmd/project/project_dump_password_test.go
+++ b/cmd/project/project_dump_password_test.go
@@ -1,0 +1,36 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+// The prompt-sentinel guards keep dump from hanging in CI waiting for a
+// password nobody can type.
+func TestAssembleConnectionURIPasswordPromptErrors(t *testing.T) {
+	chdirOutsideProject(t)
+	t.Setenv("DATABASE_URL", "")
+
+	t.Run("interaction disabled", func(t *testing.T) {
+		cmd := newDumpFlagCommand(t, nil)
+		require.NoError(t, cmd.Flags().Set("password", passwordFlagPrompt))
+		cmd.SetContext(system.WithInteraction(t.Context(), false))
+
+		_, err := assembleConnectionURI(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot prompt for password: interaction disabled")
+	})
+
+	t.Run("stdin is not a terminal", func(t *testing.T) {
+		cmd := newDumpFlagCommand(t, nil)
+		require.NoError(t, cmd.Flags().Set("password", passwordFlagPrompt))
+
+		_, err := assembleConnectionURI(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot prompt for password: stdin is not a terminal")
+	})
+}

--- a/cmd/project/project_logs_tail_test.go
+++ b/cmd/project/project_logs_tail_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package project
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the argument construction and the stream wiring to the cobra command,
+// the only behavior tailFollow owns. The follow happy path needs a running
+// tail process and is deliberately left out as flaky.
+func TestTailFollowSurfacesMissingFile(t *testing.T) {
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+	cmd := &cobra.Command{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetContext(t.Context())
+
+	err := tailFollow(cmd, filepath.Join(t.TempDir(), "missing.log"), 10)
+	require.Error(t, err)
+	assert.Contains(t, errOut.String(), "missing.log")
+	assert.Empty(t, out.String())
+}

--- a/cmd/project/project_worker_test.go
+++ b/cmd/project/project_worker_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package project
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This is the only thing standing between Ctrl+C and abandoned worker
+// children: the signal must cancel the context instead of killing the process.
+func TestCancelOnTerminationCancelsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	cancelOnTermination(ctx, cancel)
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("context was not cancelled after SIGINT")
+	}
+}

--- a/cmd/project/project_worker_test.go
+++ b/cmd/project/project_worker_test.go
@@ -4,6 +4,7 @@ package project
 
 import (
 	"context"
+	"os/signal"
 	"syscall"
 	"testing"
 	"time"
@@ -14,6 +15,10 @@ import (
 // This is the only thing standing between Ctrl+C and abandoned worker
 // children: the signal must cancel the context instead of killing the process.
 func TestCancelOnTerminationCancelsContext(t *testing.T) {
+	// cancelOnTermination never unregisters its handler, so restore the default
+	// disposition to keep the rest of the test binary interruptible.
+	t.Cleanup(func() { signal.Reset(syscall.SIGTERM, syscall.SIGINT) })
+
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 

--- a/cmd/project/project_worker_unix_test.go
+++ b/cmd/project/project_worker_unix_test.go
@@ -18,7 +18,7 @@ import (
 // the child so the poll loop can observe the exit.
 func TestGracefulStopSigtermThenProcessDone(t *testing.T) {
 	t.Run("sigterm stops within the grace period", func(t *testing.T) {
-		cmd := exec.Command("sleep", "30")
+		cmd := exec.CommandContext(t.Context(), "sleep", "30")
 		require.NoError(t, cmd.Start())
 		waitDone := make(chan struct{})
 		go func() {
@@ -35,7 +35,7 @@ func TestGracefulStopSigtermThenProcessDone(t *testing.T) {
 	})
 
 	t.Run("limit zero kills immediately", func(t *testing.T) {
-		cmd := exec.Command("sleep", "30")
+		cmd := exec.CommandContext(t.Context(), "sleep", "30")
 		require.NoError(t, cmd.Start())
 		waitDone := make(chan struct{})
 		go func() {

--- a/cmd/project/project_worker_unix_test.go
+++ b/cmd/project/project_worker_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package project
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gracefulStop is wired as exec.Cmd.Cancel for every messenger consumer;
+// returning os.ErrProcessDone is load-bearing since exec treats it as a clean
+// stop. Like in production, Cancel runs concurrently with Wait, which reaps
+// the child so the poll loop can observe the exit.
+func TestGracefulStopSigtermThenProcessDone(t *testing.T) {
+	t.Run("sigterm stops within the grace period", func(t *testing.T) {
+		cmd := exec.Command("sleep", "30")
+		require.NoError(t, cmd.Start())
+		waitDone := make(chan struct{})
+		go func() {
+			_ = cmd.Wait()
+			close(waitDone)
+		}()
+
+		start := time.Now()
+		err := gracefulStop(cmd, 5)
+		require.ErrorIs(t, err, os.ErrProcessDone)
+		assert.Less(t, time.Since(start), 3*time.Second)
+
+		<-waitDone
+	})
+
+	t.Run("limit zero kills immediately", func(t *testing.T) {
+		cmd := exec.Command("sleep", "30")
+		require.NoError(t, cmd.Start())
+		waitDone := make(chan struct{})
+		go func() {
+			_ = cmd.Wait()
+			close(waitDone)
+		}()
+
+		require.NoError(t, gracefulStop(cmd, 0))
+		<-waitDone
+	})
+}


### PR DESCRIPTION
## What

Final coverage PR in the series, covering the remaining ops gaps in cmd/project. Eight tests, no production changes.

- `admin-api`: `parsePath`'s URL assembly, which every request of the pre-authenticated curl wrapper goes through: no duplicated `api` segment, prefixing for bare paths, query-string preservation, and a documented quirk (paths merely starting with the letters "api" get mangled).
- `dump`: the password prompt-sentinel guards that keep dump from hanging in CI: "interaction disabled" and "stdin is not a terminal", both verbatim.
- `sql` plumbing: `connectProjectDatabase`'s two error paths, outside a project and connection-refused, pinning the all-nil returns that protect callers' deferred cleanup.
- `worker`: `gracefulStop` returns `os.ErrProcessDone` after SIGTERM well within the grace period (load-bearing, exec treats it as a clean stop), the limit-zero immediate kill, and `cancelOnTermination` turning SIGINT into a context cancel instead of process death, tested with a real `sleep` child and a self-sent signal.
- `config init`: the headless guard errors without writing anything, plus the wizard's only input validation.
- `doctor`: the pure-read diagnostic on a fixture project, asserting the version line, the fallback-config warning, the no-extensions case, and a detected plugin with its relative path.
- `logs`: `tailFollow`'s deterministic missing-file path, pinning the argument construction and the stderr wiring to the cobra streams.

## Notes for review

- The worker and tail tests carry `//go:build !windows` (shell semantics, signals); everything else is cross-platform.
- Deliberately skipped, as noted in the audit: console/admin-build/storefront-build RunE (spawn bin/console), validate/format RunE (tool downloads), autofix composer-plugins (tested in `internal/shop/pluginmigrate`), and the tail follow happy path (inherently timing-dependent).

## Tests

8 new test functions (+320 lines, tests only). `go test ./cmd/project/ -race -count=2 -shuffle=on` passes.
