### PR TITLE
feat(tui): add table abstraction and unify output flags

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -226,8 +226,8 @@ Machine-readable output becomes a design rule, not an afterthought:
 
 Two related gaps, both blocking the AI/agent direction and the machine-readable promise:
 
-- **Machine-readable output is ad-hoc, not a contract.** A `--json` flag exists on two commands (`project extension list` / `outdated`), and the validation reporter supports json/github/gitlab/junit/markdown (internal/validation/reporter.go). But there's no consistent output-format convention across the CLI. Most commands print human text only.
-- For agents and CI to consume any command, structured output needs to be a standard (a shared `--output=json` honored everywhere it makes sense), not something bolted onto individual commands. This is the same need behind the `doctor` command.
+- **Machine-readable output is ad-hoc, not a contract.** `--format` is the convention for selecting a command's output representation, including JSON on extension list commands and json/github/gitlab/junit/markdown validation reports. The supported values remain command-specific, and most commands still print human text only.
+- For agents and CI to consume any command, structured output needs to follow the `--format` convention everywhere it makes sense, not be bolted onto individual commands. This is the same need behind the `doctor` command.
 - **Output isn't centralized.** Commands mix ~95 direct `fmt.Print*` calls with ~296 `logging.FromContext` calls. Logging is structured (`zap`) and goes to stderr; the `fmt` calls go to stdout with no level, no format control, and no way to silence or serialize them. The situation is further complicated by native CI/CD output that is heavily used by commands such as `project ci`. That fragmentation is why a clean JSON mode is hard today. There's no single output path to switch. Routing result output through one channel (and reserving stderr for logs) is the prerequisite.
 - The interactive/non-interactive split is enforced per command, at the point of prompting (`system.IsInteractionEnabled`), and only seven non-test files check it. So headless mode holds by convention, not structurally. A new command can forget the check and silently break it.
 

--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -4,12 +4,21 @@ import (
 	"github.com/spf13/cobra"
 
 	account_api "github.com/shopware/shopware-cli/internal/account-api"
+	"github.com/shopware/shopware-cli/internal/tui"
 )
 
 var accountCompanyProducerExtensionListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all your extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		format, err := tui.ParseTableFormat(listExtensionFormat)
+		if err != nil {
+			return err
+		}
+		if listExtensionJSON {
+			format = tui.TableFormatJSON
+		}
+
 		p, err := services.AccountClient.Producer(cmd.Context())
 		if err != nil {
 			return err
@@ -25,11 +34,7 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 		}
 
 		out := cmd.OutOrStdout()
-		if listExtensionJSON {
-			return account_api.WriteExtensionsJSON(out, extensions)
-		}
-
-		return account_api.WriteExtensionsTable(out, extensions)
+		return account_api.ExtensionsTable(extensions).Write(out, format)
 	},
 }
 
@@ -37,6 +42,7 @@ var (
 	listExtensionSearch string
 	listExtensionPlugin bool
 	listExtensionApp    bool
+	listExtensionFormat string
 	listExtensionJSON   bool
 )
 
@@ -45,6 +51,8 @@ func init() {
 	accountCompanyProducerExtensionListCmd.Flags().StringVar(&listExtensionSearch, "search", "", "Filter for name")
 	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionPlugin, "plugin", false, "Show only plugins")
 	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionApp, "app", false, "Show only apps")
+	accountCompanyProducerExtensionListCmd.Flags().StringVar(&listExtensionFormat, "format", string(tui.TableFormatTable), "Output format (table or json)")
 	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionJSON, "json", false, "Output as json")
 	accountCompanyProducerExtensionListCmd.MarkFlagsMutuallyExclusive("plugin", "app")
+	accountCompanyProducerExtensionListCmd.MarkFlagsMutuallyExclusive("format", "json")
 }

--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -11,12 +11,9 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all your extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		format, err := tui.ParseTableFormat(listExtensionFormat)
+		format, err := accountExtensionListFormat(listExtensionFormat, listExtensionJSON)
 		if err != nil {
 			return err
-		}
-		if listExtensionJSON {
-			format = tui.TableFormatJSON
 		}
 
 		p, err := services.AccountClient.Producer(cmd.Context())
@@ -38,6 +35,17 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 	},
 }
 
+func accountExtensionListFormat(formatName string, jsonAlias bool) (tui.TableFormat, error) {
+	format, err := tui.ParseTableFormat(formatName)
+	if err != nil {
+		return "", err
+	}
+	if jsonAlias {
+		return tui.TableFormatJSON, nil
+	}
+	return format, nil
+}
+
 var (
 	listExtensionSearch string
 	listExtensionPlugin bool
@@ -55,4 +63,6 @@ func init() {
 	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionJSON, "json", false, "Output as json")
 	accountCompanyProducerExtensionListCmd.MarkFlagsMutuallyExclusive("plugin", "app")
 	accountCompanyProducerExtensionListCmd.MarkFlagsMutuallyExclusive("format", "json")
+	_ = accountCompanyProducerExtensionListCmd.Flags().MarkDeprecated("json", "use --format json instead")
+	_ = accountCompanyProducerExtensionListCmd.Flags().MarkHidden("json")
 }

--- a/cmd/account/account_producer_extension_list_test.go
+++ b/cmd/account/account_producer_extension_list_test.go
@@ -1,0 +1,37 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+func TestAccountExtensionListFormatFlags(t *testing.T) {
+	format := accountCompanyProducerExtensionListCmd.Flags().Lookup("format")
+	require.NotNil(t, format)
+	assert.False(t, format.Hidden)
+	assert.Empty(t, format.Deprecated)
+	assert.Equal(t, "table", format.DefValue)
+
+	jsonAlias := accountCompanyProducerExtensionListCmd.Flags().Lookup("json")
+	require.NotNil(t, jsonAlias)
+	assert.True(t, jsonAlias.Hidden)
+	assert.NotEmpty(t, jsonAlias.Deprecated)
+
+	format.Changed = true
+	jsonAlias.Changed = true
+	t.Cleanup(func() {
+		format.Changed = false
+		jsonAlias.Changed = false
+	})
+	assert.Error(t, accountCompanyProducerExtensionListCmd.ValidateFlagGroups())
+}
+
+func TestAccountExtensionListDeprecatedJSONAlias(t *testing.T) {
+	format, err := accountExtensionListFormat("table", true)
+	require.NoError(t, err)
+	assert.Equal(t, tui.TableFormatJSON, format)
+}

--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -23,7 +23,10 @@ var extensionValidateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		isFull, _ := cmd.Flags().GetBool("full")
 		storeCompliance, _ := cmd.Flags().GetBool("store-compliance")
-		reportingFormat, _ := cmd.Flags().GetString("reporter")
+		reportingFormat, err := extensionValidationFormat(cmd)
+		if err != nil {
+			return err
+		}
 		checkAgainst, _ := cmd.Flags().GetString("check-against")
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "analyse-extension-*")
 		only, _ := cmd.Flags().GetString("only")
