### PR TITLE
fix: enable OpenSearch indexing for PaaS projects

### DIFF
--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -71,17 +71,7 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 		}
 	}
 
-	shopCfg := shop.NewConfig()
-	if opts.useDocker {
-		shopCfg.Environments["local"].Type = "docker"
-		shopCfg.Docker = &shop.ConfigDocker{
-			PHP: &shop.ConfigDockerPHP{Version: composerInstallPHP},
-		}
-	} else if opts.phpVersion != "" {
-		// The version, not the executable path: the same PHP lives elsewhere on
-		// other machines, so later commands look it up locally.
-		shopCfg.PHPVersion = opts.phpVersion
-	}
+	shopCfg := newProjectConfig(opts, composerInstallPHP)
 
 	// Serve the shop at a stable hostname through the shared proxy instead of a
 	// port.
@@ -98,6 +88,28 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 
 	printCreateSummary(ctx, opts)
 	return nil
+}
+
+func newProjectConfig(opts *createOptions, composerInstallPHP string) *shop.Config {
+	shopCfg := shop.NewConfig()
+	if opts.useDocker {
+		shopCfg.Environments["local"].Type = "docker"
+		shopCfg.Docker = &shop.ConfigDocker{
+			PHP: &shop.ConfigDockerPHP{Version: composerInstallPHP},
+		}
+	} else if opts.phpVersion != "" {
+		// The version, not the executable path: the same PHP lives elsewhere on
+		// other machines, so later commands look it up locally.
+		shopCfg.PHPVersion = opts.phpVersion
+	}
+
+	if opts.selectedDeployment == shop.DeploymentShopwarePaaS {
+		shopCfg.ConfigDeployment = &shop.ConfigDeployment{
+			OpenSearch: &shop.ConfigDeploymentOpenSearch{IndexOnInstall: true},
+		}
+	}
+
+	return shopCfg
 }
 
 func printCreateSummary(ctx context.Context, opts *createOptions) {

--- a/cmd/project/project_create_install_test.go
+++ b/cmd/project/project_create_install_test.go
@@ -1,0 +1,33 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func TestNewProjectConfig(t *testing.T) {
+	t.Run("enables OpenSearch indexing on install for Shopware PaaS", func(t *testing.T) {
+		cfg := newProjectConfig(&createOptions{
+			selectedDeployment: shop.DeploymentShopwarePaaS,
+		}, "")
+
+		require.NotNil(t, cfg.ConfigDeployment)
+		require.NotNil(t, cfg.ConfigDeployment.OpenSearch)
+		assert.True(t, cfg.ConfigDeployment.OpenSearch.IndexOnInstall)
+	})
+
+	t.Run("does not add deployment configuration for other deployment methods", func(t *testing.T) {
+		cfg := newProjectConfig(&createOptions{
+			selectedDeployment: shop.DeploymentContainer,
+			useDocker:          true,
+		}, "8.4")
+
+		assert.Nil(t, cfg.ConfigDeployment)
+		require.NotNil(t, cfg.Docker)
+		assert.Equal(t, "8.4", cfg.Docker.PHP.Version)
+	})
+}

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -509,12 +509,21 @@ type ConfigDeployment struct {
 
 	// Staging mode configuration for the deployment
 	Staging *ConfigDeploymentStaging `yaml:"staging,omitempty"`
+
+	// OpenSearch configuration for the deployment.
+	OpenSearch *ConfigDeploymentOpenSearch `yaml:"opensearch,omitempty"`
 }
 
 // ConfigDeploymentStaging defines staging mode configuration.
 type ConfigDeploymentStaging struct {
 	// When enabled, staging setup commands will be executed during installation and upgrade
 	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+// ConfigDeploymentOpenSearch defines OpenSearch actions during deployment.
+type ConfigDeploymentOpenSearch struct {
+	// When enabled, OpenSearch indexes are created after a fresh installation.
+	IndexOnInstall bool `yaml:"index-on-install,omitempty"`
 }
 
 // ConfigDeploymentHookStep is a single titled step of a deployment hook.

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -87,6 +87,29 @@ func TestConfigWithoutPHPVersionStaysBackwardCompatible(t *testing.T) {
 	assert.Contains(t, string(written), "environments:")
 }
 
+func TestConfigDeploymentOpenSearchIndexOnInstallRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := NewConfig()
+	cfg.ConfigDeployment = &ConfigDeployment{
+		OpenSearch: &ConfigDeploymentOpenSearch{IndexOnInstall: true},
+	}
+
+	require.NoError(t, WriteConfig(cfg, tmpDir))
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, ".shopware-project.yml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "opensearch:\n        index-on-install: true")
+
+	configPath := filepath.Join(tmpDir, "opensearch.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte("deployment:\n  opensearch:\n    index-on-install: true\n"), 0o644))
+
+	read, err := ReadConfig(t.Context(), configPath, false)
+	require.NoError(t, err)
+	require.NotNil(t, read.ConfigDeployment)
+	require.NotNil(t, read.ConfigDeployment.OpenSearch)
+	assert.True(t, read.ConfigDeployment.OpenSearch.IndexOnInstall)
+}
+
 func TestReadConfigCompatibilityDateValidation(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".shopware-project.yml")


### PR DESCRIPTION
## What changed?

- Added the deployment-helper configuration key `deployment.opensearch.index-on-install` to the project config model.
- `project create --deployment shopware-paas` now enables this setting in the generated `.shopware-project.yml`.
- Added tests for parsing/serializing the key and for PaaS-specific project defaults.

## Why?

Deployment Helper renamed the OpenSearch installation setting in [shopware/deployment-helper@f42299b](https://github.com/shopware/deployment-helper/commit/f42299b394be22c38e5a57ca330871f8c4abe066). New Shopware PaaS projects should opt in to index creation during their initial installation.

## How was this tested?

- `go test ./...`

## Related issue or discussion

- https://github.com/shopware/deployment-helper/commit/f42299b394be22c38e5a57ca330871f8c4abe066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OpenSearch index creation during fresh installations.
  * Shopware PaaS installations now enable OpenSearch indexing automatically.
  * Deployment configuration now supports the `index-on-install` setting.
* **Tests**
  * Added coverage for OpenSearch configuration serialization and installation settings.
  * Added validation for Docker and deployment-specific project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->