### PR TITLE
fix: CoreDNS crash-loop on Corefile permission denied

### DIFF
--- a/internal/proxy/dns_container.go
+++ b/internal/proxy/dns_container.go
@@ -20,7 +20,7 @@ const (
 	// dnsConfigVersion is stamped on the container as a label; bumping it makes
 	// EnsureDNSContainerRunning recreate containers started by older CLI
 	// versions with an incompatible Corefile or run arguments.
-	dnsConfigVersion      = "1"
+	dnsConfigVersion      = "2"
 	dnsConfigVersionLabel = "com.shopware-cli.proxy-dns-config-version"
 	// dnsDomainLabel records the base domain the container's Corefile answers
 	// for, so a container serving an outdated domain is recreated.
@@ -51,8 +51,20 @@ func writeDNSCorefile(dir, baseDomain string) error {
 	}
 
 	content := fmt.Sprintf(corefileTemplate, baseDomain, dnsTTL)
+	path := filepath.Join(dnsDir, "Corefile")
 
-	return os.WriteFile(filepath.Join(dnsDir, "Corefile"), []byte(content), 0o600)
+	// 0o644: the Corefile is not secret (it only answers 127.0.0.1) and the
+	// CoreDNS image runs as UID 65532 (nonroot). A 0o600 file owned by the
+	// host user is unreadable through the bind mount and CoreDNS crash-loops
+	// with "open /Corefile: permission denied". WriteFile does not change
+	// the mode of an existing file, so chmod after write so a leftover 0o600
+	// Corefile from earlier CLI versions is repaired in place (same inode,
+	// so an already-mounted container sees the new mode immediately).
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+
+	return os.Chmod(path, 0o644)
 }
 
 // EnsureDNSContainerRunning idempotently starts the shared DNS container: it
@@ -94,6 +106,8 @@ func EnsureDNSContainerRunning(ctx context.Context, baseDomain string) error {
 		"--label", dnsDomainLabel+"="+baseDomain,
 		"-p", fmt.Sprintf("127.0.0.1:%d:53/udp", DNSPort),
 		"-p", fmt.Sprintf("127.0.0.1:%d:53/tcp", DNSPort),
+		// File mount (not a directory): CoreDNS 1.11+ is USER 65532, so the
+		// host Corefile must be world-readable — see writeDNSCorefile.
 		"-v", filepath.Join(dir, "dns", "Corefile")+":/Corefile:ro",
 		DNSImage,
 		"-conf", "/Corefile",

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -26,6 +26,10 @@ func TestWriteDNSCorefile(t *testing.T) {
 	assert.Contains(t, got, "IN A 127.0.0.1")
 	assert.Contains(t, got, "template IN AAAA")
 	assert.Contains(t, got, "rcode NOERROR")
+
+	info, err := os.Stat(filepath.Join(dir, "dns", "Corefile"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "CoreDNS 1.11+ runs as nonroot and must be able to read the bind-mounted Corefile")
 }
 
 func TestWriteDNSCorefileCustomDomain(t *testing.T) {
@@ -38,4 +42,21 @@ func TestWriteDNSCorefileCustomDomain(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, string(content), "my.example.test {")
+}
+
+func TestWriteDNSCorefileRepairsRestrictivePermissions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dnsDir := filepath.Join(dir, "dns")
+	require.NoError(t, os.MkdirAll(dnsDir, 0o700))
+
+	path := filepath.Join(dnsDir, "Corefile")
+	require.NoError(t, os.WriteFile(path, []byte("stale"), 0o600))
+
+	require.NoError(t, writeDNSCorefile(dir, "shopware.local"))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "an existing 0600 Corefile must be chmod'd so the nonroot container user can read it")
 }

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,4 +60,17 @@ func TestWriteDNSCorefileRepairsRestrictivePermissions(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "an existing 0600 Corefile must be chmod'd so the nonroot container user can read it")
+}
+
+func TestWriteDNSCorefileIgnoresUmask(t *testing.T) {
+	// umask is process-wide; do not run in parallel with other tests.
+	old := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	dir := t.TempDir()
+	require.NoError(t, writeDNSCorefile(dir, "shopware.local"))
+
+	info, err := os.Stat(filepath.Join(dir, "dns", "Corefile"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "WriteFile honors umask (077 → 0600); chmod must restore world-read")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

`shopware-cli project create` / `project proxy` starts `coredns/coredns:1.14.6` with the host Corefile bind-mounted at `/Corefile`. That image runs as UID 65532 (`nonroot`). The CLI wrote the Corefile as `0600`, so CoreDNS could not read it and crash-looped:

```
loading Caddyfile via flag: open /Corefile: permission denied
```

("Caddyfile" is CoreDNS's internal config-loader wording; the file is still a Corefile.)

The Corefile is now written `0644` (it only answers `127.0.0.1` — no secrets). Existing `0600` leftovers from earlier CLI versions are `chmod`'d in place so a bind-mounted inode becomes readable immediately. `dnsConfigVersion` is bumped to `2` so an already-created crash-looping container is recreated on the next `proxy up` / `project create`.

## Why?

CoreDNS 1.11+ images switched to a non-root user (`USER 65532`). A host-owned `0600` bind mount is unreadable to that process. `os.WriteFile` also honors umask and does not change the mode of an existing file, so a follow-up `chmod` is required.

## How was this tested?

- `go test ./internal/proxy/` — all package tests pass
- `TestWriteDNSCorefile` asserts the file is `0644`
- `TestWriteDNSCorefileRepairsRestrictivePermissions` — leftover `0600` is repaired
- `TestWriteDNSCorefileIgnoresUmask` — umask `077` still yields `0644`
- `go vet ./internal/proxy/` — clean
- Live `coredns/coredns:1.14.6` run:
  - `0600` mount reproduces `open /Corefile: permission denied` and exit 1
  - `0644` mount starts as `nonroot:nonroot`, listens on `shopware.local.:53`, answers `my-shop.shopware.local` → `127.0.0.1` on `127.0.0.1:53535`
  - `TestEnsureDNSContainerRunningIntegration` PASS against the real image

## Related issue or discussion

Reported against `shopware-cli project create` with Docker + local domain (`*.shopware.local`).

**Workaround without upgrading:**

```bash
chmod 644 ~/.config/shopware-cli/proxy/dns/Corefile   # Linux
# chmod 644 ~/Library/Application\ Support/shopware-cli/proxy/dns/Corefile  # macOS
docker rm -f shopware-cli-proxy-dns
shopware-cli project proxy up
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-151aa882-c6e5-42d6-929a-a65c1c0272bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-151aa882-c6e5-42d6-929a-a65c1c0272bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS container Corefile generation to ensure required read permissions.
  * Existing Corefiles with restrictive permissions are automatically corrected.
  * Corefile permissions remain consistent even when restrictive system settings are applied.
  * Improved DNS container startup reliability when using host-mounted Corefiles.

* **Documentation**
  * Clarified that host-mounted Corefiles must be readable by the DNS service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->