@@ -33,10 +36,6 @@ var extensionValidateCmd = &cobra.Command{
 		// If the user does not want to run full validation, only run shopware-cli
 		if !isFull {
 			only = "sw-cli"
-		}
-
-		if reportingFormat == "" {
-			reportingFormat = validation.DetectDefaultReporter()
 		}
 
 		if err != nil {
@@ -138,19 +137,35 @@ var extensionValidateCmd = &cobra.Command{
 	},
 }
 
+func extensionValidationFormat(cmd *cobra.Command) (string, error) {
+	format, _ := cmd.Flags().GetString("format")
+	reporter, _ := cmd.Flags().GetString("reporter")
+	if reporter != "" {
+		format = reporter
+	}
+	if format == "" {
+		format = validation.DetectDefaultReporter()
+	}
+
+	return format, validation.ValidateReporter(format)
+}
+
 func init() {
 	extensionRootCmd.AddCommand(extensionValidateCmd)
 	extensionValidateCmd.PersistentFlags().Bool("full", false, "Run full validation including PHPStan, ESLint and Stylelint")
 	extensionValidateCmd.PersistentFlags().Bool("store-compliance", false, "Runs specific store compliance checks")
+	extensionValidateCmd.PersistentFlags().String("format", "", "Reporting format (summary, json, github, gitlab, junit, markdown)")
 	extensionValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, gitlab, junit, markdown)")
 	extensionValidateCmd.PersistentFlags().String("check-against", "highest", "Check against Shopware Version (highest, lowest)")
 	extensionValidateCmd.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	extensionValidateCmd.PersistentFlags().String("exclude", "", "Exclude specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	extensionValidateCmd.PersistentFlags().Bool("no-copy", false, "Do not copy extension files to temporary directory")
+	extensionValidateCmd.MarkFlagsMutuallyExclusive("format", "reporter")
+	_ = extensionValidateCmd.PersistentFlags().MarkDeprecated("reporter", "use --format instead")
+	_ = extensionValidateCmd.PersistentFlags().MarkHidden("reporter")
 	extensionValidateCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		reporter, _ := cmd.Flags().GetString("reporter")
-		if reporter != "summary" && reporter != "json" && reporter != "github" && reporter != "gitlab" && reporter != "junit" && reporter != "markdown" && reporter != "" {
-			return fmt.Errorf("invalid reporter format: %s. Must be either 'summary', 'json', 'github', 'gitlab', 'junit' or 'markdown'", reporter)
+		if _, err := extensionValidationFormat(cmd); err != nil {
+			return err
 		}
 
 		mode, _ := cmd.Flags().GetString("check-against")

--- a/cmd/extension/extension_validate_format_test.go
+++ b/cmd/extension/extension_validate_format_test.go
@@ -1,0 +1,58 @@
+package extension
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionValidateFormatFlags(t *testing.T) {
+	format := extensionValidateCmd.Flags().Lookup("format")
+	require.NotNil(t, format)
+	assert.False(t, format.Hidden)
+	assert.Empty(t, format.Deprecated)
+
+	reporter := extensionValidateCmd.Flags().Lookup("reporter")
+	require.NotNil(t, reporter)
+	assert.True(t, reporter.Hidden)
+	assert.NotEmpty(t, reporter.Deprecated)
+
+	format.Changed = true
+	reporter.Changed = true
+	t.Cleanup(func() {
+		format.Changed = false
+		reporter.Changed = false
+	})
+	assert.Error(t, extensionValidateCmd.ValidateFlagGroups())
+}
+
+func TestExtensionValidationFormatSupportsNewAndDeprecatedFlags(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+
+	newFlag := newExtensionValidationFormatCommand()
+	require.NoError(t, newFlag.Flags().Set("format", "markdown"))
+	format, err := extensionValidationFormat(newFlag)
+	require.NoError(t, err)
+	assert.Equal(t, "markdown", format)
+
+	deprecatedFlag := newExtensionValidationFormatCommand()
+	require.NoError(t, deprecatedFlag.Flags().Set("reporter", "github"))
+	format, err = extensionValidationFormat(deprecatedFlag)
+	require.NoError(t, err)
+	assert.Equal(t, "github", format)
+
+	invalid := newExtensionValidationFormatCommand()
+	require.NoError(t, invalid.Flags().Set("format", "yaml"))
+	_, err = extensionValidationFormat(invalid)
+	assert.Error(t, err)
+}
+
+func newExtensionValidationFormatCommand() *cobra.Command {
+	command := &cobra.Command{}
+	command.Flags().String("format", "", "")
+	command.Flags().String("reporter", "", "")
+	return command
+}

--- a/cmd/project/project_extension.go
+++ b/cmd/project/project_extension.go
@@ -1,10 +1,25 @@
 package project
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+)
 
 var projectExtensionCmd = &cobra.Command{
 	Use:   "extension",
 	Short: "Manage the extensions of the Shopware shop",
+}
+
+func projectExtensionOutputFormat(formatName string, jsonAlias bool) (tui.TableFormat, error) {
+	format, err := tui.ParseTableFormat(formatName)
+	if err != nil {
+		return "", err
+	}
+	if jsonAlias {
+		return tui.TableFormatJSON, nil
+	}
+	return format, nil
 }
 
 func init() {

--- a/cmd/project/project_extension_list.go
+++ b/cmd/project/project_extension_list.go
@@ -1,9 +1,6 @@
 package project
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
@@ -15,7 +12,15 @@ var projectExtensionListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List all installed extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		outputAsJson, _ := cmd.PersistentFlags().GetBool("json")
+		formatName, _ := cmd.Flags().GetString("format")
+		format, err := tui.ParseTableFormat(formatName)
+		if err != nil {
+			return err
+		}
+		outputAsJSON, _ := cmd.Flags().GetBool("json")
+		if outputAsJSON {
+			format = tui.TableFormatJSON
+		}
 
 		projectRoot, err := findClosestShopwareProject(true)
 		if err != nil {
@@ -41,28 +46,22 @@ var projectExtensionListCmd = &cobra.Command{
 			return err
 		}
 
-		if outputAsJson {
-			content, err := json.Marshal(extensions)
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(string(content))
-
-			return nil
-		}
-
-		rows := make([][]string, 0, len(extensions))
+		result := tui.NewTable(
+			tui.TableColumn{Title: "Name", JSONKey: "name"},
+			tui.TableColumn{Title: "Version", JSONKey: "version"},
+			tui.TableColumn{Title: "Status", JSONKey: "status"},
+		)
 		for _, extension := range extensions {
-			rows = append(rows, []string{extension.Name, extension.Version, extension.Status()})
+			result.AddRow(extension.Name, extension.Version, extension.Status())
 		}
-		tui.PrintTable([]string{"Name", "Version", "Status"}, rows)
 
-		return nil
+		return result.Write(cmd.OutOrStdout(), format)
 	},
 }
 
 func init() {
 	projectExtensionCmd.AddCommand(projectExtensionListCmd)
-	projectExtensionListCmd.PersistentFlags().Bool("json", false, "Output as json")
+	projectExtensionListCmd.Flags().String("format", string(tui.TableFormatTable), "Output format (table or json)")
+	projectExtensionListCmd.Flags().Bool("json", false, "Output as json")
+	projectExtensionListCmd.MarkFlagsMutuallyExclusive("format", "json")
 }

--- a/cmd/project/project_extension_list.go
+++ b/cmd/project/project_extension_list.go
@@ -13,13 +13,10 @@ var projectExtensionListCmd = &cobra.Command{
 	Short:   "List all installed extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		formatName, _ := cmd.Flags().GetString("format")
-		format, err := tui.ParseTableFormat(formatName)
+		outputAsJSON, _ := cmd.Flags().GetBool("json")
+		format, err := projectExtensionOutputFormat(formatName, outputAsJSON)
 		if err != nil {
 			return err
-		}
-		outputAsJSON, _ := cmd.Flags().GetBool("json")
-		if outputAsJSON {
-			format = tui.TableFormatJSON
 		}
 
 		projectRoot, err := findClosestShopwareProject(true)
@@ -46,17 +43,21 @@ var projectExtensionListCmd = &cobra.Command{
 			return err
 		}
 
-		result := tui.NewTable(
-			tui.TableColumn{Title: "Name", JSONKey: "name"},
-			tui.TableColumn{Title: "Version", JSONKey: "version"},
-			tui.TableColumn{Title: "Status", JSONKey: "status"},
-		)
-		for _, extension := range extensions {
-			result.AddRow(extension.Name, extension.Version, extension.Status())
-		}
-
-		return result.Write(cmd.OutOrStdout(), format)
+		return projectExtensionListTable(extensions).Write(cmd.OutOrStdout(), format)
 	},
+}
+
+func projectExtensionListTable(extensions adminSdk.ExtensionList) *tui.Table {
+	result := tui.NewTable(
+		tui.TableColumn{Title: "Name", JSONKey: "name"},
+		tui.TableColumn{Title: "Version", JSONKey: "version"},
+		tui.TableColumn{Title: "Status", JSONKey: "status"},
+	)
+	for _, extension := range extensions {
+		result.AddRowWithJSON(extension, extension.Name, extension.Version, extension.Status())
+	}
+
+	return result
 }
 
 func init() {
@@ -64,4 +65,6 @@ func init() {
 	projectExtensionListCmd.Flags().String("format", string(tui.TableFormatTable), "Output format (table or json)")
 	projectExtensionListCmd.Flags().Bool("json", false, "Output as json")
 	projectExtensionListCmd.MarkFlagsMutuallyExclusive("format", "json")
+	_ = projectExtensionListCmd.Flags().MarkDeprecated("json", "use --format json instead")
+	_ = projectExtensionListCmd.Flags().MarkHidden("json")
 }

--- a/cmd/project/project_extension_outdated.go
+++ b/cmd/project/project_extension_outdated.go
@@ -15,13 +15,10 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 	Short: "List all outdated extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		formatName, _ := cmd.Flags().GetString("format")
-		format, err := tui.ParseTableFormat(formatName)
+		outputAsJSON, _ := cmd.Flags().GetBool("json")
+		format, err := projectExtensionOutputFormat(formatName, outputAsJSON)
 		if err != nil {
 			return err
-		}
-		outputAsJSON, _ := cmd.Flags().GetBool("json")
-		if outputAsJSON {
-			format = tui.TableFormatJSON
 		}
 
 		projectRoot, err := findClosestShopwareProject(true)
@@ -54,15 +51,7 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 			return nil
 		}
 
-		result := tui.NewTable(
-			tui.TableColumn{Title: "Name", JSONKey: "name"},
-			tui.TableColumn{Title: "Current Version", JSONKey: "currentVersion"},
-			tui.TableColumn{Title: "Latest Version", JSONKey: "latestVersion"},
-			tui.TableColumn{Title: "Update Source", JSONKey: "updateSource"},
-		)
-		for _, extension := range extensions {
-			result.AddRow(extension.Name, extension.Version, extension.LatestVersion, extension.UpdateSource)
-		}
+		result := projectExtensionOutdatedTable(extensions)
 		if err := result.Write(cmd.OutOrStdout(), format); err != nil {
 			return err
 		}
@@ -74,9 +63,25 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 	},
 }
 
