### PR TITLE
chore: remove AI-generated slop from cmd and internal

### DIFF
--- a/cmd/extension/extension_args_test.go
+++ b/cmd/extension/extension_args_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The single-path commands process exactly one extension, so extra paths must
-// be rejected instead of silently ignored.
 func TestSinglePathCommandsRejectExtraArgs(t *testing.T) {
 	commands := []string{"fix", "validate", "get-name", "get-version", "get-changelog"}
 
@@ -32,8 +30,6 @@ func TestSinglePathCommandsRejectExtraArgs(t *testing.T) {
 	}
 }
 
-// package takes a path and an optional branch, so a third argument must be
-// rejected instead of silently ignored.
 func TestPackageRejectsMoreThanTwoArgs(t *testing.T) {
 	out := new(bytes.Buffer)
 	extensionRootCmd.SetOut(out)

--- a/cmd/project/project_args_test.go
+++ b/cmd/project/project_args_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// format, validate and fix take at most one optional path, so extra paths
-// must be rejected instead of silently ignored.
 func TestOptionalPathCommandsRejectExtraArgs(t *testing.T) {
 	commands := []string{"format", "validate", "fix"}
 

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -84,8 +84,7 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 	}
 
 	// Serve the shop at a stable hostname through the shared proxy instead of a
-	// port. Only the environment url is written: the deprecated top-level url
-	// would warn on every later command and override environments.local.
+	// port.
 	if opts.useDocker && opts.useLocalDomain {
 		url := "https://" + proxy.LocalDomainHostname(opts.projectFolder, proxy.BaseDomain())
 		if env := shopCfg.Environments["local"]; env != nil {

--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -302,9 +302,6 @@ func (e *devEnvironment) stop(cmd *cobra.Command, opts executor.StopOptions) err
 		title = "Stopping development environment and removing data..."
 	}
 
-	// runStep drops the spinner when there is no interactive terminal, so
-	// `project dev stop` also works headless (CI, an agent, a pipe with no
-	// /dev/tty) — matching start.
 	stop := func(ctx context.Context) error {
 		return e.executor.StopEnvironment(ctx, opts)
 	}

--- a/cmd/project/project_env_resolution_test.go
+++ b/cmd/project/project_env_resolution_test.go
@@ -104,8 +104,6 @@ environments:
 
 	err := projectExtensionListCmd.RunE(projectExtensionListCmd, []string{})
 	require.Error(t, err)
-	// environments.local is what the empty -e selects; the deprecated
-	// top-level url only fills in what it leaves unset.
 	assert.Contains(t, err.Error(), "127.0.0.1:7", "without -e environments.local must be used")
 	assert.NotContains(t, err.Error(), "127.0.0.1:9", "the deprecated top-level url must not override environments.local")
 }

--- a/cmd/project/project_extension_upload_test.go
+++ b/cmd/project/project_extension_upload_test.go
@@ -10,11 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newEmptyExtensionListShop fakes the minimal Admin API surface the upload
-// command touches, always reporting an empty installed-extension list, and
-// records every request as "METHOD path". With failSecondList the second
-// installed-list request returns a 500. Requests outside that surface get
-// a 404 so they surface as command errors.
+// newEmptyExtensionListShop fakes the Admin API surface of an empty shop and records requests as "METHOD path".
 func newEmptyExtensionListShop(t *testing.T, failSecondList bool) (*httptest.Server, func() []string) {
 	t.Helper()
 
@@ -61,8 +57,6 @@ func newEmptyExtensionListShop(t *testing.T, failSecondList bool) (*httptest.Ser
 	}
 }
 
-// setupUploadActivateEnv points the upload command at the fake shop and turns
-// the activate flag on, restoring the shared flag state afterwards.
 func setupUploadActivateEnv(t *testing.T, srvURL string) {
 	t.Helper()
 
@@ -91,8 +85,7 @@ func TestExtensionUploadActivateFailsWhenShopDoesNotListExtension(t *testing.T) 
 	assert.Contains(t, err.Error(), "cannot run lifecycle events")
 	assert.Contains(t, err.Error(), "FroshTest")
 
-	// The lifecycle lookup must run against a list fetched after the refresh
-	// call, or fresh uploads are invisible to it on real shops.
+	// The installed list must be queried after the refresh call.
 	got := calls()
 	refreshIdx, lastListIdx := -1, -1
 	for i, call := range got {

--- a/cmd/project/project_fix_test.go
+++ b/cmd/project/project_fix_test.go
@@ -19,8 +19,6 @@ func TestProjectFixNoArgsOutsideProjectReturnsError(t *testing.T) {
 }
 
 func TestProjectFixNoArgsAppliesGitGuardToResolvedProject(t *testing.T) {
-	// The cwd contains a .git dir so a regression that guards the cwd instead
-	// of the resolved project root would not produce the guard error.
 	cwd := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(cwd, ".git"), 0o755))
 	t.Chdir(cwd)
@@ -50,8 +48,6 @@ func TestProjectFixPassesGitGuardWithGitDirectory(t *testing.T) {
 
 	projectFixCmd.SetContext(t.Context())
 	err := projectFixCmd.RunE(projectFixCmd, []string{dir})
-	// The guard passes and the run fails at the next step, reading the
-	// project's composer.json.
 	require.ErrorIs(t, err, os.ErrNotExist)
 	assert.Contains(t, err.Error(), "composer.json")
 }

--- a/internal/proxy/hostname.go
+++ b/internal/proxy/hostname.go
@@ -14,9 +14,8 @@ import (
 
 // ProjectHostname derives the hostname a project should be reachable at
 // through the shared proxy. If a url is explicitly set in
-// .shopware-project.yml (environments.local.url, or the deprecated top-level
-// url), its host is used as an override — unless it is an IP address or
-// localhost, which is what freshly created projects point at
+// .shopware-project.yml, its host is used as an override — unless it is an
+// IP address or localhost, which is what freshly created projects point at
 // (http://127.0.0.1:8000) and never a usable proxy hostname. Otherwise the
 // hostname is derived from the project directory name.
 func ProjectHostname(projectRoot string, cfg *shop.Config, baseDomain string) (string, error) {

--- a/internal/proxy/infra.go
+++ b/internal/proxy/infra.go
@@ -150,8 +150,7 @@ func IsProxyProjectForDomain(cfg *shop.Config, baseDomain string) bool {
 		return false
 	}
 
-	// Resolve the url the same way the executor does, so proxy detection and
-	// the executor never disagree about which url the project serves.
+	// Resolve the url the same way the executor does.
 	effective := cfg.EffectiveURL()
 
 	if effective == "" {

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -55,10 +55,8 @@ type Config struct {
 	foundConfig            bool
 }
 
-// ResolveEnvironment returns the named environment. An empty name uses
-// environments.local; the deprecated top-level url/admin_api only fill in what
-// that environment does not set, so a mixed file never loses the environment's
-// type (which selects the executor) or its url.
+// ResolveEnvironment returns the named environment, or for an empty name
+// environments.local with the deprecated top-level url/admin_api as fallback.
 func (c *Config) ResolveEnvironment(name string) (*EnvironmentConfig, error) {
 	if name != "" {
 		env, ok := c.Environments[name]
@@ -83,8 +81,8 @@ func (c *Config) ResolveEnvironment(name string) (*EnvironmentConfig, error) {
 	return c.topLevelEnvironment(local), nil
 }
 
-// topLevelEnvironment builds the environment described by the deprecated
-// top-level url/admin_api. Values set on base take precedence over them.
+// topLevelEnvironment builds the environment from the deprecated top-level
+// url/admin_api, using values set on base where present.
 func (c *Config) topLevelEnvironment(base *EnvironmentConfig) *EnvironmentConfig {
 	env := EnvironmentConfig{Type: "local"}
 	if base != nil {
@@ -105,10 +103,8 @@ func (c *Config) topLevelEnvironment(base *EnvironmentConfig) *EnvironmentConfig
 	return &env
 }
 
-// EffectiveURL returns the shop URL the CLI resolves for the default
-// environment: environments.local.url, falling back to the deprecated
-// top-level url. It mirrors ResolveEnvironment for callers that only need the
-// URL and cannot fail on an unknown environment name.
+// EffectiveURL returns the URL of the default environment:
+// environments.local.url, falling back to the deprecated top-level url.
 func (c *Config) EffectiveURL() string {
 	if c == nil {
 		return ""
@@ -993,12 +989,8 @@ func ReadProjectURLState(configPath, envName string) (ConfigURLState, error) {
 	return state, nil
 }
 
-// SetProjectURL points the project config at url in place: the environment
-// url when the environment exists, otherwise the deprecated top-level url. An
-// existing top-level url is updated too, so a mixed file does not keep serving
-// the old url to anything still reading it — but it is never newly created,
-// which would deprecation-warn on every later command. Comments, ordering and
-// unknown keys are preserved.
+// SetProjectURL points the project config's environment (or top-level) url at
+// url in place, preserving comments, ordering and unknown keys.
 func SetProjectURL(configPath, envName, url string) error {
 	doc, root, err := loadConfigDoc(configPath)
 	if err != nil {
@@ -1018,10 +1010,8 @@ func SetProjectURL(configPath, envName, url string) error {
 	return writeConfigDoc(configPath, doc)
 }
 
-// RestoreProjectURL puts the url values captured in prev back in place:
-// previously present keys get their old value, previously absent ones are
-// removed again — for the environment url too, since SetProjectURL creates it
-// when the environment exists.
+// RestoreProjectURL restores the url values captured in prev; previously
+// absent keys are removed again.
 func RestoreProjectURL(configPath, envName string, prev ConfigURLState) error {
 	doc, root, err := loadConfigDoc(configPath)
 	if err != nil {
@@ -1045,8 +1035,7 @@ func RestoreProjectURL(configPath, envName string, prev ConfigURLState) error {
 	return writeConfigDoc(configPath, doc)
 }
 
-// envNode returns the environments.<env> mapping node, or nil when the
-// environment is not configured in the file.
+// envNode returns the environments.<env> mapping node, or nil.
 func envNode(root *yaml.Node, envName string) *yaml.Node {
 	environments := configMapValue(root, "environments")
 	if environments == nil || environments.Kind != yaml.MappingNode {

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -186,8 +186,6 @@ func TestResolveEnvironment(t *testing.T) {
 
 		env, err := cfg.ResolveEnvironment("")
 		require.NoError(t, err)
-		// The type picks the executor, so it must never come from the
-		// deprecated top-level keys, which never described one.
 		assert.Equal(t, "docker", env.Type)
 		assert.Equal(t, "http://localhost:8000", env.URL)
 		assert.Equal(t, "admin", env.AdminApi.Username)
@@ -1037,8 +1035,7 @@ func TestEffectiveURL(t *testing.T) {
 	assert.Empty(t, (&Config{}).EffectiveURL())
 	assert.Equal(t, "https://myshop.com", (&Config{URL: "https://myshop.com"}).EffectiveURL())
 
-	// environments.local wins over the deprecated top-level url, matching
-	// ResolveEnvironment.
+	// environments.local wins over the deprecated top-level url.
 	mixed := &Config{
 		URL:          "http://127.0.0.1:8000",
 		Environments: map[string]*EnvironmentConfig{"local": {URL: "https://my-shop.shopware.local"}},

--- a/internal/shop/config_url_test.go
+++ b/internal/shop/config_url_test.go
@@ -124,8 +124,7 @@ environments:
 
 	updated, err := os.ReadFile(path)
 	require.NoError(t, err)
-	// Only the environment url is rewritten; a top-level url would
-	// deprecation-warn on every later command.
+	// Only the environment url is rewritten.
 	assert.Equal(t, 1, countOccurrences(string(updated), "https://my-shop.shopware.local"))
 	assert.NotContains(t, string(updated), "\nurl:")
 


### PR DESCRIPTION
## Summary
- Drops justification-style comments added by recent AI-generated PRs (e.g. *"...must be rejected instead of silently ignored"*, regression-narration comments in tests)
- Condenses verbose multi-sentence doc comments to the house style used elsewhere in the codebase (`internal/shop/config.go`, `internal/proxy`, upload test helpers)
- Trims narration comments in `project dev stop`, `project create` install and env-resolution tests

## What is intentionally kept
- All functional changes from those PRs: arg validators, git-guard ordering, post-refresh list fetch + nil check on upload, URL resolution logic
- All test coverage — comment-only cleanup
- The `nil` guard on `Config.EffectiveURL` (reachable via callers that pass nil configs)

## Verification
- `go build ./...`
- `go vet ./cmd/... ./internal/proxy/ ./internal/shop/`
- `go test ./cmd/... ./internal/proxy/ ./internal/shop/`

12 files changed, +19/−59 lines, no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for project URL selection, environment resolution, proxy behavior, and local development configuration.
  * Updated comments and test descriptions to better reflect current behavior.

* **Tests**
  * Refined test comments and descriptions without changing test logic, assertions, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->