+func projectExtensionOutdatedTable(extensions adminSdk.ExtensionList) *tui.Table {
+	result := tui.NewTable(
+		tui.TableColumn{Title: "Name", JSONKey: "name"},
+		tui.TableColumn{Title: "Current Version", JSONKey: "currentVersion"},
+		tui.TableColumn{Title: "Latest Version", JSONKey: "latestVersion"},
+		tui.TableColumn{Title: "Update Source", JSONKey: "updateSource"},
+	)
+	for _, extension := range extensions {
+		result.AddRowWithJSON(extension, extension.Name, extension.Version, extension.LatestVersion, extension.UpdateSource)
+	}
+
+	return result
+}
+
 func init() {
 	projectExtensionCmd.AddCommand(projectExtensionOutdatedCmd)
 	projectExtensionOutdatedCmd.Flags().String("format", string(tui.TableFormatTable), "Output format (table or json)")
 	projectExtensionOutdatedCmd.Flags().Bool("json", false, "Output as json")
 	projectExtensionOutdatedCmd.MarkFlagsMutuallyExclusive("format", "json")
+	_ = projectExtensionOutdatedCmd.Flags().MarkDeprecated("json", "use --format json instead")
+	_ = projectExtensionOutdatedCmd.Flags().MarkHidden("json")
 }

--- a/cmd/project/project_extension_outdated.go
+++ b/cmd/project/project_extension_outdated.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -15,7 +14,15 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 	Use:   "outdated",
 	Short: "List all outdated extensions",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		outputAsJson, _ := cmd.PersistentFlags().GetBool("json")
+		formatName, _ := cmd.Flags().GetString("format")
+		format, err := tui.ParseTableFormat(formatName)
+		if err != nil {
+			return err
+		}
+		outputAsJSON, _ := cmd.Flags().GetBool("json")
+		if outputAsJSON {
+			format = tui.TableFormatJSON
+		}
 
 		projectRoot, err := findClosestShopwareProject(true)
 		if err != nil {
@@ -37,33 +44,31 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 		}
 
 		extensions, _, err := client.ExtensionManager.ListAvailableExtensions(adminSdk.NewApiContext(cmd.Context()))
-		extensions = extensions.FilterByUpdateable()
-
 		if err != nil {
 			return err
 		}
+		extensions = extensions.FilterByUpdateable()
 
-		if outputAsJson {
-			content, err := json.Marshal(extensions)
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(string(content))
-
-			return nil
-		}
-
-		if len(extensions) == 0 {
+		if len(extensions) == 0 && format == tui.TableFormatTable {
 			logging.FromContext(cmd.Context()).Infof("All extensions are up-to-date")
 			return nil
 		}
 
-		rows := make([][]string, 0, len(extensions))
+		result := tui.NewTable(
+			tui.TableColumn{Title: "Name", JSONKey: "name"},
+			tui.TableColumn{Title: "Current Version", JSONKey: "currentVersion"},
+			tui.TableColumn{Title: "Latest Version", JSONKey: "latestVersion"},
+			tui.TableColumn{Title: "Update Source", JSONKey: "updateSource"},
+		)
 		for _, extension := range extensions {
-			rows = append(rows, []string{extension.Name, extension.Version, extension.LatestVersion, extension.UpdateSource})
+			result.AddRow(extension.Name, extension.Version, extension.LatestVersion, extension.UpdateSource)
 		}
-		tui.PrintTable([]string{"Name", "Current Version", "Latest Version", "Update Source"}, rows)
+		if err := result.Write(cmd.OutOrStdout(), format); err != nil {
+			return err
+		}
+		if format == tui.TableFormatJSON {
+			return nil
+		}
 
 		return fmt.Errorf("there are %d outdated extensions", len(extensions))
 	},
@@ -71,5 +76,7 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 
 func init() {
 	projectExtensionCmd.AddCommand(projectExtensionOutdatedCmd)
-	projectExtensionOutdatedCmd.PersistentFlags().Bool("json", false, "Output as json")
+	projectExtensionOutdatedCmd.Flags().String("format", string(tui.TableFormatTable), "Output format (table or json)")
+	projectExtensionOutdatedCmd.Flags().Bool("json", false, "Output as json")
+	projectExtensionOutdatedCmd.MarkFlagsMutuallyExclusive("format", "json")
 }

--- a/cmd/project/project_output_format_test.go
+++ b/cmd/project/project_output_format_test.go
@@ -1,0 +1,121 @@
+package project
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+func TestProjectExtensionTablesPreserveJSONContract(t *testing.T) {
+	extension := &adminSdk.ExtensionDetail{
+		Name:          "Example",
+		Version:       "1.0.0",
+		LatestVersion: "1.1.0",
+		Active:        true,
+		UpdateSource:  "store",
+	}
+	extensions := adminSdk.ExtensionList{extension}
+
+	expected, err := json.Marshal(extensions)
+	require.NoError(t, err)
+
+	for _, result := range []*tui.Table{
+		projectExtensionListTable(extensions),
+		projectExtensionOutdatedTable(extensions),
+	} {
+		output, err := result.Render(tui.TableFormatJSON)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(expected), output)
+	}
+}
+
+func TestProjectOutputFormatFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    *cobra.Command
+		legacyFlag string
+		defaultVal string
+	}{
+		{
+			name:       "extension list",
+			command:    projectExtensionListCmd,
+			legacyFlag: "json",
+			defaultVal: "table",
+		},
+		{
+			name:       "extension outdated",
+			command:    projectExtensionOutdatedCmd,
+			legacyFlag: "json",
+			defaultVal: "table",
+		},
+		{
+			name:       "validate",
+			command:    projectValidateCmd,
+			legacyFlag: "reporter",
+			defaultVal: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			format := test.command.Flags().Lookup("format")
+			require.NotNil(t, format)
+			assert.False(t, format.Hidden)
+			assert.Empty(t, format.Deprecated)
+			assert.Equal(t, test.defaultVal, format.DefValue)
+
+			legacy := test.command.Flags().Lookup(test.legacyFlag)
+			require.NotNil(t, legacy)
+			assert.True(t, legacy.Hidden)
+			assert.NotEmpty(t, legacy.Deprecated)
+
+			format.Changed = true
+			legacy.Changed = true
+			t.Cleanup(func() {
+				format.Changed = false
+				legacy.Changed = false
+			})
+			assert.Error(t, test.command.ValidateFlagGroups())
+		})
+	}
+}
+
+func TestProjectValidationFormatSupportsNewAndDeprecatedFlags(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+
+	newFlag := newValidationFormatCommand()
+	require.NoError(t, newFlag.Flags().Set("format", "json"))
+	format, err := projectValidationFormat(newFlag)
+	require.NoError(t, err)
+	assert.Equal(t, "json", format)
+
+	deprecatedFlag := newValidationFormatCommand()
+	require.NoError(t, deprecatedFlag.Flags().Set("reporter", "junit"))
+	format, err = projectValidationFormat(deprecatedFlag)
+	require.NoError(t, err)
+	assert.Equal(t, "junit", format)
+
+	defaultFormat, err := projectValidationFormat(newValidationFormatCommand())
+	require.NoError(t, err)
+	assert.Equal(t, "summary", defaultFormat)
+}
+
+func TestProjectExtensionDeprecatedJSONAlias(t *testing.T) {
+	format, err := projectExtensionOutputFormat("table", true)
+	require.NoError(t, err)
+	assert.Equal(t, tui.TableFormatJSON, format)
+}
+
+func newValidationFormatCommand() *cobra.Command {
+	command := &cobra.Command{}
+	command.Flags().String("format", "", "")
+	command.Flags().String("reporter", "", "")
+	return command
+}

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -19,10 +19,16 @@ var projectValidateCmd = &cobra.Command{
 	Short: "Validate project",
 	Args:  cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := projectValidationFormat(cmd); err != nil {
+			return err
+		}
 		return verifier.SetupTools(cmd.Context(), cmd.Root().Version)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		reportingFormat, _ := cmd.Flags().GetString("reporter")
+		reportingFormat, err := projectValidationFormat(cmd)
+		if err != nil {
+			return err
+		}
 		only, _ := cmd.Flags().GetString("only")
 		exclude, _ := cmd.Flags().GetString("exclude")
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "analyse-project-*")
@@ -46,10 +52,6 @@ var projectValidateCmd = &cobra.Command{
 		projectPath, err = filepath.Abs(projectPath)
 		if err != nil {
 			return fmt.Errorf("cannot find path: %w", err)
-		}
-
-		if reportingFormat == "" {
-			reportingFormat = validation.DetectDefaultReporter()
 		}
 
 		if !noCopy {
@@ -104,11 +106,28 @@ var projectValidateCmd = &cobra.Command{
 	},
 }
 
+func projectValidationFormat(cmd *cobra.Command) (string, error) {
+	format, _ := cmd.Flags().GetString("format")
+	reporter, _ := cmd.Flags().GetString("reporter")
+	if reporter != "" {
+		format = reporter
+	}
+	if format == "" {
+		format = validation.DetectDefaultReporter()
+	}
+
+	return format, validation.ValidateReporter(format)
+}
+
 func init() {
 	projectRootCmd.AddCommand(projectValidateCmd)
+	projectValidateCmd.PersistentFlags().String("format", "", "Reporting format (summary, json, github, gitlab, junit, markdown)")
 	projectValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, gitlab, junit, markdown)")
 	projectValidateCmd.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	projectValidateCmd.PersistentFlags().String("exclude", "", "Exclude specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	projectValidateCmd.PersistentFlags().Bool("no-copy", false, "Do not copy project files to temporary directory")
 	projectValidateCmd.PersistentFlags().Bool("local-only", false, "Only read plugins in custom/* folders")
+	projectValidateCmd.MarkFlagsMutuallyExclusive("format", "reporter")
+	_ = projectValidateCmd.PersistentFlags().MarkDeprecated("reporter", "use --format instead")
+	_ = projectValidateCmd.PersistentFlags().MarkHidden("reporter")
 }

--- a/internal/account-api/producer_store_list.go
+++ b/internal/account-api/producer_store_list.go
@@ -3,13 +3,8 @@ package account_api
 import (
 	"cmp"
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"slices"
-
-	"charm.land/lipgloss/v2"
-	liplogtable "charm.land/lipgloss/v2/table"
 
 	"github.com/shopware/shopware-cli/internal/tui"
 )
@@ -87,52 +82,16 @@ func IncludeExtension(extension Extension, pluginOnly, appOnly bool) bool {
 	return true
 }
 
-type extensionListItem struct {
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Compatible bool   `json:"compatibleWithLatestVersion"`
-	Status     string `json:"status"`
-	Producer   string `json:"producer"`
-}
+func ExtensionsTable(extensions []Extension) *tui.Table {
+	result := tui.NewTable(
+		tui.TableColumn{Title: "Name", JSONKey: "name"},
+		tui.TableColumn{Title: "Type", JSONKey: "type"},
+		tui.TableColumn{Title: "Compatible with latest version", JSONKey: "compatibleWithLatestVersion"},
+		tui.TableColumn{Title: "Status", JSONKey: "status"},
+		tui.TableColumn{Title: "Producer", JSONKey: "producer"},
+	)
 
-func WriteExtensionsJSON(w io.Writer, extensions []Extension) error {
-	items := make([]extensionListItem, 0, len(extensions))
 	for _, extension := range extensions {
-		items = append(items, extensionListItem{
-			Name:       extension.Name,
-			Type:       extension.Generation.Name,
-			Compatible: extension.IsCompatibleWithLatestShopwareVersion,
-			Status:     extension.Status.Name,
-			Producer:   extension.Producer.Name,
-		})
-	}
-
-	content, err := json.Marshal(items)
-	if err != nil {
-		return err
-	}
-
-	_, err = fmt.Fprintln(w, string(content))
-	return err
-}
-
-func WriteExtensionsTable(w io.Writer, extensions []Extension) error {
-	cellStyle := lipgloss.NewStyle().Padding(0, 1)
-
-	t := liplogtable.New().
-		Border(lipgloss.NormalBorder()).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			return cellStyle
-		}).
-		Headers("Name", "Type", "Compatible with latest version", "Status")
-
-	lastProducerId := 0
-	for _, extension := range extensions {
-		if extension.Producer.Id != lastProducerId {
-			lastProducerId = extension.Producer.Id
-			t.Row(tui.BoldText.Render(extension.Producer.Name), "", "", "")
-		}
-
 		compatible := tui.RedText.Render("No")
 		if extension.IsCompatibleWithLatestShopwareVersion {
 			compatible = tui.GreenText.Render("Yes")
@@ -148,14 +107,31 @@ func WriteExtensionsTable(w io.Writer, extensions []Extension) error {
 			status = tui.DimText.Render(extension.Status.Name)
 		}
 
-		t.Row(
-			"  "+extension.Name,
-			tui.DimText.Render(extension.Generation.Description),
-			compatible,
-			status,
+		result.AddRow(
+			extension.Name,
+			tui.TableCell{
+				Value:        extension.Generation.Name,
+				TerminalText: tui.DimText.Render(extension.Generation.Description),
+			},
+			tui.TableCell{
+				Value:        extension.IsCompatibleWithLatestShopwareVersion,
+				TerminalText: compatible,
+			},
+			tui.TableCell{
+				Value:        extension.Status.Name,
+				TerminalText: status,
+			},
+			extension.Producer.Name,
 		)
 	}
 
-	_, err := fmt.Fprintln(w, t.Render())
-	return err
+	return result
+}
+
+func WriteExtensionsJSON(w io.Writer, extensions []Extension) error {
+	return ExtensionsTable(extensions).Write(w, tui.TableFormatJSON)
+}
+
+func WriteExtensionsTable(w io.Writer, extensions []Extension) error {
+	return ExtensionsTable(extensions).Write(w, tui.TableFormatTable)
 }

--- a/internal/account-api/producer_store_list_test.go
+++ b/internal/account-api/producer_store_list_test.go
@@ -125,7 +125,13 @@ func TestWriteExtensionsJSON(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, WriteExtensionsJSON(&buf, []Extension{ext}))
 
-	var items []extensionListItem
+	var items []struct {
+		Name       string `json:"name"`
+		Type       string `json:"type"`
+		Compatible bool   `json:"compatibleWithLatestVersion"`
+		Status     string `json:"status"`
+		Producer   string `json:"producer"`
+	}
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &items))
 	require.Len(t, items, 1)
 	assert.Equal(t, "PaymentPlugin", items[0].Name)

--- a/internal/tui/README.md
+++ b/internal/tui/README.md
@@ -404,8 +404,9 @@ err = table.Write(cmd.OutOrStdout(), format)
 ```
 
 `TableCell` keeps the typed JSON value separate from styled or human-readable
-terminal text. `RenderTable` and `PrintTable` remain available for terminal-only
-call sites using `[][]string`.
+terminal text. `AddRowWithJSON` preserves established JSON row contracts that
+contain more fields than the human-readable table. `RenderTable` and
+`PrintTable` remain available for terminal-only call sites using `[][]string`.
 
 ```
 ┌─────────┬────────────┐

--- a/internal/tui/README.md
+++ b/internal/tui/README.md
@@ -387,19 +387,32 @@ tui.NewScrollbar(tui.ScrollbarOptions{Total: 30, Visible: 5, Offset: 10, Height:
 ↓
 ```
 
-### RenderTable / PrintTable — bordered tables for command output
+### Table — terminal and JSON command output
 
 ```go
-tui.PrintTable([]string{"Name", "Version"}, rows)
+table := tui.NewTable(
+    tui.TableColumn{Title: "Name", JSONKey: "name"},
+    tui.TableColumn{Title: "Compatible", JSONKey: "compatible"},
+)
+table.AddRow(
+    "Example",
+    tui.TableCell{Value: true, TerminalText: tui.GreenText.Render("Yes")},
+)
+
+format, err := tui.ParseTableFormat(formatFlag)
+err = table.Write(cmd.OutOrStdout(), format)
 ```
 
+`TableCell` keeps the typed JSON value separate from styled or human-readable
+terminal text. `RenderTable` and `PrintTable` remain available for terminal-only
+call sites using `[][]string`.
+
 ```
-┌───────────────┬─────────┐
-│ Name          │ Version │
-├───────────────┼─────────┤
-│ frosh/tools   │ 2.1.0   │
-│ shopware/core │ 6.7.4.1 │
-└───────────────┴─────────┘
+┌─────────┬────────────┐
+│ Name    │ Compatible │
+├─────────┼────────────┤
+│ Example │ Yes        │
+└─────────┴────────────┘
 ```
 
 ### Labels & small helpers

--- a/internal/tui/README.md
+++ b/internal/tui/README.md
@@ -400,7 +400,12 @@ table.AddRow(
 )
 
 format, err := tui.ParseTableFormat(formatFlag)
-err = table.Write(cmd.OutOrStdout(), format)
+if err != nil {
+    return err
+}
+if err := table.Write(cmd.OutOrStdout(), format); err != nil {
+    return err
+}
 ```
 
 `TableCell` keeps the typed JSON value separate from styled or human-readable
@@ -408,7 +413,7 @@ terminal text. `AddRowWithJSON` preserves established JSON row contracts that
 contain more fields than the human-readable table. `RenderTable` and
 `PrintTable` remain available for terminal-only call sites using `[][]string`.
 
-```
+```text
 ┌─────────┬────────────┐
 │ Name    │ Compatible │
 ├─────────┼────────────┤

--- a/internal/tui/printtable.go
+++ b/internal/tui/printtable.go
@@ -246,8 +246,7 @@ func RenderTable(headers []string, rows [][]string) string {
 		t.AddRow(values...)
 	}
 
-	rendered, _ := t.Render(TableFormatTable)
-	return rendered
+	return t.renderTerminal()
 }
 
 // PrintTable prints a bordered table to stdout — the shared shape of the

--- a/internal/tui/printtable.go
+++ b/internal/tui/printtable.go
@@ -51,7 +51,13 @@ type TableCell struct {
 // Table contains one output-neutral table definition.
 type Table struct {
 	columns []TableColumn
-	rows    [][]any
+	rows    []tableRow
+}
+
+type tableRow struct {
+	cells        []any
+	jsonValue    any
+	hasJSONValue bool
 }
 
 // NewTable creates a table with the given columns.
@@ -61,7 +67,19 @@ func NewTable(columns ...TableColumn) *Table {
 
 // AddRow appends a row. Row width is validated when the table is rendered.
 func (t *Table) AddRow(values ...any) {
-	t.rows = append(t.rows, slices.Clone(values))
+	t.rows = append(t.rows, tableRow{cells: slices.Clone(values)})
+}
+
+// AddRowWithJSON appends a row with a custom JSON representation. Prefer
+// AddRow when JSON should contain exactly the configured columns. This method
+// supports established JSON contracts that contain more data than the
+// corresponding human-readable table.
+func (t *Table) AddRowWithJSON(jsonValue any, values ...any) {
+	t.rows = append(t.rows, tableRow{
+		cells:        slices.Clone(values),
+		jsonValue:    jsonValue,
+		hasJSONValue: true,
+	})
 }
 
 // Render renders the table in the requested format.
@@ -115,8 +133,8 @@ func (t *Table) validate() error {
 	}
 
 	for i, row := range t.rows {
-		if len(row) != len(t.columns) {
-			return fmt.Errorf("table row %d has %d cells, expected %d", i+1, len(row), len(t.columns))
+		if len(row.cells) != len(t.columns) {
+			return fmt.Errorf("table row %d has %d cells, expected %d", i+1, len(row.cells), len(t.columns))
 		}
 	}
 
@@ -137,8 +155,8 @@ func (t *Table) renderTerminal() string {
 		Headers(headers...)
 
 	for _, row := range t.rows {
-		values := make([]string, len(row))
-		for i, value := range row {
+		values := make([]string, len(row.cells))
+		for i, value := range row.cells {
 			values[i] = terminalCellText(value)
 		}
 		renderer.Row(values...)
@@ -155,6 +173,14 @@ func (t *Table) renderJSON() ([]byte, error) {
 		if rowIndex > 0 {
 			output.WriteByte(',')
 		}
+		if row.hasJSONValue {
+			value, err := json.Marshal(row.jsonValue)
+			if err != nil {
+				return nil, fmt.Errorf("marshal table row %d: %w", rowIndex+1, err)
+			}
+			output.Write(value)
+			continue
+		}
 		output.WriteByte('{')
 
 		for columnIndex, column := range t.columns {
@@ -166,7 +192,7 @@ func (t *Table) renderJSON() ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			value, err := json.Marshal(jsonCellValue(row[columnIndex]))
+			value, err := json.Marshal(jsonCellValue(row.cells[columnIndex]))
 			if err != nil {
 				return nil, fmt.Errorf("marshal table row %d column %q: %w", rowIndex+1, column.JSONKey, err)
 			}

--- a/internal/tui/printtable.go
+++ b/internal/tui/printtable.go
@@ -1,26 +1,227 @@
 package tui
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
 )
 
-// RenderTable renders a bordered table with a header row. Cells may be
-// pre-styled; every cell gets one column of horizontal padding.
-func RenderTable(headers []string, rows [][]string) string {
-	cellStyle := lipgloss.NewStyle().Padding(0, 1)
+// TableFormat is an output format supported by Table.
+type TableFormat string
 
-	t := table.New().
+const (
+	TableFormatTable TableFormat = "table"
+	TableFormatJSON  TableFormat = "json"
+)
+
+// ParseTableFormat validates a table output format.
+func ParseTableFormat(value string) (TableFormat, error) {
+	format := TableFormat(strings.ToLower(value))
+	switch format {
+	case TableFormatTable, TableFormatJSON:
+		return format, nil
+	default:
+		return "", fmt.Errorf("unknown table format %q, allowed values: table, json", value)
+	}
+}
+
+// TableColumn configures one terminal table column and its corresponding JSON
+// object key.
+type TableColumn struct {
+	Title   string
+	JSONKey string
+}
+
+// TableCell holds a raw value for JSON output and, optionally, a separate
+// representation for terminal output. TerminalText is useful for colors,
+// human-readable booleans, and other presentation that should not leak into
+// machine-readable output.
+type TableCell struct {
+	Value        any
+	TerminalText string
+}
+
+// Table contains one output-neutral table definition.
+type Table struct {
+	columns []TableColumn
+	rows    [][]any
+}
+
+// NewTable creates a table with the given columns.
+func NewTable(columns ...TableColumn) *Table {
+	return &Table{columns: slices.Clone(columns)}
+}
+
+// AddRow appends a row. Row width is validated when the table is rendered.
+func (t *Table) AddRow(values ...any) {
+	t.rows = append(t.rows, slices.Clone(values))
+}
+
+// Render renders the table in the requested format.
+func (t *Table) Render(format TableFormat) (string, error) {
+	if err := t.validate(); err != nil {
+		return "", err
+	}
+
+	switch format {
+	case TableFormatTable:
+		return t.renderTerminal(), nil
+	case TableFormatJSON:
+		content, err := t.renderJSON()
+		if err != nil {
+			return "", err
+		}
+		return string(content), nil
+	default:
+		return "", fmt.Errorf("unknown table format %q, allowed values: table, json", format)
+	}
+}
+
+// Write renders the table and writes it with a trailing newline.
+func (t *Table) Write(w io.Writer, format TableFormat) error {
+	content, err := t.Render(format)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintln(w, content)
+	return err
+}
+
+func (t *Table) validate() error {
+	if len(t.columns) == 0 {
+		return errors.New("table must have at least one column")
+	}
+
+	keys := make(map[string]struct{}, len(t.columns))
+	for i, column := range t.columns {
+		if column.Title == "" {
+			return fmt.Errorf("table column %d must have a title", i+1)
+		}
+		if column.JSONKey == "" {
+			return fmt.Errorf("table column %q must have a JSON key", column.Title)
+		}
+		if _, exists := keys[column.JSONKey]; exists {
+			return fmt.Errorf("table JSON key %q is duplicated", column.JSONKey)
+		}
+		keys[column.JSONKey] = struct{}{}
+	}
+
+	for i, row := range t.rows {
+		if len(row) != len(t.columns) {
+			return fmt.Errorf("table row %d has %d cells, expected %d", i+1, len(row), len(t.columns))
+		}
+	}
+
+	return nil
+}
+
+func (t *Table) renderTerminal() string {
+	headers := make([]string, len(t.columns))
+	for i, column := range t.columns {
+		headers[i] = column.Title
+	}
+
+	cellStyle := lipgloss.NewStyle().Padding(0, 1)
+	renderer := table.New().
 		Border(lipgloss.NormalBorder()).
 		BorderStyle(lipgloss.NewStyle().Foreground(BorderColor)).
 		StyleFunc(func(int, int) lipgloss.Style { return cellStyle }).
 		Headers(headers...)
-	for _, row := range rows {
-		t.Row(row...)
+
+	for _, row := range t.rows {
+		values := make([]string, len(row))
+		for i, value := range row {
+			values[i] = terminalCellText(value)
+		}
+		renderer.Row(values...)
 	}
-	return t.Render()
+
+	return renderer.Render()
+}
+
+func (t *Table) renderJSON() ([]byte, error) {
+	var output bytes.Buffer
+	output.WriteByte('[')
+
+	for rowIndex, row := range t.rows {
+		if rowIndex > 0 {
+			output.WriteByte(',')
+		}
+		output.WriteByte('{')
+
+		for columnIndex, column := range t.columns {
+			if columnIndex > 0 {
+				output.WriteByte(',')
+			}
+
+			key, err := json.Marshal(column.JSONKey)
+			if err != nil {
+				return nil, err
+			}
+			value, err := json.Marshal(jsonCellValue(row[columnIndex]))
+			if err != nil {
+				return nil, fmt.Errorf("marshal table row %d column %q: %w", rowIndex+1, column.JSONKey, err)
+			}
+
+			output.Write(key)
+			output.WriteByte(':')
+			output.Write(value)
+		}
+
+		output.WriteByte('}')
+	}
+
+	output.WriteByte(']')
+	return output.Bytes(), nil
+}
+
+func terminalCellText(value any) string {
+	if cell, ok := value.(TableCell); ok {
+		if cell.TerminalText != "" {
+			return cell.TerminalText
+		}
+		value = cell.Value
+	}
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func jsonCellValue(value any) any {
+	if cell, ok := value.(TableCell); ok {
+		return cell.Value
+	}
+	return value
+}
+
+// RenderTable renders a bordered table with a header row. Cells may be
+// pre-styled; every cell gets one column of horizontal padding.
+func RenderTable(headers []string, rows [][]string) string {
+	columns := make([]TableColumn, len(headers))
+	for i, header := range headers {
+		columns[i] = TableColumn{Title: header, JSONKey: fmt.Sprintf("column%d", i+1)}
+	}
+
+	t := NewTable(columns...)
+	for _, row := range rows {
+		values := make([]any, len(row))
+		for i, value := range row {
+			values[i] = value
+		}
+		t.AddRow(values...)
+	}
+
+	rendered, _ := t.Render(TableFormatTable)
+	return rendered
 }
 
 // PrintTable prints a bordered table to stdout — the shared shape of the

--- a/internal/tui/printtable_test.go
+++ b/internal/tui/printtable_test.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableRendersTerminalAndJSONFromSameRows(t *testing.T) {
+	result := NewTable(
+		TableColumn{Title: "Name", JSONKey: "name"},
+		TableColumn{Title: "Compatible", JSONKey: "compatible"},
+	)
+	result.AddRow(
+		"Example",
+		TableCell{Value: true, TerminalText: "Yes"},
+	)
+
+	terminal, err := result.Render(TableFormatTable)
+	require.NoError(t, err)
+	assert.Contains(t, terminal, "Name")
+	assert.Contains(t, terminal, "Example")
+	assert.Contains(t, terminal, "Yes")
+	assert.NotContains(t, terminal, "true")
+
+	jsonOutput, err := result.Render(TableFormatJSON)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"name":"Example","compatible":true}]`, jsonOutput)
+	assert.Equal(t, `[{"name":"Example","compatible":true}]`, jsonOutput)
+}
+
+func TestTableJSONUsesEmptyArrayForNoRows(t *testing.T) {
+	result := NewTable(TableColumn{Title: "Name", JSONKey: "name"})
+
+	output, err := result.Render(TableFormatJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", output)
+}
+
+func TestTableWriteAddsTrailingNewline(t *testing.T) {
+	result := NewTable(TableColumn{Title: "Name", JSONKey: "name"})
+	result.AddRow("Example")
+
+	var output bytes.Buffer
+	require.NoError(t, result.Write(&output, TableFormatJSON))
+	assert.Equal(t, "[{\"name\":\"Example\"}]\n", output.String())
+}
+
+func TestTableValidatesConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		table *Table
+		error string
+	}{
+		{
+			name:  "no columns",
+			table: NewTable(),
+			error: "table must have at least one column",
+		},
+		{
+			name:  "missing title",
+			table: NewTable(TableColumn{JSONKey: "name"}),
+			error: "table column 1 must have a title",
+		},
+		{
+			name:  "missing JSON key",
+			table: NewTable(TableColumn{Title: "Name"}),
+			error: `table column "Name" must have a JSON key`,
+		},
+		{
+			name: "duplicate JSON key",
+			table: NewTable(
+				TableColumn{Title: "Name", JSONKey: "name"},
+				TableColumn{Title: "Other name", JSONKey: "name"},
+			),
+			error: `table JSON key "name" is duplicated`,
+		},
+		{
+			name: "wrong row width",
+			table: func() *Table {
+				result := NewTable(TableColumn{Title: "Name", JSONKey: "name"})
+				result.AddRow("Example", "extra")
+				return result
+			}(),
+			error: "table row 1 has 2 cells, expected 1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.table.Render(TableFormatJSON)
+			require.EqualError(t, err, test.error)
+		})
+	}
+}
+
+func TestParseTableFormat(t *testing.T) {
+	format, err := ParseTableFormat("JSON")
+	require.NoError(t, err)
+	assert.Equal(t, TableFormatJSON, format)
+
+	_, err = ParseTableFormat("yaml")
+	require.EqualError(t, err, `unknown table format "yaml", allowed values: table, json`)
+}

--- a/internal/tui/printtable_test.go
+++ b/internal/tui/printtable_test.go
@@ -123,3 +123,13 @@ func TestParseTableFormat(t *testing.T) {
 	_, err = ParseTableFormat("yaml")
 	require.EqualError(t, err, `unknown table format "yaml", allowed values: table, json`)
 }
+
+func TestRenderTablePreservesLegacyInvalidInputBehavior(t *testing.T) {
+	emptyHeader := RenderTable([]string{""}, [][]string{{"value"}})
+	assert.NotEmpty(t, emptyHeader)
+	assert.Contains(t, emptyHeader, "value")
+
+	mismatchedRow := RenderTable([]string{"Name", "Version"}, [][]string{{"Example"}})
+	assert.NotEmpty(t, mismatchedRow)
+	assert.Contains(t, mismatchedRow, "Example")
+}

--- a/internal/tui/printtable_test.go
+++ b/internal/tui/printtable_test.go
@@ -39,6 +39,25 @@ func TestTableJSONUsesEmptyArrayForNoRows(t *testing.T) {
 	assert.Equal(t, "[]", output)
 }
 
+func TestTableSupportsEstablishedJSONRowContract(t *testing.T) {
+	type item struct {
+		Name   string `json:"name"`
+		Active bool   `json:"active"`
+	}
+
+	result := NewTable(TableColumn{Title: "Name", JSONKey: "name"})
+	result.AddRowWithJSON(item{Name: "Example", Active: true}, "Example")
+
+	terminal, err := result.Render(TableFormatTable)
+	require.NoError(t, err)
+	assert.Contains(t, terminal, "Example")
+	assert.NotContains(t, terminal, "Active")
+
+	jsonOutput, err := result.Render(TableFormatJSON)
+	require.NoError(t, err)
+	assert.Equal(t, `[{"name":"Example","active":true}]`, jsonOutput)
+}
+
 func TestTableWriteAddsTrailingNewline(t *testing.T) {
 	result := NewTable(TableColumn{Title: "Name", JSONKey: "name"})
 	result.AddRow("Example")

--- a/internal/validation/reporter.go
+++ b/internal/validation/reporter.go
@@ -13,6 +13,19 @@ import (
 	"strings"
 )
 
+const reporterFormats = "summary, json, github, gitlab, junit, markdown"
+
+// ValidateReporter checks whether name identifies a supported validation
+// report format.
+func ValidateReporter(name string) error {
+	switch name {
+	case "summary", "json", "github", "gitlab", "junit", "markdown":
+		return nil
+	default:
+		return fmt.Errorf("invalid reporting format %q, allowed values: %s", name, reporterFormats)
+	}
+}
+
 func DetectDefaultReporter() string {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		return "github"
@@ -26,6 +39,10 @@ func DetectDefaultReporter() string {
 }
 
 func DoCheckReport(result Check, reportingFormat string) error {
+	if err := ValidateReporter(reportingFormat); err != nil {
+		return err
+	}
+
 	switch reportingFormat {
 	case "summary":
 		if err := doSummaryReport(result); err != nil {

--- a/internal/validation/reporter_test.go
+++ b/internal/validation/reporter_test.go
@@ -164,6 +164,14 @@ func TestErrorExistsSummary(t *testing.T) {
 	assert.Error(t, DoCheckReport(check, "summary"))
 }
 
+func TestValidateReporter(t *testing.T) {
+	for _, format := range []string{"summary", "json", "github", "gitlab", "junit", "markdown"} {
+		assert.NoError(t, ValidateReporter(format))
+	}
+
+	assert.EqualError(t, ValidateReporter("yaml"), `invalid reporting format "yaml", allowed values: summary, json, github, gitlab, junit, markdown`)
+}
+
 func TestGitLabReport(t *testing.T) {
 	testResults := []CheckResult{
 		{


### PR DESCRIPTION
## What changed?
Added a shared `tui.Table` abstraction whose configured columns and rows can be rendered as either a bordered terminal table or JSON.

- Columns define their terminal title and JSON key.
- Rows retain typed JSON values.
- `TableCell` provides separate styled or human-readable terminal text without leaking ANSI sequences into JSON.
- `AddRowWithJSON` supports established JSON contracts that contain more fields than the human table.
- Invalid columns, duplicate JSON keys, and inconsistent row widths return descriptive errors.
- Existing `RenderTable` and `PrintTable` callers remain supported.
- Producer extension, project extension list, and project extension outdated output now use the table abstraction for both formats.

Standardized output-selection flags as proposed in #1471:

- `project extension list`, `project extension outdated`, and `account company producer extension list` now use `--format table|json`.
- `extension validate` and `project validate` now use `--format summary|json|github|gitlab|junit|markdown`.
- Existing `--json` and `--reporter` flags remain functional as hidden, deprecated aliases for one-release compatibility.
- Passing a replacement flag together with its deprecated alias is rejected.
- Existing project extension JSON payloads remain unchanged.
- `project sql --format` and `project sbom --format` are unchanged.
- `architecture.md` now identifies `--format` as the CLI convention.

Before:

```console
$ shopware-cli project extension list --json
[{"extensions":[],"id":null,"localId":"",...,"name":"PayPal","version":"6.0.0",...}]

$ shopware-cli extension validate ExamplePlugin --reporter json
```

After (with the same JSON/report payloads):

```console
$ shopware-cli project extension list --format json
[{"extensions":[],"id":null,"localId":"",...,"name":"PayPal","version":"6.0.0",...}]

$ shopware-cli extension validate ExamplePlugin --format json
```

The producer extension terminal table represents its producer as an explicit column, while typed values such as compatibility remain booleans in JSON:

```text
┌───────────────┬────────┬────────────────────────────────┬──────────┬──────────┐
│ Name          │ Type   │ Compatible with latest version │ Status   │ Producer │
├───────────────┼────────┼────────────────────────────────┼──────────┼──────────┤
│ PaymentPlugin │ Plugin │ Yes                            │ approved │ Acme     │
└───────────────┴────────┴────────────────────────────────┴──────────┴──────────┘
```

## Why?
List commands should not maintain separate terminal and JSON rendering paths, and the CLI should have one convention for selecting machine-readable output. A single output-neutral table definition keeps presentation aligned, while `--format` gives list, validation, SQL, and SBOM commands a consistent flag name with command-specific values.

## How was this tested?
- Added unit coverage for terminal and JSON rendering from the same rows.
- Covered typed/styled cells, established JSON row contracts, deterministic JSON output, empty tables, trailing newlines, format parsing, duplicate keys, missing column metadata, and invalid row widths.
- Added regression tests proving project extension JSON payloads are preserved.
- Added command tests for the new flags, deprecated aliases, hidden alias metadata, reporter resolution, and mutual exclusion.
- Manually checked help output and rejection of combined old/new flags.
- Ran `go test ./...`.
- Ran `go vet ./...`.
- Ran `golangci-lint run ./...` (0 issues).

## Related issue or discussion
Closes #1471.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format` support for extension listing, outdated checks, and validation reports.
  * Added table and JSON output options with consistent extension result formatting.
  * Added support for validation report formats including summary, JSON, GitHub, GitLab, JUnit, and Markdown.
* **Bug Fixes**
  * Improved outdated-extension messaging for JSON output.
  * Invalid formats now produce clear errors before processing begins.
* **Documentation**
  * Updated table output guidance and standardized structured-output conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->