### PR TITLE
test: add shared testhelper fixture builders and migrate tests onto them

### DIFF
--- a/cmd/extension/extension_package_test.go
+++ b/cmd/extension/extension_package_test.go
@@ -23,8 +23,13 @@ func TestPackageDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
 		Label:       map[string]string{"de-DE": "Test", "en-GB": "Test"},
 		Psr4:        map[string]string{`FroshTest\`: "src/"},
 	}.String())
-	testhelper.WriteFile(t, filepath.Join(extDir, ".shopware-extension.yml"),
-		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n")
+	testhelper.WriteFile(t, filepath.Join(extDir, ".shopware-extension.yml"), `build:
+  zip:
+    composer:
+      enabled: false
+    assets:
+      enabled: false
+`)
 
 	workDir := t.TempDir()
 	decoyBackup := filepath.Join(workDir, "FroshTest-backup-2024.zip")

--- a/cmd/extension/extension_package_test.go
+++ b/cmd/extension/extension_package_test.go
@@ -7,25 +7,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestPackageDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
 	extDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(extDir, "composer.json"), []byte(`{
-			"name": "frosh/frosh-test",
-			"type": "shopware-platform-plugin",
-			"license": "MIT",
-			"version": "1.0.0",
-			"require": { "shopware/core": "~6.6.0" },
-			"autoload": { "psr-4": { "FroshTest\\": "src/" } },
-			"extra": {
-				"shopware-plugin-class": "FroshTest\\FroshTest",
-				"label": { "de-DE": "Test", "en-GB": "Test" }
-			}
-		}`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(extDir, ".shopware-extension.yml"), []byte(
-		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n",
-	), 0o644))
+	testhelper.WriteFile(t, filepath.Join(extDir, "composer.json"), testhelper.ComposerJSON{
+		Name:        "frosh/frosh-test",
+		Type:        "shopware-platform-plugin",
+		License:     "MIT",
+		Version:     "1.0.0",
+		Require:     map[string]string{"shopware/core": "~6.6.0"},
+		PluginClass: `FroshTest\FroshTest`,
+		Label:       map[string]string{"de-DE": "Test", "en-GB": "Test"},
+		Psr4:        map[string]string{`FroshTest\`: "src/"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(extDir, ".shopware-extension.yml"),
+		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n")
 
 	workDir := t.TempDir()
 	decoyBackup := filepath.Join(workDir, "FroshTest-backup-2024.zip")

--- a/cmd/extension/extension_prepare_test.go
+++ b/cmd/extension/extension_prepare_test.go
@@ -2,26 +2,13 @@ package extension
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
 
-const testPrepareAppManifest = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<description>A description</description>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-</manifest>`
+	"github.com/shopware/shopware-cli/internal/testhelper"
+)
 
 func TestExtensionPrepareCommandDeprecated(t *testing.T) {
 	t.Parallel()
@@ -49,8 +36,7 @@ func TestExtensionPreparePrintsDeprecationNotice(t *testing.T) {
 }
 
 func TestExtensionPrepareStillExecutes(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.xml"), []byte(testPrepareAppManifest), 0o644))
+	dir := testhelper.NewApp(t, "MyExampleApp")
 
 	out := new(bytes.Buffer)
 	extensionPrepareCmd.SetOut(out)

--- a/cmd/project/ci_helpers_test.go
+++ b/cmd/project/ci_helpers_test.go
@@ -9,16 +9,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestCleanupTcpdfKeepsOnlyCourierAndHelvetica(t *testing.T) {
 	root := t.TempDir()
 	fonts := filepath.Join(root, "vendor", "tecnickcom", "tcpdf", "fonts")
-	require.NoError(t, os.MkdirAll(fonts, 0o755))
 	// foo.z falls to the general keep-list rule; the file named exactly .z
 	// has its own branch.
 	for _, name := range []string{"helvetica.php", "courier_bold.php", "times.php", "foo.z", ".z"} {
-		require.NoError(t, os.WriteFile(filepath.Join(fonts, name), []byte("x"), 0o644))
+		testhelper.WriteFile(t, filepath.Join(fonts, name), "x")
 	}
 
 	require.NoError(t, cleanupTcpdf(root, t.Context()))

--- a/cmd/project/project_dump_test.go
+++ b/cmd/project/project_dump_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func newDumpFlagCommand(t *testing.T, flags map[string]string) *cobra.Command {
@@ -84,8 +86,9 @@ func TestAssembleConnectionURIDatabaseURLInsideProject(t *testing.T) {
 	projectRoot := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "bin"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "bin", "console"), nil, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "composer.json"), []byte(`{"require": {"shopware/core": "6.6.0"}}`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, ".env"), []byte("DATABASE_URL=mysql://app:secret@db.example.com:3307/shop\n"), 0o644))
+	testhelper.WriteFile(t, filepath.Join(projectRoot, "composer.json"),
+		testhelper.ComposerJSON{Require: map[string]string{"shopware/core": "6.6.0"}}.String())
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://app:secret@db.example.com:3307/shop\n")
 
 	t.Setenv("PROJECT_ROOT", "")
 	t.Setenv("DATABASE_URL", "")

--- a/cmd/project/project_env_resolution_test.go
+++ b/cmd/project/project_env_resolution_test.go
@@ -1,13 +1,14 @@
 package project
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 // writeMinimalPlugin creates a minimal platform plugin so the upload command reaches the environment-resolution step.
@@ -15,24 +16,20 @@ func writeMinimalPlugin(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{
-		"name": "frosh/frosh-test",
-		"type": "shopware-platform-plugin",
-		"license": "MIT",
-		"version": "1.0.0",
-		"require": { "shopware/core": "~6.6.0" },
-		"autoload": { "psr-4": { "FroshTest\\": "src/" } },
-		"extra": {
-			"shopware-plugin-class": "FroshTest\\FroshTest",
-			"label": { "de-DE": "Test", "en-GB": "Test" }
-		}
-	}`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".shopware-extension.yml"), []byte(
-		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n",
-	), 0o644))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "src", "FroshTest.php"),
-		[]byte("<?php\nnamespace FroshTest;\nuse Shopware\\Core\\Framework\\Plugin;\nclass FroshTest extends Plugin {}\n"), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:        "frosh/frosh-test",
+		Type:        "shopware-platform-plugin",
+		License:     "MIT",
+		Version:     "1.0.0",
+		Require:     map[string]string{"shopware/core": "~6.6.0"},
+		PluginClass: `FroshTest\FroshTest`,
+		Label:       map[string]string{"de-DE": "Test", "en-GB": "Test"},
+		Psr4:        map[string]string{`FroshTest\`: "src/"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, ".shopware-extension.yml"),
+		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n")
+	testhelper.WriteFile(t, filepath.Join(dir, "src", "FroshTest.php"),
+		"<?php\nnamespace FroshTest;\nuse Shopware\\Core\\Framework\\Plugin;\nclass FroshTest extends Plugin {}\n")
 
 	return dir
 }
@@ -52,7 +49,7 @@ func setupEnvironmentConfig(t *testing.T) {
 	t.Setenv("PROJECT_ROOT", t.TempDir())
 
 	configPath := filepath.Join(t.TempDir(), ".shopware-project.yml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	testhelper.WriteFile(t, configPath, `
 url: http://127.0.0.1:9
 compatibility_date: "2026-01-01"
 admin_api:
@@ -64,7 +61,7 @@ environments:
     admin_api:
       client_id: staging-id
       client_secret: staging-secret
-`), 0o644))
+`)
 
 	previousConfigPath := projectConfigPath
 	previousEnvironmentName := environmentName
@@ -80,7 +77,7 @@ func TestNoEnvFlagPrefersLocalEnvironmentOverTopLevel(t *testing.T) {
 	t.Setenv("PROJECT_ROOT", t.TempDir())
 
 	configPath := filepath.Join(t.TempDir(), ".shopware-project.yml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	testhelper.WriteFile(t, configPath, `
 url: http://127.0.0.1:9
 compatibility_date: "2026-01-01"
 admin_api:
@@ -92,7 +89,7 @@ environments:
     admin_api:
       client_id: local-id
       client_secret: local-secret
-`), 0o644))
+`)
 
 	previousConfigPath := projectConfigPath
 	previousEnvironmentName := environmentName
@@ -116,7 +113,7 @@ func TestNoEnvFlagUsesLocalWhenNoTopLevel(t *testing.T) {
 	t.Setenv("PROJECT_ROOT", t.TempDir())
 
 	configPath := filepath.Join(t.TempDir(), ".shopware-project.yml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	testhelper.WriteFile(t, configPath, `
 compatibility_date: "2026-01-01"
 environments:
   local:
@@ -124,7 +121,7 @@ environments:
     admin_api:
       client_id: local-id
       client_secret: local-secret
-`), 0o644))
+`)
 
 	previousConfigPath := projectConfigPath
 	previousEnvironmentName := environmentName

--- a/cmd/project/project_env_resolution_test.go
+++ b/cmd/project/project_env_resolution_test.go
@@ -26,10 +26,18 @@ func writeMinimalPlugin(t *testing.T) string {
 		Label:       map[string]string{"de-DE": "Test", "en-GB": "Test"},
 		Psr4:        map[string]string{`FroshTest\`: "src/"},
 	}.String())
-	testhelper.WriteFile(t, filepath.Join(dir, ".shopware-extension.yml"),
-		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n")
-	testhelper.WriteFile(t, filepath.Join(dir, "src", "FroshTest.php"),
-		"<?php\nnamespace FroshTest;\nuse Shopware\\Core\\Framework\\Plugin;\nclass FroshTest extends Plugin {}\n")
+	testhelper.WriteFile(t, filepath.Join(dir, ".shopware-extension.yml"), `build:
+  zip:
+    composer:
+      enabled: false
+    assets:
+      enabled: false
+`)
+	testhelper.WriteFile(t, filepath.Join(dir, "src", "FroshTest.php"), `<?php
+namespace FroshTest;
+use Shopware\Core\Framework\Plugin;
+class FroshTest extends Plugin {}
+`)
 
 	return dir
 }

--- a/cmd/project/project_sbom_test.go
+++ b/cmd/project/project_sbom_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -25,11 +26,11 @@ func TestGenerateProjectSBOMSkipsWhenLockMissing(t *testing.T) {
 func TestGenerateProjectSBOM(t *testing.T) {
 	root := t.TempDir()
 
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{
-		"name": "acme/shop",
-		"version": "1.2.3"
-	}`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
+	testhelper.WriteFile(t, filepath.Join(root, "composer.json"),
+		testhelper.ComposerJSON{Name: "acme/shop", Version: "1.2.3"}.String())
+	// The lock carries license and require fields the SBOM must pick up, which
+	// testhelper.ComposerLock cannot express.
+	testhelper.WriteFile(t, filepath.Join(root, "composer.lock"), `{
 		"packages": [
 			{
 				"name": "symfony/console",
@@ -42,7 +43,7 @@ func TestGenerateProjectSBOM(t *testing.T) {
 		"packages-dev": [
 			{"name": "phpunit/phpunit", "version": "10.0.0", "license": ["BSD-3-Clause"]}
 		]
-	}`), 0o644))
+	}`)
 
 	assert.NoError(t, generateProjectSBOM(t.Context(), root))
 
@@ -74,11 +75,12 @@ func TestProjectSbomCommandUnsupportedFormat(t *testing.T) {
 
 func TestProjectSbomCommandSuccess(t *testing.T) {
 	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{"name":"acme/shop","version":"1.2.3"}`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
+	testhelper.WriteFile(t, filepath.Join(root, "composer.json"),
+		testhelper.ComposerJSON{Name: "acme/shop", Version: "1.2.3"}.String())
+	testhelper.WriteFile(t, filepath.Join(root, "composer.lock"), `{
 		"packages":[{"name":"symfony/console","version":"v6.3.0","type":"library","license":["MIT"]}],
 		"packages-dev":[]
-	}`), 0o644))
+	}`)
 
 	out := filepath.Join(root, "from-cmd.json")
 	require.NoError(t, projectSbomCmd.Flags().Set("format", shop.ProjectSBOMFormatCycloneDXJSON))

--- a/cmd/project/project_upgrade_check_test.go
+++ b/cmd/project/project_upgrade_check_test.go
@@ -1,41 +1,24 @@
 package project
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
-func writeUpgradeCheckPlugin(t *testing.T, root, name, composerJSON string) {
-	t.Helper()
-	dir := filepath.Join(root, "custom", "plugins", name)
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composerJSON), 0o644))
-}
-
 func TestGetLocalExtensionsReadsComposerLockAndCustomPlugins(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("PROJECT_ROOT", root)
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"),
-		[]byte(`{"packages":[{"name":"shopware/core","version":"v6.6.5.0"}]}`), 0o644))
+	p := testhelper.NewProject(t)
+	t.Setenv("PROJECT_ROOT", p.Root)
+	p.File("composer.lock", testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.5.0"},
+	))
 
-	writeUpgradeCheckPlugin(t, root, "FroshTest", `{
-		"name": "frosh/frosh-test",
-		"type": "shopware-platform-plugin",
-		"version": "1.2.0",
-		"require": { "shopware/core": "~6.6.0" },
-		"extra": { "shopware-plugin-class": "FroshTest\\FroshTest" }
-	}`)
+	p.CustomPlugin("FroshTest", testhelper.PluginComposer("frosh/frosh-test", "1.2.0", `FroshTest\FroshTest`))
 	// A plugin without a parseable version falls back to 1.0.0.
-	writeUpgradeCheckPlugin(t, root, "NoVersion", `{
-		"name": "frosh/no-version",
-		"type": "shopware-platform-plugin",
-		"require": { "shopware/core": "~6.6.0" },
-		"extra": { "shopware-plugin-class": "NoVersion\\NoVersion" }
-	}`)
+	p.CustomPlugin("NoVersion", testhelper.PluginComposer("frosh/no-version", "", `NoVersion\NoVersion`))
 
 	coreVersion, extensions, err := getLocalExtensions()
 	require.NoError(t, err)
@@ -55,10 +38,11 @@ func TestGetLocalExtensionsErrorsWhenCoreMissing(t *testing.T) {
 	})
 
 	t.Run("core not in the lock file", func(t *testing.T) {
-		root := t.TempDir()
-		t.Setenv("PROJECT_ROOT", root)
-		require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"),
-			[]byte(`{"packages":[{"name":"vendor/other","version":"1.0.0"}]}`), 0o644))
+		p := testhelper.NewProject(t)
+		t.Setenv("PROJECT_ROOT", p.Root)
+		p.File("composer.lock", testhelper.ComposerLock(
+			testhelper.LockPackage{Name: "vendor/other", Version: "1.0.0"},
+		))
 
 		_, _, err := getLocalExtensions()
 		require.Error(t, err)

--- a/internal/executor/database_test.go
+++ b/internal/executor/database_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestDatabaseConnectionDefaults(t *testing.T) {
@@ -27,7 +29,7 @@ func TestDatabaseConnectionFromEnvFile(t *testing.T) {
 	t.Setenv("DATABASE_URL", "")
 
 	projectRoot := t.TempDir()
-	writeFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://app:secret@db.example.com:3307/shop?sslmode=disable\n")
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://app:secret@db.example.com:3307/shop?sslmode=disable\n")
 
 	conn, err := databaseConnectionFromEnv(projectRoot, nil)
 	require.NoError(t, err)
@@ -43,8 +45,8 @@ func TestDatabaseConnectionEnvLocalOverridesEnv(t *testing.T) {
 	t.Setenv("DATABASE_URL", "")
 
 	projectRoot := t.TempDir()
-	writeFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://a:a@one/first\n")
-	writeFile(t, filepath.Join(projectRoot, ".env.local"), "DATABASE_URL=mysql://b:b@two/second\n")
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://a:a@one/first\n")
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env.local"), "DATABASE_URL=mysql://b:b@two/second\n")
 
 	conn, err := databaseConnectionFromEnv(projectRoot, nil)
 	require.NoError(t, err)
@@ -57,7 +59,7 @@ func TestDatabaseConnectionRealEnvWinsOverFile(t *testing.T) {
 	t.Setenv("DATABASE_URL", "mysql://real:env@realhost/realdb")
 
 	projectRoot := t.TempDir()
-	writeFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://file:file@filehost/filedb\n")
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://file:file@filehost/filedb\n")
 
 	conn, err := databaseConnectionFromEnv(projectRoot, nil)
 	require.NoError(t, err)
@@ -177,7 +179,7 @@ func TestLocalExecutorDatabaseConnection(t *testing.T) {
 	t.Setenv("DATABASE_URL", "")
 
 	projectRoot := t.TempDir()
-	writeFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://shopware:shopware@127.0.0.1:13306/dev\n")
+	testhelper.WriteFile(t, filepath.Join(projectRoot, ".env"), "DATABASE_URL=mysql://shopware:shopware@127.0.0.1:13306/dev\n")
 
 	exec := &LocalExecutor{projectRoot: projectRoot}
 
@@ -187,12 +189,4 @@ func TestLocalExecutorDatabaseConnection(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:13306", conn.Addr())
 	assert.Equal(t, "shopware", conn.Username)
 	assert.Equal(t, "dev", conn.Database)
-}
-
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/internal/extension/app_test.go
+++ b/internal/extension/app_test.go
@@ -7,120 +7,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
-const testAppManifest = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-</manifest>`
+// testAppManifestWith builds a variant of the complete MyExampleApp manifest.
+func testAppManifestWith(mutate func(*testhelper.AppManifest)) testhelper.AppManifest {
+	m := testhelper.NewAppManifest("MyExampleApp")
+	mutate(&m)
+	return m
+}
 
-const testAppManifestMissingLicense = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-	</meta>
-</manifest>`
-
-const testAppManifestMissingCopyright = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<author>Your Company Ltd.</author>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-</manifest>`
-
-const testAppManifestMissingAuthor = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-</manifest>`
-
-const testAppManifestCompatibility = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<compatibility>~6.5.0</compatibility>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-</manifest>`
-
-const testAppManifestIcon = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-		<icon>app.png</icon>
-	</meta>
-</manifest>`
-
-const testAppManifestSetup = `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-	<meta>
-		<name>MyExampleApp</name>
-		<label>Label</label>
-		<label lang="de-DE">Name</label>
-		<description>A description</description>
-		<description lang="de-DE">Eine Beschreibung</description>
-		<compatibility>~6.5.0</compatibility>
-		<author>Your Company Ltd.</author>
-		<copyright>(c) by Your Company Ltd.</copyright>
-		<version>1.0.0</version>
-		<license>MIT</license>
-	</meta>
-	<setup>
-		<secret>foo</secret>
-	</setup>
-</manifest>`
+var (
+	testAppManifest                 = testhelper.NewAppManifest("MyExampleApp")
+	testAppManifestMissingLicense   = testAppManifestWith(func(m *testhelper.AppManifest) { m.License = "" })
+	testAppManifestMissingCopyright = testAppManifestWith(func(m *testhelper.AppManifest) { m.Copyright = "" })
+	testAppManifestMissingAuthor    = testAppManifestWith(func(m *testhelper.AppManifest) { m.Author = "" })
+	testAppManifestCompatibility    = testAppManifestWith(func(m *testhelper.AppManifest) { m.Compatibility = "~6.5.0" })
+	testAppManifestIcon             = testAppManifestWith(func(m *testhelper.AppManifest) { m.Icon = "app.png" })
+	testAppManifestSetup            = testAppManifestWith(func(m *testhelper.AppManifest) {
+		m.Compatibility = "~6.5.0"
+		m.SetupSecret = "foo"
+	})
+)
 
 func TestIconNotExists(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifest)
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -137,9 +49,7 @@ func TestIconNotExists(t *testing.T) {
 }
 
 func TestAppNoLicense(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingLicense), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestMissingLicense)
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
@@ -155,9 +65,7 @@ func TestAppNoLicense(t *testing.T) {
 }
 
 func TestAppNoCopyright(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingCopyright), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestMissingCopyright)
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
@@ -173,9 +81,7 @@ func TestAppNoCopyright(t *testing.T) {
 }
 
 func TestAppNoAuthor(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingAuthor), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestMissingAuthor)
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
@@ -191,9 +97,7 @@ func TestAppNoAuthor(t *testing.T) {
 }
 
 func TestAppHasSecret(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestSetup), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestSetup)
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
@@ -209,12 +113,10 @@ func TestAppHasSecret(t *testing.T) {
 }
 
 func TestIconExistsDefaultsPath(t *testing.T) {
-	appPath := t.TempDir()
+	appPath := testhelper.AppDir(t, testAppManifest)
 
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -230,9 +132,7 @@ func TestIconExistsDefaultsPath(t *testing.T) {
 }
 
 func TestIconExistsDifferentPath(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestIcon), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestIcon)
 	assert.NoError(t, createTestImageWithSize(filepath.Join(appPath, "app.png"), 120, 120))
 
 	app, err := newApp(t.Context(), appPath)
@@ -249,9 +149,7 @@ func TestIconExistsDifferentPath(t *testing.T) {
 }
 
 func TestNoCompatibilityGiven(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifest)
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -264,9 +162,7 @@ func TestNoCompatibilityGiven(t *testing.T) {
 }
 
 func TestCompatibilityGiven(t *testing.T) {
-	appPath := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestCompatibility), 0o644))
+	appPath := testhelper.AppDir(t, testAppManifestCompatibility)
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -279,11 +175,9 @@ func TestCompatibilityGiven(t *testing.T) {
 }
 
 func TestAppWithPHPFiles(t *testing.T) {
-	appPath := t.TempDir()
+	appPath := testhelper.AppDir(t, testAppManifest)
 
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
-
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.php"), []byte("<?php echo 'Hello World';"), 0o644))
 
@@ -303,12 +197,11 @@ func TestAppWithTwigFiles(t *testing.T) {
 		t.Skip("skipping test on windows")
 	}
 
-	appPath := t.TempDir()
+	appPath := testhelper.AppDir(t, testAppManifest)
 
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/views/"), 0o755))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.twig"), []byte("<?php echo 'Hello World';"), 0o644))
 	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "Resources/views/test.twig"), []byte("<?php echo 'Hello World';"), 0o644))

--- a/internal/extension/bundle_test.go
+++ b/internal/extension/bundle_test.go
@@ -1,11 +1,12 @@
 package extension
 
 import (
-	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestCreateBundleEmptyFolder(t *testing.T) {
@@ -17,15 +18,10 @@ func TestCreateBundleEmptyFolder(t *testing.T) {
 }
 
 func TestCreateBundleInvalidComposerType(t *testing.T) {
-	dir := t.TempDir()
-
-	// Create composer.json
-	composer := []byte(`{
-		"name": "shopware/invalid",
-		"type": "invalid"
-	}
-	`)
-	_ = os.WriteFile(path.Join(dir, "composer.json"), composer, 0o644)
+	dir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name: "shopware/invalid",
+		Type: "invalid",
+	})
 
 	bundle, err := newShopwareBundle(t.Context(), dir)
 	assert.Error(t, err)
@@ -34,15 +30,10 @@ func TestCreateBundleInvalidComposerType(t *testing.T) {
 }
 
 func TestCreateBundleMissingName(t *testing.T) {
-	dir := t.TempDir()
-
-	// Create composer.json
-	composer := []byte(`{
-		"name": "shopware/invalid",
-		"type": "shopware-bundle"
-	}
-	`)
-	_ = os.WriteFile(path.Join(dir, "composer.json"), composer, 0o644)
+	dir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name: "shopware/invalid",
+		Type: "shopware-bundle",
+	})
 
 	bundle, err := newShopwareBundle(t.Context(), dir)
 	assert.Error(t, err)
@@ -51,24 +42,13 @@ func TestCreateBundleMissingName(t *testing.T) {
 }
 
 func TestCreateBundle(t *testing.T) {
-	dir := t.TempDir()
-
-	// Create composer.json
-	composer := []byte(`{
-		"name": "shopware/invalid",
-		"version": "1.0.0",
-		"type": "shopware-bundle",
-		"extra": {
-			"shopware-bundle-name": "TestBundle"
-		},
-		"autoload": {
-			"psr-4": {
-				"TestBundle\\": "src/"
-			}
-		}
-	}
-	`)
-	_ = os.WriteFile(path.Join(dir, "composer.json"), composer, 0o644)
+	dir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name:    "shopware/invalid",
+		Version: "1.0.0",
+		Type:    "shopware-bundle",
+		Extra:   map[string]any{"shopware-bundle-name": "TestBundle"},
+		Psr4:    map[string]string{`TestBundle\`: "src/"},
+	})
 
 	bundle, err := newShopwareBundle(t.Context(), dir)
 	assert.NoError(t, err)

--- a/internal/extension/checksum_test.go
+++ b/internal/extension/checksum_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestGenerateChecksumJSONOverwritesExistingChecksum(t *testing.T) {
-	extensionDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "composer.json"), []byte(`{"name":"test/test-ext","version":"1.0.0"}`), 0o644))
-	require.NoError(t, os.MkdirAll(filepath.Join(extensionDir, "src", "Resources"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "src", "Resources", "changed.js"), []byte("before"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "src", "Resources", "removed.js"), []byte("removed"), 0o644))
+	extensionDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{Name: "test/test-ext", Version: "1.0.0"})
+	testhelper.WriteFile(t, filepath.Join(extensionDir, "src", "Resources", "changed.js"), "before")
+	testhelper.WriteFile(t, filepath.Join(extensionDir, "src", "Resources", "removed.js"), "removed")
 
 	mockExt := &mockExtension{
 		name:       "TestExt",

--- a/internal/extension/cleanup_test.go
+++ b/internal/extension/cleanup_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestCleanupExtensionFolder_RemovesDefaultNotAllowedPaths(t *testing.T) {
@@ -25,16 +27,15 @@ func TestCleanupExtensionFolder_RemovesDefaultNotAllowedPaths(t *testing.T) {
 	for _, p := range pathsToCreate {
 		fullPath := filepath.Join(tmpDir, p)
 		if filepath.Ext(p) == "" && !contains([]string{"phpstan.neon", "Makefile"}, p) {
-			require.NoError(t, os.MkdirAll(fullPath, 0755))
 			// Add a file inside directories
-			require.NoError(t, os.WriteFile(filepath.Join(fullPath, "test.txt"), []byte("test"), 0644))
+			testhelper.WriteFile(t, filepath.Join(fullPath, "test.txt"), "test")
 		} else {
-			require.NoError(t, os.WriteFile(fullPath, []byte("test"), 0644))
+			testhelper.WriteFile(t, fullPath, "test")
 		}
 	}
 
 	// Create a file that should remain
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte("{}"), 0644))
+	testhelper.WriteFile(t, filepath.Join(tmpDir, "composer.json"), "{}")
 
 	err := CleanupExtensionFolder(tmpDir, nil)
 	require.NoError(t, err)
@@ -53,9 +54,7 @@ func TestCleanupExtensionFolder_RemovesDefaultNotAllowedPaths(t *testing.T) {
 func TestCleanupExtensionFolder_RemovesNotAllowedFilesInSubdirectories(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create subdirectory structure
 	subDir := filepath.Join(tmpDir, "src", "Resources")
-	require.NoError(t, os.MkdirAll(subDir, 0755))
 
 	// Create not-allowed files in subdirectories
 	notAllowedFiles := []string{
@@ -67,11 +66,11 @@ func TestCleanupExtensionFolder_RemovesNotAllowedFilesInSubdirectories(t *testin
 	}
 
 	for _, f := range notAllowedFiles {
-		require.NoError(t, os.WriteFile(f, []byte("test"), 0644))
+		testhelper.WriteFile(t, f, "test")
 	}
 
 	// Create a file that should remain
-	require.NoError(t, os.WriteFile(filepath.Join(subDir, "index.js"), []byte("test"), 0644))
+	testhelper.WriteFile(t, filepath.Join(subDir, "index.js"), "test")
 
 	err := CleanupExtensionFolder(tmpDir, nil)
 	require.NoError(t, err)
@@ -99,11 +98,11 @@ func TestCleanupExtensionFolder_RemovesNotAllowedExtensions(t *testing.T) {
 	}
 
 	for _, f := range notAllowedExtFiles {
-		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, f), []byte("test"), 0644))
+		testhelper.WriteFile(t, filepath.Join(tmpDir, f), "test")
 	}
 
 	// Create a file that should remain
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.js"), []byte("test"), 0644))
+	testhelper.WriteFile(t, filepath.Join(tmpDir, "main.js"), "test")
 
 	err := CleanupExtensionFolder(tmpDir, nil)
 	require.NoError(t, err)
@@ -129,13 +128,11 @@ func TestCleanupExtensionFolder_WithAdditionalPaths(t *testing.T) {
 	}
 
 	for _, p := range customPaths {
-		fullPath := filepath.Join(tmpDir, p)
-		require.NoError(t, os.MkdirAll(fullPath, 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(fullPath, "file.txt"), []byte("test"), 0644))
+		testhelper.WriteFile(t, filepath.Join(tmpDir, p, "file.txt"), "test")
 	}
 
 	// Create a file that should remain
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "src.js"), []byte("test"), 0644))
+	testhelper.WriteFile(t, filepath.Join(tmpDir, "src.js"), "test")
 
 	err := CleanupExtensionFolder(tmpDir, customPaths)
 	require.NoError(t, err)
@@ -176,8 +173,7 @@ func TestCleanupExtensionFolder_NestedNodeModules(t *testing.T) {
 
 	// Create nested node_modules that matches default path
 	nestedPath := filepath.Join(tmpDir, "src", "Resources", "app", "administration", "node_modules")
-	require.NoError(t, os.MkdirAll(nestedPath, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(nestedPath, "package.json"), []byte("{}"), 0644))
+	testhelper.WriteFile(t, filepath.Join(nestedPath, "package.json"), "{}")
 
 	err := CleanupExtensionFolder(tmpDir, nil)
 	require.NoError(t, err)

--- a/internal/extension/project_test.go
+++ b/internal/extension/project_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestGetShopwareProjectConstraintComposerJson(t *testing.T) {
@@ -130,14 +131,7 @@ final public const SHOPWARE_FALLBACK_VERSION = '6.6.9999999.9999999-dev';
 			tmpDir := t.TempDir()
 
 			for file, content := range tc.Files {
-				tmpFile := filepath.Join(tmpDir, file)
-				parentDir := filepath.Dir(tmpFile)
-
-				if _, err := os.Stat(parentDir); os.IsNotExist(err) {
-					assert.NoError(t, os.MkdirAll(parentDir, 0o755))
-				}
-
-				assert.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+				testhelper.WriteFile(t, filepath.Join(tmpDir, file), content)
 			}
 
 			constraint, err := GetShopwareProjectConstraint(tmpDir)
@@ -156,10 +150,10 @@ final public const SHOPWARE_FALLBACK_VERSION = '6.6.9999999.9999999-dev';
 }
 
 func TestFindAssetSourcesOfProjectYAMLBundles(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	// Minimal composer.json without extra bundles
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{"require": {"shopware/core": "~6.6.0"}}`), 0o644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Require: map[string]string{"shopware/core": "~6.6.0"},
+	})
 
 	// Create the bundle directory
 	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
@@ -189,9 +183,9 @@ func TestFindAssetSourcesOfProjectYAMLBundles(t *testing.T) {
 }
 
 func TestFindAssetSourcesOfProjectYAMLBundleNameOverride(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{"require": {"shopware/core": "~6.6.0"}}`), 0o644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Require: map[string]string{"shopware/core": "~6.6.0"},
+	})
 	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	shopCfg := &shop.Config{
@@ -214,13 +208,11 @@ func TestFindAssetSourcesOfProjectYAMLBundleNameOverride(t *testing.T) {
 }
 
 func TestFindAssetSourcesOfProjectYAMLBundleDeduplication(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	// composer.json declares the same bundle path
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-bundles": {"src/MyBundle": {"name": "MyBundle"}}}
-	}`), 0o644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Require: map[string]string{"shopware/core": "~6.6.0"},
+		Extra:   map[string]any{"shopware-bundles": map[string]any{"src/MyBundle": map[string]string{"name": "MyBundle"}}},
+	})
 	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	shopCfg := &shop.Config{

--- a/internal/extension/root_test.go
+++ b/internal/extension/root_test.go
@@ -8,25 +8,12 @@ import (
 	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestGetExtensionByFolder_DetectsApp(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create manifest.xml for an App
-	manifestContent := `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        <name>TestApp</name>
-        <label>Test App</label>
-        <description>A test app</description>
-        <author>Test Author</author>
-        <copyright>(c) Test</copyright>
-        <version>1.0.0</version>
-        <license>MIT</license>
-    </meta>
-</manifest>`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "manifest.xml"), []byte(manifestContent), 0644))
+	tmpDir := testhelper.NewApp(t, "TestApp")
 
 	ext, err := GetExtensionByFolder(t.Context(), tmpDir)
 	require.NoError(t, err)
@@ -38,45 +25,24 @@ func TestGetExtensionByFolder_DetectsApp(t *testing.T) {
 }
 
 func TestGetExtensionByFolder_DetectsPlatformPlugin(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	// Create composer.json for a PlatformPlugin
-	composerContent := `{
-    "name": "test/test-plugin",
-    "type": "shopware-platform-plugin",
-    "version": "1.0.0",
-    "license": "MIT",
-    "description": "Test plugin",
-    "authors": [{"name": "Test"}],
-    "require": {
-        "shopware/core": "~6.5.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Test\\TestPlugin\\": "src/"
-        }
-    },
-    "extra": {
-        "shopware-plugin-class": "Test\\TestPlugin\\TestPlugin",
-        "label": {
-            "de-DE": "Test Plugin",
-            "en-GB": "Test Plugin"
-        },
-        "description": {
-            "de-DE": "Ein Test Plugin",
-            "en-GB": "A test plugin"
-        },
-        "manufacturerLink": {
-            "de-DE": "https://example.com",
-            "en-GB": "https://example.com"
-        },
-        "supportLink": {
-            "de-DE": "https://example.com/support",
-            "en-GB": "https://example.com/support"
-        }
-    }
-}`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(composerContent), 0644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name:        "test/test-plugin",
+		Type:        "shopware-platform-plugin",
+		Version:     "1.0.0",
+		License:     "MIT",
+		Description: "Test plugin",
+		Authors:     []string{"Test"},
+		Require:     map[string]string{"shopware/core": "~6.5.0"},
+		Psr4:        map[string]string{`Test\TestPlugin\`: "src/"},
+		PluginClass: `Test\TestPlugin\TestPlugin`,
+		Label:       map[string]string{"de-DE": "Test Plugin", "en-GB": "Test Plugin"},
+		Extra: map[string]any{
+			"description":      map[string]string{"de-DE": "Ein Test Plugin", "en-GB": "A test plugin"},
+			"manufacturerLink": map[string]string{"de-DE": "https://example.com", "en-GB": "https://example.com"},
+			"supportLink":      map[string]string{"de-DE": "https://example.com/support", "en-GB": "https://example.com/support"},
+		},
+	})
 
 	ext, err := GetExtensionByFolder(t.Context(), tmpDir)
 	require.NoError(t, err)
@@ -88,27 +54,16 @@ func TestGetExtensionByFolder_DetectsPlatformPlugin(t *testing.T) {
 }
 
 func TestGetExtensionByFolder_DetectsShopwareBundle(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	// Create composer.json for a ShopwareBundle
-	composerContent := `{
-    "name": "test/test-bundle",
-    "type": "shopware-bundle",
-    "version": "1.0.0",
-    "license": "MIT",
-    "require": {
-        "shopware/core": "~6.5.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Test\\TestBundle\\": "src/"
-        }
-    },
-    "extra": {
-        "shopware-bundle-name": "TestBundle"
-    }
-}`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(composerContent), 0644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name:    "test/test-bundle",
+		Type:    "shopware-bundle",
+		Version: "1.0.0",
+		License: "MIT",
+		Require: map[string]string{"shopware/core": "~6.5.0"},
+		Psr4:    map[string]string{`Test\TestBundle\`: "src/"},
+		Extra:   map[string]any{"shopware-bundle-name": "TestBundle"},
+	})
 
 	ext, err := GetExtensionByFolder(t.Context(), tmpDir)
 	require.NoError(t, err)
@@ -140,29 +95,14 @@ func TestGetExtensionByFolder_RejectsUnknownType(t *testing.T) {
 }
 
 func TestGetExtensionByFolder_PrefersManifestOverComposer(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	// Create both manifest.xml and composer.json
-	manifestContent := `<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        <name>TestApp</name>
-        <label>Test App</label>
-        <description>A test app</description>
-        <author>Test Author</author>
-        <copyright>(c) Test</copyright>
-        <version>1.0.0</version>
-        <license>MIT</license>
-    </meta>
-</manifest>`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "manifest.xml"), []byte(manifestContent), 0644))
+	tmpDir := testhelper.NewApp(t, "TestApp")
 
-	composerContent := `{
-    "name": "test/test-plugin",
-    "type": "shopware-platform-plugin",
-    "version": "1.0.0"
-}`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(composerContent), 0644))
+	testhelper.WriteFile(t, filepath.Join(tmpDir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "test/test-plugin",
+		Type:    "shopware-platform-plugin",
+		Version: "1.0.0",
+	}.String())
 
 	ext, err := GetExtensionByFolder(t.Context(), tmpDir)
 	require.NoError(t, err)
@@ -171,36 +111,21 @@ func TestGetExtensionByFolder_PrefersManifestOverComposer(t *testing.T) {
 }
 
 func TestUpdateMetaData_PlatformPlugin(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	composerContent := `{
-  "name": "test/test-plugin",
-  "type": "shopware-platform-plugin",
-  "version": "1.0.0",
-  "license": "MIT",
-  "description": "Test plugin",
-  "authors": [{"name": "Test"}],
-  "require": {
-    "shopware/core": "~6.5.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Test\\TestPlugin\\": "src/"
-    }
-  },
-  "extra": {
-    "shopware-plugin-class": "Test\\TestPlugin\\TestPlugin",
-    "label": {
-      "de-DE": "Altes Label DE",
-      "en-GB": "Old Label EN"
-    },
-    "description": {
-      "de-DE": "Alte Beschreibung",
-      "en-GB": "Old description"
-    }
-  }
-}`
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(composerContent), 0644))
+	tmpDir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name:        "test/test-plugin",
+		Type:        "shopware-platform-plugin",
+		Version:     "1.0.0",
+		License:     "MIT",
+		Description: "Test plugin",
+		Authors:     []string{"Test"},
+		Require:     map[string]string{"shopware/core": "~6.5.0"},
+		Psr4:        map[string]string{`Test\TestPlugin\`: "src/"},
+		PluginClass: `Test\TestPlugin\TestPlugin`,
+		Label:       map[string]string{"de-DE": "Altes Label DE", "en-GB": "Old Label EN"},
+		Extra: map[string]any{
+			"description": map[string]string{"de-DE": "Alte Beschreibung", "en-GB": "Old description"},
+		},
+	})
 
 	ext, err := GetExtensionByFolder(t.Context(), tmpDir)
 	require.NoError(t, err)

--- a/internal/flexmigrator/cleanup_test.go
+++ b/internal/flexmigrator/cleanup_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestCleanup(t *testing.T) {
@@ -27,19 +29,14 @@ func TestCleanup(t *testing.T) {
 		}
 
 		for _, file := range filesToCreate {
-			fullPath := filepath.Join(tempDir, file)
-			err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
-			require.NoError(t, err)
-			err = os.WriteFile(fullPath, []byte("test content"), 0o644)
-			require.NoError(t, err)
+			testhelper.WriteFile(t, filepath.Join(tempDir, file), "test content")
 		}
 
 		// Create a file that should not be removed
-		err := os.WriteFile(filepath.Join(tempDir, "keep-me.txt"), []byte("keep this file"), 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(tempDir, "keep-me.txt"), "keep this file")
 
 		// Run cleanup
-		err = Cleanup(tempDir)
+		err := Cleanup(tempDir)
 		require.NoError(t, err)
 
 		// Verify files were removed
@@ -67,23 +64,16 @@ func TestCleanup(t *testing.T) {
 		}
 
 		for _, dir := range dirsToCreate {
-			fullPath := filepath.Join(tempDir, dir)
-			err := os.MkdirAll(fullPath, 0o755)
-			require.NoError(t, err)
 			// Add a file in each directory
-			err = os.WriteFile(filepath.Join(fullPath, "test.txt"), []byte("test content"), 0o644)
-			require.NoError(t, err)
+			testhelper.WriteFile(t, filepath.Join(tempDir, dir, "test.txt"), "test content")
 		}
 
 		// Create a directory that should not be removed
 		keepDir := filepath.Join(tempDir, "keep-me")
-		err := os.MkdirAll(keepDir, 0o755)
-		require.NoError(t, err)
-		err = os.WriteFile(filepath.Join(keepDir, "test.txt"), []byte("keep this file"), 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(keepDir, "test.txt"), "keep this file")
 
 		// Run cleanup
-		err = Cleanup(tempDir)
+		err := Cleanup(tempDir)
 		require.NoError(t, err)
 
 		// Verify directories were removed
@@ -126,11 +116,7 @@ func TestCleanup(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			fullPath := filepath.Join(tempDir, tc.path)
-			err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
-			require.NoError(t, err)
-			err = os.WriteFile(fullPath, tc.content, 0o644)
-			require.NoError(t, err)
+			testhelper.WriteFile(t, filepath.Join(tempDir, tc.path), string(tc.content))
 
 			if tc.remove {
 				// Verify the MD5 matches what we expect
@@ -173,13 +159,10 @@ func TestCleanup(t *testing.T) {
 		// Create a file that's in cleanupByMd5 but with different content
 		filePath := "config/packages/shopware.yaml"
 		fullPath := filepath.Join(tempDir, filePath)
-		err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
-		require.NoError(t, err)
-		err = os.WriteFile(fullPath, []byte("custom content that doesn't match MD5"), 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, fullPath, "custom content that doesn't match MD5")
 
 		// Run cleanup
-		err = Cleanup(tempDir)
+		err := Cleanup(tempDir)
 		require.NoError(t, err)
 
 		// Verify file still exists

--- a/internal/flexmigrator/composer_test.go
+++ b/internal/flexmigrator/composer_test.go
@@ -2,13 +2,14 @@ package flexmigrator
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/shyim/go-composer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestMigrateComposerJson(t *testing.T) {
@@ -44,8 +45,7 @@ func TestMigrateComposerJson(t *testing.T) {
 		composerFile := filepath.Join(tempDir, "composer.json")
 		content, err := json.MarshalIndent(initialComposer, "", "  ")
 		require.NoError(t, err)
-		err = os.WriteFile(composerFile, content, 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, composerFile, string(content))
 
 		// Run the migration
 		err = MigrateComposerJson(tempDir)
@@ -132,7 +132,7 @@ func TestMigrateComposerJson(t *testing.T) {
 		composerFile := filepath.Join(tempDir, "composer.json")
 		content, err := json.MarshalIndent(initialComposer, "", "  ")
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(composerFile, content, 0o644))
+		testhelper.WriteFile(t, composerFile, string(content))
 
 		require.NoError(t, MigrateComposerJson(tempDir))
 
@@ -159,10 +159,9 @@ func TestMigrateComposerJson(t *testing.T) {
 		t.Parallel()
 		tempDir := t.TempDir()
 		composerFile := filepath.Join(tempDir, "composer.json")
-		err := os.WriteFile(composerFile, []byte("invalid json"), 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, composerFile, "invalid json")
 
-		err = MigrateComposerJson(tempDir)
+		err := MigrateComposerJson(tempDir)
 		assert.Error(t, err)
 	})
 }

--- a/internal/flexmigrator/env_test.go
+++ b/internal/flexmigrator/env_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestMigrateEnv(t *testing.T) {
@@ -18,11 +20,10 @@ func TestMigrateEnv(t *testing.T) {
 
 		// Create a test .env file
 		envContent := []byte("APP_ENV=dev\nAPP_SECRET=test")
-		err := os.WriteFile(filepath.Join(tempDir, ".env"), envContent, 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(tempDir, ".env"), string(envContent))
 
 		// Run the migration
-		err = MigrateEnv(tempDir)
+		err := MigrateEnv(tempDir)
 		require.NoError(t, err)
 
 		// Verify .env.local exists with original content
@@ -41,10 +42,9 @@ func TestMigrateEnv(t *testing.T) {
 		tempDir := t.TempDir()
 
 		envContent := []byte("APP_ENV=dev\nCOMPOSE_PROJECT_NAME=sw-shop-abcdef\nAPP_SECRET=test\n")
-		err := os.WriteFile(filepath.Join(tempDir, ".env"), envContent, 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(tempDir, ".env"), string(envContent))
 
-		err = MigrateEnv(tempDir)
+		err := MigrateEnv(tempDir)
 		require.NoError(t, err)
 
 		envLocalContent, err := os.ReadFile(filepath.Join(tempDir, ".env.local"))
@@ -65,13 +65,11 @@ func TestMigrateEnv(t *testing.T) {
 		envContent := []byte("APP_ENV=dev\nAPP_SECRET=test")
 		envLocalContent := []byte("APP_ENV=local\nAPP_SECRET=local")
 
-		err := os.WriteFile(filepath.Join(tempDir, ".env"), envContent, 0o644)
-		require.NoError(t, err)
-		err = os.WriteFile(filepath.Join(tempDir, ".env.local"), envLocalContent, 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(tempDir, ".env"), string(envContent))
+		testhelper.WriteFile(t, filepath.Join(tempDir, ".env.local"), string(envLocalContent))
 
 		// Run the migration
-		err = MigrateEnv(tempDir)
+		err := MigrateEnv(tempDir)
 		require.NoError(t, err)
 
 		// Verify both files still exist with original content
@@ -107,11 +105,10 @@ func TestMigrateEnv(t *testing.T) {
 
 		// Create only .env.local file
 		envLocalContent := []byte("APP_ENV=local\nAPP_SECRET=local")
-		err := os.WriteFile(filepath.Join(tempDir, ".env.local"), envLocalContent, 0o644)
-		require.NoError(t, err)
+		testhelper.WriteFile(t, filepath.Join(tempDir, ".env.local"), string(envLocalContent))
 
 		// Run the migration
-		err = MigrateEnv(tempDir)
+		err := MigrateEnv(tempDir)
 		require.NoError(t, err)
 
 		// Verify .env.local still exists with original content

--- a/internal/shop/composer_scripts_test.go
+++ b/internal/shop/composer_scripts_test.go
@@ -1,12 +1,13 @@
 package shop
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestGetComposerScripts(t *testing.T) {
@@ -76,5 +77,5 @@ func TestFindComposerScript(t *testing.T) {
 
 func writeComposerJSON(t *testing.T, dir, contents string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(contents), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), contents)
 }

--- a/internal/shop/pluginmigrate/pluginmigrate_test.go
+++ b/internal/shop/pluginmigrate/pluginmigrate_test.go
@@ -18,6 +18,7 @@ import (
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 // fakeExecutor satisfies executor.Executor and lets each test decide which
@@ -62,52 +63,22 @@ func (f *fakeExecutor) AdminAPIClient(context.Context) (*adminSdk.Client, error)
 }
 func (f *fakeExecutor) ShopConfig() *shop.Config { return nil }
 
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-}
-
 // setupProject creates a project with one Store plugin and one local plugin
 // in custom/plugins, plus a vendor extension Composer already manages.
 func setupProject(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
 
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {"shopware/core": "6.6.10.3"}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{"packages": [], "packages-dev": []}`)
+	p := testhelper.NewProject(t).
+		File("composer.json", testhelper.ComposerJSON{
+			Name:    "shopware/production",
+			Require: map[string]string{"shopware/core": "6.6.10.3"},
+		}.String()).
+		File("composer.lock", testhelper.ComposerLock()).
+		VendorPackage("swag/demo", testhelper.PluginComposer("swag/demo", "2.0.0", `Swag\Demo\Demo`)).
+		CustomPlugin("StorePlugin", testhelper.PluginComposer("swag/store-plugin", "3.1.0", `Swag\StorePlugin\StorePlugin`)).
+		CustomPlugin("LocalPlugin", testhelper.PluginComposer("acme/local-plugin", "1.0.0", `Acme\LocalPlugin\LocalPlugin`))
 
-	writeFile(t, filepath.Join(dir, "vendor", "swag", "demo", "composer.json"), `{
-		"name": "swag/demo",
-		"type": "shopware-platform-plugin",
-		"version": "2.0.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Swag\\Demo\\Demo", "label": {"en-GB": "Demo"}},
-		"autoload": {"psr-4": {"Swag\\Demo\\": "src/"}}
-	}`)
-
-	writeFile(t, filepath.Join(dir, "custom", "plugins", "StorePlugin", "composer.json"), `{
-		"name": "swag/store-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "3.1.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Swag\\StorePlugin\\StorePlugin", "label": {"en-GB": "Store"}},
-		"autoload": {"psr-4": {"Swag\\StorePlugin\\": "src/"}}
-	}`)
-
-	writeFile(t, filepath.Join(dir, "custom", "plugins", "LocalPlugin", "composer.json"), `{
-		"name": "acme/local-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Acme\\LocalPlugin\\LocalPlugin", "label": {"en-GB": "Local"}},
-		"autoload": {"psr-4": {"Acme\\LocalPlugin\\": "src/"}}
-	}`)
-
-	return dir
+	return p.Root
 }
 
 func trueExecutor() *fakeExecutor {
@@ -301,7 +272,7 @@ func TestFetchPublishedVersionsUsesConfiguredRepository(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), `{
 		"require": {"shopware/core": "6.6.10.3"},
 		"repositories": [{"type": "composer", "url": "`+srv.URL+`"}]
 	}`)
@@ -379,7 +350,7 @@ func TestRunPluginRefreshFailureIsNonFatal(t *testing.T) {
 
 func TestBackupRestrictsSensitiveFilePermissions(t *testing.T) {
 	dir := setupProject(t)
-	writeFile(t, filepath.Join(dir, "auth.json"), `{"bearer": {"packages.shopware.com": "secret"}}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "auth.json"), `{"bearer": {"packages.shopware.com": "secret"}}`)
 	m := NewPluginMigrator(dir, nil)
 	t.Cleanup(func() { _ = os.RemoveAll(m.backupDir()) })
 
@@ -492,15 +463,11 @@ func TestRunHeadlessFailingRequireReportsRestore(t *testing.T) {
 
 func TestRunHeadlessNothingActionable(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{"require": {"shopware/core": "6.6.10.3"}}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"),
+		testhelper.ComposerJSON{Require: map[string]string{"shopware/core": "6.6.10.3"}}.String())
 	// An extension without a composer package name cannot be migrated.
-	writeFile(t, filepath.Join(dir, "custom", "plugins", "Broken", "composer.json"), `{
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Broken\\Broken", "label": {"en-GB": "Broken"}},
-		"autoload": {"psr-4": {"Broken\\": "src/"}}
-	}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "custom", "plugins", "Broken", "composer.json"),
+		testhelper.PluginComposer("", "1.0.0", `Broken\Broken`).String())
 	m := headlessMigrator(dir, trueExecutor(), nil, nil)
 
 	var out bytes.Buffer

--- a/internal/shop/project_sbom_test.go
+++ b/internal/shop/project_sbom_test.go
@@ -8,17 +8,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func writeMinimalComposerProject(t *testing.T, root string) {
 	t.Helper()
 
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{
-		"name": "acme/shop",
-		"version": "1.2.3"
-	}`), 0o644))
+	testhelper.WriteFile(t, filepath.Join(root, "composer.json"),
+		testhelper.ComposerJSON{Name: "acme/shop", Version: "1.2.3"}.String())
 
-	require.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
+	// The SBOM needs license and require metadata per package, which the
+	// shared lock builder does not model.
+	testhelper.WriteFile(t, filepath.Join(root, "composer.lock"), `{
 		"packages": [
 			{
 				"name": "symfony/console",
@@ -31,7 +33,7 @@ func writeMinimalComposerProject(t *testing.T, root string) {
 		"packages-dev": [
 			{"name": "phpunit/phpunit", "version": "10.0.0", "license": ["BSD-3-Clause"]}
 		]
-	}`), 0o644))
+	}`)
 }
 
 func TestWriteProjectSBOM(t *testing.T) {

--- a/internal/shop/upgrade/composerjson_test.go
+++ b/internal/shop/upgrade/composerjson_test.go
@@ -8,21 +8,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestRewriteComposerJSON(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name: "shopware/production",
+		Require: map[string]string{
 			"shopware/administration": "6.6.10.3",
-			"shopware/core": "6.6.10.3",
-			"shopware/storefront": "6.6.10.3",
-			"swag/demo": "^2.0",
-			"symfony/flex": "~2"
-		}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
+			"shopware/core":           "6.6.10.3",
+			"shopware/storefront":     "6.6.10.3",
+			"swag/demo":               "^2.0",
+			"symfony/flex":            "~2",
+		},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
 
 	changes, err := newTestUpgrader(t, dir).RewriteComposerJSON("6.7.11.0", map[string]string{"swag/demo": "2.1.3"})
 	require.NoError(t, err)
@@ -58,8 +60,8 @@ func TestRenderUpgradeManifestLeavesProjectUntouched(t *testing.T) {
 		"name": "shopware/production",
 		"require": {"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*"}
 	}`
-	writeFile(t, filepath.Join(dir, "composer.json"), original)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{"packages": [], "packages-dev": []}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), original)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock())
 
 	manifest, err := newTestUpgrader(t, dir).renderUpgradeManifest("6.7.11.0")
 	require.NoError(t, err)
@@ -77,11 +79,11 @@ func TestRenderUpgradeManifestLeavesProjectUntouched(t *testing.T) {
 
 func TestRewriteComposerJSONWithoutResolvedVersions(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*", "swag/demo": "^2.0"}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "shopware/production",
+		Require: map[string]string{"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*", "swag/demo": "^2.0"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
 
 	changes, err := newTestUpgrader(t, dir).RewriteComposerJSON("6.7.11.0", nil)
 	require.NoError(t, err)
@@ -90,14 +92,11 @@ func TestRewriteComposerJSONWithoutResolvedVersions(t *testing.T) {
 
 func TestRewriteComposerJSONDoesNotMoveRequireDevPackages(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require-dev": {
-			"shopware/core": "6.6.10.3",
-			"swag/demo": "^2.0"
-		}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:       "shopware/production",
+		RequireDev: map[string]string{"shopware/core": "6.6.10.3", "swag/demo": "^2.0"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
 
 	changes, err := newTestUpgrader(t, dir).RewriteComposerJSON("6.7.11.0", map[string]string{"swag/demo": "2.1.3"})
 	require.NoError(t, err)
@@ -124,11 +123,11 @@ func TestLockNameFor(t *testing.T) {
 
 func TestRewriteComposerJSONLeavesAuditConfigUntouched(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*"}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "shopware/production",
+		Require: map[string]string{"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
 
 	u := newTestUpgrader(t, dir)
 	u.DisableAuditBlock()

--- a/internal/shop/upgrade/readiness_test.go
+++ b/internal/shop/upgrade/readiness_test.go
@@ -11,51 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-}
-
-const testComposerLock = `{
-	"packages": [
-		{"name": "shopware/core", "version": "v6.6.10.3"},
-		{"name": "swag/demo", "version": "2.0.0", "type": "shopware-platform-plugin"}
-	],
-	"packages-dev": []
-}`
+var testComposerLock = testhelper.ComposerLock(
+	testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.10.3"},
+	testhelper.LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
+)
 
 func setupProject(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
 
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*", "swag/demo": "^2.0"}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), testComposerLock)
+	p := testhelper.NewProject(t).
+		File("composer.json", testhelper.ComposerJSON{
+			Name:    "shopware/production",
+			Require: map[string]string{"shopware/core": "6.6.10.3", "shopware/deployment-helper": "*", "swag/demo": "^2.0"},
+		}.String()).
+		File("composer.lock", testComposerLock).
+		VendorPackage("swag/demo", testhelper.PluginComposer("swag/demo", "2.0.0", `Swag\Demo\Demo`)).
+		CustomPlugin("LocalPlugin", testhelper.PluginComposer("acme/local-plugin", "1.0.0", `Acme\LocalPlugin\LocalPlugin`))
 
-	writeFile(t, filepath.Join(dir, "vendor", "swag", "demo", "composer.json"), `{
-		"name": "swag/demo",
-		"type": "shopware-platform-plugin",
-		"version": "2.0.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Swag\\Demo\\Demo", "label": {"en-GB": "Demo"}},
-		"autoload": {"psr-4": {"Swag\\Demo\\": "src/"}}
-	}`)
-
-	writeFile(t, filepath.Join(dir, "custom", "plugins", "LocalPlugin", "composer.json"), `{
-		"name": "acme/local-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-plugin-class": "Acme\\LocalPlugin\\LocalPlugin", "label": {"en-GB": "Local"}},
-		"autoload": {"psr-4": {"Acme\\LocalPlugin\\": "src/"}}
-	}`)
-
-	return dir
+	return p.Root
 }
 
 func newTestUpgrader(t *testing.T, dir string) *ProjectUpgrader {
@@ -126,7 +102,7 @@ func TestReadinessAllExtensionsComposerManaged(t *testing.T) {
 
 func TestReadinessMissingComposerLock(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{"require": {}}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), `{"require": {}}`)
 
 	r := newTestUpgrader(t, dir).RunReadinessChecks(t.Context())
 
@@ -139,8 +115,8 @@ func TestReadinessMissingComposerLock(t *testing.T) {
 
 func TestReadinessLockWithoutCore(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "composer.json"), `{"require": {}}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{"packages": [], "packages-dev": []}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), `{"require": {}}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock())
 
 	r := newTestUpgrader(t, dir).RunReadinessChecks(t.Context())
 
@@ -154,7 +130,8 @@ func TestReadinessDeploymentHelperMissing(t *testing.T) {
 	// Drop the local plugin so the extension gate does not block; this test
 	// only cares about the deployment-helper check.
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "custom")))
-	writeFile(t, filepath.Join(dir, "composer.json"), `{"require": {"shopware/core": "6.6.10.3"}}`)
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"),
+		testhelper.ComposerJSON{Require: map[string]string{"shopware/core": "6.6.10.3"}}.String())
 
 	r := newTestUpgrader(t, dir).RunReadinessChecks(t.Context())
 
@@ -197,7 +174,7 @@ func TestCheckGitClean(t *testing.T) {
 	}
 
 	runGit("init")
-	writeFile(t, filepath.Join(dir, "a.txt"), "hello")
+	testhelper.WriteFile(t, filepath.Join(dir, "a.txt"), "hello")
 
 	check = checkGitClean(t.Context(), dir)
 	assert.Equal(t, StateFail, check.State, "untracked file means dirty tree")

--- a/internal/shop/upgrade/resolve_test.go
+++ b/internal/shop/upgrade/resolve_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func writeLocks(t *testing.T) (currentPath, resolvedPath string) {
@@ -14,26 +16,20 @@ func writeLocks(t *testing.T) (currentPath, resolvedPath string) {
 	currentPath = filepath.Join(dir, "composer.lock")
 	resolvedPath = filepath.Join(dir, "resolved.lock")
 
-	writeFile(t, currentPath, `{
-		"packages": [
-			{"name": "shopware/core", "version": "v6.6.10.3"},
-			{"name": "swag/demo", "version": "2.0.0", "type": "shopware-platform-plugin"},
-			{"name": "acme/other", "version": "2.0.0"},
-			{"name": "legacy/package", "version": "1.0.0"},
-			{"name": "vendor/untouched", "version": "1.0.0"}
-		],
-		"packages-dev": []
-	}`)
-	writeFile(t, resolvedPath, `{
-		"packages": [
-			{"name": "shopware/core", "version": "v6.7.11.0"},
-			{"name": "shopware/deployment-helper", "version": "v0.5.1"},
-			{"name": "swag/demo", "version": "2.1.3", "type": "shopware-platform-plugin"},
-			{"name": "acme/other", "version": "1.9.0"},
-			{"name": "vendor/untouched", "version": "1.0.0"}
-		],
-		"packages-dev": []
-	}`)
+	testhelper.WriteFile(t, currentPath, testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.10.3"},
+		testhelper.LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
+		testhelper.LockPackage{Name: "acme/other", Version: "2.0.0"},
+		testhelper.LockPackage{Name: "legacy/package", Version: "1.0.0"},
+		testhelper.LockPackage{Name: "vendor/untouched", Version: "1.0.0"},
+	))
+	testhelper.WriteFile(t, resolvedPath, testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.7.11.0"},
+		testhelper.LockPackage{Name: "shopware/deployment-helper", Version: "v0.5.1"},
+		testhelper.LockPackage{Name: "swag/demo", Version: "2.1.3", Type: "shopware-platform-plugin"},
+		testhelper.LockPackage{Name: "acme/other", Version: "1.9.0"},
+		testhelper.LockPackage{Name: "vendor/untouched", Version: "1.0.0"},
+	))
 	return currentPath, resolvedPath
 }
 
@@ -74,7 +70,7 @@ func TestResolvedVersion(t *testing.T) {
 
 func TestLockVersionsIncludesDevelopmentPackages(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "composer.lock")
-	writeFile(t, path, `{
+	testhelper.WriteFile(t, path, `{
 		"packages": [{"name": "shopware/core", "version": "v6.7.11.0"}],
 		"packages-dev": [{"name": "phpunit/phpunit", "version": "v11.5.0"}]
 	}`)

--- a/internal/shop/upgrade/run_test.go
+++ b/internal/shop/upgrade/run_test.go
@@ -14,6 +14,7 @@ import (
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 // fakeExecutor satisfies executor.Executor and lets each test decide which
@@ -255,7 +256,7 @@ func TestRunnerRecipesInstallIsNonFatal(t *testing.T) {
 func TestRunnerRestoresComposeProjectNameAfterRecipesReset(t *testing.T) {
 	dir := setupProject(t)
 	envPath := filepath.Join(dir, ".env")
-	require.NoError(t, os.WriteFile(envPath, []byte("COMPOSE_PROJECT_NAME=sw-shop-abc123\nAPP_ENV=prod\n"), 0o644))
+	testhelper.WriteFile(t, envPath, "COMPOSE_PROJECT_NAME=sw-shop-abc123\nAPP_ENV=prod\n")
 
 	u := NewProjectUpgrader(dir, &fakeExecutor{
 		composer: func(ctx context.Context, args ...string) *executor.Process {

--- a/internal/testhelper/README.md
+++ b/internal/testhelper/README.md
@@ -1,0 +1,164 @@
+# testhelper
+
+Shared fixture builders for tests. This package removes the boilerplate of
+building Shopware project and extension trees on disk — temp directories,
+composer.json / composer.lock rendering, and app manifest.xml rendering — so
+tests state *what* the fixture is, not how to write it.
+
+Everything here is behavior-first: builders render deterministic output, omit
+zero-valued fields, and are covered by this package's own tests. When a fixture
+can't be expressed (see [When to keep raw strings](#when-to-keep-raw-strings)),
+fall back to a raw string through `WriteFile` — that escape hatch is part of
+the design, not a workaround.
+
+## Files and directories
+
+### `WriteFile(t, path, content)`
+
+The atom: mkdir-p the parent, write the file, fail the test on error.
+Replaces the `os.MkdirAll` + `os.WriteFile` + error-check triple.
+
+```go
+testhelper.WriteFile(t, filepath.Join(dir, ".env"), "DATABASE_URL=mysql://app:secret@db/shop\n")
+```
+
+### `Project` — a Shopware project root
+
+Chainable builder around a fresh temp dir for project-shaped fixtures
+(root composer.json + lock + vendor + custom/plugins):
+
+```go
+p := testhelper.NewProject(t).
+    File("composer.json", testhelper.ComposerJSON{
+        Name:    "shopware/production",
+        Require: map[string]string{"shopware/core": "6.6.10.3"},
+    }.String()).
+    File("composer.lock", testhelper.ComposerLock(
+        testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.10.3"},
+    )).
+    VendorPackage("swag/demo", testhelper.PluginComposer("swag/demo", "2.0.0", `Swag\Demo\Demo`)).
+    CustomPlugin("LocalPlugin", testhelper.PluginComposer("acme/local-plugin", "1.0.0", `Acme\LocalPlugin\LocalPlugin`)).
+    Dir("var/cache") // empty directory, no file needed
+
+root := p.Root
+```
+
+`File` and `Dir` take slash-separated paths relative to `Root`. Scenario
+helpers (a package's `setupProject(t)`) should stay package-local and compose
+these calls — this package provides the atoms, not the scenarios.
+
+### Standalone extension directories
+
+For a single plugin/bundle/app rooted in its own temp dir (not inside a
+project):
+
+```go
+// The composer content matters to the test: keep it visible at the call site.
+dir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+    Name: "shopware/invalid",
+    Type: "invalid", // the test asserts this is rejected
+})
+
+// The manifest content matters:
+appPath := testhelper.AppDir(t, manifest) // manifest is a testhelper.AppManifest
+
+// Any valid extension will do — the test doesn't assert its metadata:
+pluginDir := testhelper.NewPlugin(t, "FroshTools") // test/frosh-tools, class FroshTools\FroshTools, v1.0.0
+appDir := testhelper.NewApp(t, "MyExampleApp")
+```
+
+Rule of thumb: if the test asserts names, versions, classes, or labels — or
+the fixture is deliberately broken — use `ExtensionDir`/`AppDir` with an
+explicit builder so the reader sees the arrange step. Use `NewPlugin`/`NewApp`
+only when the fixture is incidental.
+
+## composer.json
+
+`ComposerJSON` renders a manifest; zero-valued fields are omitted, so partial
+and degenerate manifests (`{}`, version-only) stay expressible:
+
+```go
+testhelper.ComposerJSON{Name: "swag/demo", Type: "shopware-bundle"}.String()
+```
+
+Supported fields: `Name`, `Type`, `Version`, `License`, `Description`,
+`Authors` (rendered as `[{"name": ...}]`), `Require`, `RequireDev`,
+`PluginClass` (`extra.shopware-plugin-class`), `Label` (`extra.label`),
+`Psr4` (`autoload.psr-4`), and `Extra map[string]any` for anything else under
+`extra` (e.g. `shopware-bundle-name`, `manufacturerLink`).
+
+`PluginComposer(name, version, class)` is the canonical platform plugin:
+`type: shopware-platform-plugin`, `require: {"shopware/core": "~6.6.0"}`, with
+the en-GB label and PSR-4 prefix derived from the bootstrap class. Override
+fields on the returned value when the defaults don't fit:
+
+```go
+c := testhelper.PluginComposer("frosh/tools", "2.0.0", `Frosh\Tools\FroshTools`)
+c.Require = map[string]string{"shopware/core": "~6.7.0"}
+```
+
+An empty version renders no `version` key (useful for fallback-version tests).
+
+## composer.lock
+
+`ComposerLock(packages...)` renders `{"packages": [...], "packages-dev": []}`:
+
+```go
+testhelper.ComposerLock() // empty lock
+testhelper.ComposerLock(
+    testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.10.3",
+        Require: map[string]string{"php": ">=8.2"}},
+    testhelper.LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
+)
+```
+
+`LockPackage` carries `Name`, `Version`, `Type`, and a per-package `Require`.
+Locks needing more (per-package `license` arrays, populated `packages-dev`)
+stay raw — see below.
+
+## App manifest.xml
+
+`NewAppManifest(name)` returns a complete, valid manifest with placeholder
+metadata (label/description in en + de-DE, author, copyright, version 1.0.0,
+MIT). Zero-valued fields are omitted, so validator tests express "manifest
+missing exactly one element" by clearing that field:
+
+```go
+m := testhelper.NewAppManifest("MyExampleApp")
+m.License = ""          // missing-license variant
+m.Compatibility = "~6.5.0"
+m.Icon = "app.png"
+m.SetupSecret = "foo"   // adds a <setup><secret> block
+testhelper.WriteFile(t, filepath.Join(dir, "manifest.xml"), m.String())
+// or: dir := testhelper.AppDir(t, m)
+```
+
+`Label` and `Description` are `map[lang]text` with `""` as the default
+language, rendered default-first.
+
+## When to keep raw strings
+
+Do **not** force a fixture through a builder when:
+
+- **The test asserts byte-exact file content** (e.g. content compared after a
+  git archive round-trip, or a renderer asserted to leave a file untouched).
+  A builder's formatting is not part of its contract.
+- **The fixture is the test data**: broken JSON, `"{}"`, partial documents
+  exercising parse-error paths.
+- **The shape is intentionally inexpressible**: manifests with arbitrary
+  unknown XML elements asserted to survive rewriting, locks with per-package
+  license arrays, composer files with `repositories` blocks.
+- **The file needs special permissions** (executables, `0600` credentials) —
+  `WriteFile` always writes `0o644`.
+
+In those cases write the raw string via `testhelper.WriteFile` (or plain
+`os.WriteFile` for special permissions) and, where it isn't obvious, leave a
+short comment saying why the builder doesn't apply.
+
+## Adding to this package
+
+Add a field or helper only when a second (ideally third) call site needs it —
+single-use shapes stay raw at their call site. Every addition needs coverage
+in this package's tests, and rendering must stay deterministic (sort map keys
+before emitting). Test doubles for interfaces (executors, validation checks)
+do not belong here yet; they live package-local.

--- a/internal/testhelper/README.md
+++ b/internal/testhelper/README.md
@@ -155,6 +155,13 @@ In those cases write the raw string via `testhelper.WriteFile` (or plain
 `os.WriteFile` for special permissions) and, where it isn't obvious, leave a
 short comment saying why the builder doesn't apply.
 
+Config YAML (`.shopware-extension.yml`, `.shopware-project.yml`) also stays
+raw — as backtick multiline literals, not `\n`-escaped strings. Do NOT build
+these by marshaling the production config structs: their `omitempty` tags drop
+zero-valued nested structs, so an explicit `enabled: false` marshals to
+nothing and the loader's `enabled: true` defaults silently flip the fixture's
+meaning (verified — a Config with zip packing disabled marshals to `{}`).
+
 ## Adding to this package
 
 Add a field or helper only when a second (ideally third) call site needs it —

--- a/internal/testhelper/composer.go
+++ b/internal/testhelper/composer.go
@@ -10,18 +10,19 @@ import (
 // out of the rendered JSON, so partial and degenerate manifests (only a
 // version, an empty object) stay expressible.
 type ComposerJSON struct {
-	Name        string
-	Type        string
-	Version     string
-	License     string
-	Description string
-	Authors     []string // rendered as [{"name": ...}, ...]
-	Require     map[string]string
-	RequireDev  map[string]string
-	PluginClass string            // extra.shopware-plugin-class
-	Label       map[string]string // extra.label
-	Extra       map[string]any    // additional extra entries, merged last
-	Psr4        map[string]string // autoload.psr-4
+	Name         string
+	Type         string
+	Version      string
+	License      string
+	Description  string
+	Authors      []string // rendered as [{"name": ...}, ...]
+	Require      map[string]string
+	RequireDev   map[string]string
+	PluginClass  string            // extra.shopware-plugin-class
+	Label        map[string]string // extra.label
+	Extra        map[string]any    // additional extra entries, merged last
+	Psr4         map[string]string // autoload.psr-4
+	Repositories []map[string]any  // composer repositories, e.g. path or composer type
 }
 
 // PluginComposer returns the composer.json for a Shopware platform plugin.
@@ -89,6 +90,9 @@ func (c ComposerJSON) String() string {
 	if len(c.Psr4) > 0 {
 		m["autoload"] = map[string]any{"psr-4": c.Psr4}
 	}
+	if len(c.Repositories) > 0 {
+		m["repositories"] = c.Repositories
+	}
 	return marshalIndent(m)
 }
 
@@ -98,6 +102,7 @@ type LockPackage struct {
 	Version string            `json:"version"`
 	Type    string            `json:"type,omitempty"`
 	Require map[string]string `json:"require,omitempty"`
+	Dist    map[string]string `json:"dist,omitempty"` // e.g. {"type": "path", "url": "custom/static-plugins/Foo"}
 }
 
 // ComposerLock renders a composer.lock with the given packages and an empty

--- a/internal/testhelper/composer.go
+++ b/internal/testhelper/composer.go
@@ -1,0 +1,137 @@
+package testhelper
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+)
+
+// ComposerJSON describes a composer.json fixture. Zero-valued fields are left
+// out of the rendered JSON, so partial and degenerate manifests (only a
+// version, an empty object) stay expressible.
+type ComposerJSON struct {
+	Name        string
+	Type        string
+	Version     string
+	License     string
+	Description string
+	Authors     []string // rendered as [{"name": ...}, ...]
+	Require     map[string]string
+	RequireDev  map[string]string
+	PluginClass string            // extra.shopware-plugin-class
+	Label       map[string]string // extra.label
+	Extra       map[string]any    // additional extra entries, merged last
+	Psr4        map[string]string // autoload.psr-4
+}
+
+// PluginComposer returns the composer.json for a Shopware platform plugin.
+// class is the fully qualified bootstrap class (e.g. `Swag\Demo\Demo`); the
+// en-GB label and the PSR-4 autoload prefix are derived from it. Callers can
+// override any field before rendering.
+func PluginComposer(name, version, class string) ComposerJSON {
+	parts := strings.Split(class, `\`)
+	c := ComposerJSON{
+		Name:        name,
+		Type:        "shopware-platform-plugin",
+		Version:     version,
+		Require:     map[string]string{"shopware/core": "~6.6.0"},
+		PluginClass: class,
+		Label:       map[string]string{"en-GB": parts[len(parts)-1]},
+	}
+	if len(parts) > 1 {
+		c.Psr4 = map[string]string{strings.Join(parts[:len(parts)-1], `\`) + `\`: "src/"}
+	}
+	return c
+}
+
+// String renders the manifest as JSON.
+func (c ComposerJSON) String() string {
+	m := map[string]any{}
+	if c.Name != "" {
+		m["name"] = c.Name
+	}
+	if c.Type != "" {
+		m["type"] = c.Type
+	}
+	if c.Version != "" {
+		m["version"] = c.Version
+	}
+	if c.License != "" {
+		m["license"] = c.License
+	}
+	if c.Description != "" {
+		m["description"] = c.Description
+	}
+	if len(c.Authors) > 0 {
+		authors := make([]map[string]string, 0, len(c.Authors))
+		for _, name := range c.Authors {
+			authors = append(authors, map[string]string{"name": name})
+		}
+		m["authors"] = authors
+	}
+	if len(c.Require) > 0 {
+		m["require"] = c.Require
+	}
+	if len(c.RequireDev) > 0 {
+		m["require-dev"] = c.RequireDev
+	}
+	extra := map[string]any{}
+	if c.PluginClass != "" {
+		extra["shopware-plugin-class"] = c.PluginClass
+	}
+	if len(c.Label) > 0 {
+		extra["label"] = c.Label
+	}
+	maps.Copy(extra, c.Extra)
+	if len(extra) > 0 {
+		m["extra"] = extra
+	}
+	if len(c.Psr4) > 0 {
+		m["autoload"] = map[string]any{"psr-4": c.Psr4}
+	}
+	return marshalIndent(m)
+}
+
+// LockPackage is one entry in a composer.lock packages list.
+type LockPackage struct {
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Type    string            `json:"type,omitempty"`
+	Require map[string]string `json:"require,omitempty"`
+}
+
+// ComposerLock renders a composer.lock with the given packages and an empty
+// packages-dev section.
+func ComposerLock(packages ...LockPackage) string {
+	if packages == nil {
+		packages = []LockPackage{}
+	}
+	return marshalIndent(map[string]any{
+		"packages":     packages,
+		"packages-dev": []LockPackage{},
+	})
+}
+
+// kebabCase converts a CamelCase plugin name to its kebab-case composer form:
+// "FroshTools" -> "frosh-tools".
+func kebabCase(name string) string {
+	var b strings.Builder
+	for i, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('-')
+			}
+			r += 'a' - 'A'
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func marshalIndent(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err) // unreachable for the map/struct shapes above
+	}
+	return string(b)
+}

--- a/internal/testhelper/composer_test.go
+++ b/internal/testhelper/composer_test.go
@@ -116,3 +116,27 @@ func readFile(t *testing.T, path string) string {
 	require.NoError(t, err)
 	return string(b)
 }
+
+func TestComposerJSONRepositoriesAndLockDist(t *testing.T) {
+	m := decode(t, ComposerJSON{
+		Name: "shopware/production",
+		Repositories: []map[string]any{
+			{"type": "path", "url": "custom/static-plugins/*", "options": map[string]any{"symlink": true}},
+		},
+	}.String())
+	assert.Equal(t, []any{map[string]any{
+		"type": "path", "url": "custom/static-plugins/*",
+		"options": map[string]any{"symlink": true},
+	}}, m["repositories"])
+
+	assert.JSONEq(t, `{
+		"packages": [
+			{"name": "acme/custom-plugin", "version": "1.0.0", "type": "shopware-platform-plugin",
+			 "dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}}
+		],
+		"packages-dev": []
+	}`, ComposerLock(LockPackage{
+		Name: "acme/custom-plugin", Version: "1.0.0", Type: "shopware-platform-plugin",
+		Dist: map[string]string{"type": "path", "url": "custom/static-plugins/MyCustomPlugin"},
+	}))
+}

--- a/internal/testhelper/composer_test.go
+++ b/internal/testhelper/composer_test.go
@@ -1,0 +1,118 @@
+package testhelper
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decode(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(s), &m))
+	return m
+}
+
+func TestPluginComposerDerivesLabelAndAutoload(t *testing.T) {
+	m := decode(t, PluginComposer("swag/demo", "2.0.0", `Swag\Demo\Demo`).String())
+
+	assert.Equal(t, "swag/demo", m["name"])
+	assert.Equal(t, "shopware-platform-plugin", m["type"])
+	assert.Equal(t, "2.0.0", m["version"])
+	assert.Equal(t, map[string]any{"shopware/core": "~6.6.0"}, m["require"])
+	assert.Equal(t, map[string]any{
+		"shopware-plugin-class": `Swag\Demo\Demo`,
+		"label":                 map[string]any{"en-GB": "Demo"},
+	}, m["extra"])
+	assert.Equal(t, map[string]any{"psr-4": map[string]any{`Swag\Demo\`: "src/"}}, m["autoload"])
+}
+
+func TestComposerJSONOmitsZeroFields(t *testing.T) {
+	assert.JSONEq(t, `{}`, ComposerJSON{}.String())
+
+	// A plugin without a version must render without the key, not with "".
+	m := decode(t, PluginComposer("frosh/no-version", "", `NoVersion`).String())
+	_, hasVersion := m["version"]
+	assert.False(t, hasVersion)
+	// A class without a namespace cannot produce a PSR-4 prefix.
+	_, hasAutoload := m["autoload"]
+	assert.False(t, hasAutoload)
+}
+
+func TestComposerLock(t *testing.T) {
+	assert.JSONEq(t, `{"packages": [], "packages-dev": []}`, ComposerLock())
+
+	assert.JSONEq(t, `{
+		"packages": [
+			{"name": "shopware/core", "version": "v6.6.10.3"},
+			{"name": "swag/demo", "version": "2.0.0", "type": "shopware-platform-plugin"}
+		],
+		"packages-dev": []
+	}`, ComposerLock(
+		LockPackage{Name: "shopware/core", Version: "v6.6.10.3"},
+		LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
+	))
+
+	assert.JSONEq(t, `{
+		"packages": [
+			{"name": "shopware/core", "version": "v6.6.10.3", "require": {"php": ">=8.2"}}
+		],
+		"packages-dev": []
+	}`, ComposerLock(
+		LockPackage{Name: "shopware/core", Version: "v6.6.10.3", Require: map[string]string{"php": ">=8.2"}},
+	))
+}
+
+func TestProjectWritesRelativeFiles(t *testing.T) {
+	p := NewProject(t).
+		File("composer.lock", ComposerLock()).
+		VendorPackage("swag/demo", PluginComposer("swag/demo", "2.0.0", `Swag\Demo\Demo`)).
+		CustomPlugin("LocalPlugin", PluginComposer("acme/local-plugin", "1.0.0", `Acme\LocalPlugin\LocalPlugin`))
+
+	assert.FileExists(t, p.Root+"/composer.lock")
+	assert.FileExists(t, p.Root+"/vendor/swag/demo/composer.json")
+	assert.FileExists(t, p.Root+"/custom/plugins/LocalPlugin/composer.json")
+}
+
+func TestComposerJSONExtendedFields(t *testing.T) {
+	c := PluginComposer("swag/demo", "1.0.0", `Swag\Demo\Demo`)
+	c.Description = "Test plugin"
+	c.Authors = []string{"Test"}
+	c.RequireDev = map[string]string{"shopware/deployment-helper": "^1.0"}
+	c.Extra = map[string]any{"description": map[string]string{"en-GB": "Demo plugin"}}
+
+	m := decode(t, c.String())
+	assert.Equal(t, "Test plugin", m["description"])
+	assert.Equal(t, []any{map[string]any{"name": "Test"}}, m["authors"])
+	assert.Equal(t, map[string]any{"shopware/deployment-helper": "^1.0"}, m["require-dev"])
+	extra, ok := m["extra"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, `Swag\Demo\Demo`, extra["shopware-plugin-class"])
+	assert.Equal(t, map[string]any{"en-GB": "Demo plugin"}, extra["description"])
+}
+
+func TestExtensionDirAndPluginHelpers(t *testing.T) {
+	dir := ExtensionDir(t, ComposerJSON{Name: "swag/demo", Type: "shopware-bundle"})
+	assert.FileExists(t, dir+"/composer.json")
+
+	pluginDir := NewPlugin(t, "FroshTools")
+	m := decode(t, readFile(t, pluginDir+"/composer.json"))
+	assert.Equal(t, "test/frosh-tools", m["name"])
+	assert.Equal(t, "shopware-platform-plugin", m["type"])
+	extra, ok := m["extra"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, `FroshTools\FroshTools`, extra["shopware-plugin-class"])
+
+	appDir := NewApp(t, "MyExampleApp")
+	assert.FileExists(t, appDir+"/manifest.xml")
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/testhelper/manifest.go
+++ b/internal/testhelper/manifest.go
@@ -1,0 +1,93 @@
+package testhelper
+
+import (
+	"encoding/xml"
+	"sort"
+	"strings"
+)
+
+// AppManifest describes a manifest.xml fixture for a Shopware app. Zero-valued
+// fields are omitted from the output, so validator tests can express a
+// manifest missing exactly one required element by clearing that field on the
+// value NewAppManifest returns.
+type AppManifest struct {
+	Name          string
+	Label         map[string]string // lang -> text; "" is the default language
+	Description   map[string]string // lang -> text; "" is the default language
+	Compatibility string
+	Author        string
+	Copyright     string
+	Version       string
+	License       string
+	Icon          string
+	SetupSecret   string
+}
+
+// NewAppManifest returns a complete, valid app manifest with placeholder
+// metadata. Tests clear or override individual fields to build variants.
+func NewAppManifest(name string) AppManifest {
+	return AppManifest{
+		Name:        name,
+		Label:       map[string]string{"": "Label", "de-DE": "Name"},
+		Description: map[string]string{"": "A description", "de-DE": "Eine Beschreibung"},
+		Author:      "Your Company Ltd.",
+		Copyright:   "(c) by Your Company Ltd.",
+		Version:     "1.0.0",
+		License:     "MIT",
+	}
+}
+
+// String renders the manifest as XML.
+func (m AppManifest) String() string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">` + "\n")
+	b.WriteString("\t<meta>\n")
+
+	writeElem := func(name, lang, value string) {
+		if value == "" {
+			return
+		}
+		b.WriteString("\t\t<")
+		b.WriteString(name)
+		if lang != "" {
+			b.WriteString(` lang="`)
+			b.WriteString(lang)
+			b.WriteString(`"`)
+		}
+		b.WriteString(">")
+		_ = xml.EscapeText(&b, []byte(value))
+		b.WriteString("</")
+		b.WriteString(name)
+		b.WriteString(">\n")
+	}
+	writeLocalized := func(name string, values map[string]string) {
+		langs := make([]string, 0, len(values))
+		for lang := range values {
+			langs = append(langs, lang)
+		}
+		sort.Strings(langs) // "" (default language) sorts first
+		for _, lang := range langs {
+			writeElem(name, lang, values[lang])
+		}
+	}
+
+	writeElem("name", "", m.Name)
+	writeLocalized("label", m.Label)
+	writeLocalized("description", m.Description)
+	writeElem("compatibility", "", m.Compatibility)
+	writeElem("author", "", m.Author)
+	writeElem("copyright", "", m.Copyright)
+	writeElem("version", "", m.Version)
+	writeElem("license", "", m.License)
+	writeElem("icon", "", m.Icon)
+
+	b.WriteString("\t</meta>\n")
+	if m.SetupSecret != "" {
+		b.WriteString("\t<setup>\n\t\t<secret>")
+		_ = xml.EscapeText(&b, []byte(m.SetupSecret))
+		b.WriteString("</secret>\n\t</setup>\n")
+	}
+	b.WriteString("</manifest>")
+	return b.String()
+}

--- a/internal/testhelper/manifest_test.go
+++ b/internal/testhelper/manifest_test.go
@@ -1,0 +1,73 @@
+package testhelper
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type manifestMeta struct {
+	Name          string   `xml:"name"`
+	Labels        []string `xml:"label"`
+	Descriptions  []string `xml:"description"`
+	Compatibility string   `xml:"compatibility"`
+	Author        string   `xml:"author"`
+	Copyright     string   `xml:"copyright"`
+	Version       string   `xml:"version"`
+	License       string   `xml:"license"`
+	Icon          string   `xml:"icon"`
+}
+
+type manifestDoc struct {
+	Meta  manifestMeta `xml:"meta"`
+	Setup *struct {
+		Secret string `xml:"secret"`
+	} `xml:"setup"`
+}
+
+func decodeManifest(t *testing.T, s string) manifestDoc {
+	t.Helper()
+	var doc manifestDoc
+	require.NoError(t, xml.Unmarshal([]byte(s), &doc))
+	return doc
+}
+
+func TestNewAppManifestRendersCompleteMeta(t *testing.T) {
+	doc := decodeManifest(t, NewAppManifest("MyExampleApp").String())
+
+	assert.Equal(t, "MyExampleApp", doc.Meta.Name)
+	// The default language entry must come before translations.
+	assert.Equal(t, []string{"Label", "Name"}, doc.Meta.Labels)
+	assert.Equal(t, []string{"A description", "Eine Beschreibung"}, doc.Meta.Descriptions)
+	assert.Equal(t, "Your Company Ltd.", doc.Meta.Author)
+	assert.Equal(t, "(c) by Your Company Ltd.", doc.Meta.Copyright)
+	assert.Equal(t, "1.0.0", doc.Meta.Version)
+	assert.Equal(t, "MIT", doc.Meta.License)
+	assert.Empty(t, doc.Meta.Compatibility)
+	assert.Empty(t, doc.Meta.Icon)
+	assert.Nil(t, doc.Setup)
+}
+
+func TestAppManifestOmitsClearedFields(t *testing.T) {
+	m := NewAppManifest("MyExampleApp")
+	m.License = ""
+
+	rendered := m.String()
+	assert.NotContains(t, rendered, "<license>")
+	assert.Empty(t, decodeManifest(t, rendered).Meta.License)
+}
+
+func TestAppManifestOptionalElements(t *testing.T) {
+	m := NewAppManifest("MyExampleApp")
+	m.Compatibility = "~6.5.0"
+	m.Icon = "app.png"
+	m.SetupSecret = "foo"
+
+	doc := decodeManifest(t, m.String())
+	assert.Equal(t, "~6.5.0", doc.Meta.Compatibility)
+	assert.Equal(t, "app.png", doc.Meta.Icon)
+	require.NotNil(t, doc.Setup)
+	assert.Equal(t, "foo", doc.Setup.Secret)
+}

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -1,0 +1,99 @@
+// Package testhelper provides shared fixture builders for tests: writing
+// files into temp directories and rendering the composer.json / composer.lock
+// shapes that Shopware project and extension tests need over and over.
+package testhelper
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WriteFile writes content to path, creating parent directories as needed.
+func WriteFile(tb testing.TB, filePath, content string) {
+	tb.Helper()
+	require.NoError(tb, os.MkdirAll(filepath.Dir(filePath), 0o755))
+	require.NoError(tb, os.WriteFile(filePath, []byte(content), 0o644))
+}
+
+// ExtensionDir writes composer.json into a fresh temp directory and returns
+// the directory: a standalone plugin or bundle root. Use it when the test
+// cares about the composer content — the manifest stays visible at the call
+// site; reach for NewPlugin when any valid plugin will do.
+func ExtensionDir(tb testing.TB, c ComposerJSON) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	WriteFile(tb, filepath.Join(dir, "composer.json"), c.String())
+	return dir
+}
+
+// AppDir writes manifest.xml into a fresh temp directory and returns the
+// directory: a standalone Shopware app root.
+func AppDir(tb testing.TB, m AppManifest) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	WriteFile(tb, filepath.Join(dir, "manifest.xml"), m.String())
+	return dir
+}
+
+// NewPlugin returns a directory containing a valid platform plugin for tests
+// that just need one and don't assert its metadata. The composer name and
+// bootstrap class are derived from name: "FroshTools" becomes
+// "test/frosh-tools" with class `FroshTools\FroshTools` at version 1.0.0.
+// Tests that assert those values should use ExtensionDir with an explicit
+// ComposerJSON instead.
+func NewPlugin(tb testing.TB, name string) string {
+	tb.Helper()
+	return ExtensionDir(tb, PluginComposer("test/"+kebabCase(name), "1.0.0", name+`\`+name))
+}
+
+// NewApp returns a directory containing a valid app manifest for tests that
+// just need one and don't assert its metadata.
+func NewApp(tb testing.TB, name string) string {
+	tb.Helper()
+	return AppDir(tb, NewAppManifest(name))
+}
+
+// Project is a Shopware project rooted in a temp directory that tests can
+// populate file by file.
+type Project struct {
+	TB   testing.TB
+	Root string
+}
+
+// NewProject creates an empty project in a fresh temp directory.
+func NewProject(tb testing.TB) *Project {
+	tb.Helper()
+	return &Project{TB: tb, Root: tb.TempDir()}
+}
+
+// Dir creates an empty directory at the slash-separated path relative to the
+// project root.
+func (p *Project) Dir(rel string) *Project {
+	p.TB.Helper()
+	require.NoError(p.TB, os.MkdirAll(filepath.Join(p.Root, filepath.FromSlash(rel)), 0o755))
+	return p
+}
+
+// File writes content at the slash-separated path relative to the project root.
+func (p *Project) File(rel, content string) *Project {
+	p.TB.Helper()
+	WriteFile(p.TB, filepath.Join(p.Root, filepath.FromSlash(rel)), content)
+	return p
+}
+
+// VendorPackage writes vendor/<name>/composer.json for a Composer-managed package.
+func (p *Project) VendorPackage(name string, composer ComposerJSON) *Project {
+	p.TB.Helper()
+	return p.File(path.Join("vendor", name, "composer.json"), composer.String())
+}
+
+// CustomPlugin writes custom/plugins/<dirName>/composer.json for a locally
+// installed plugin.
+func (p *Project) CustomPlugin(dirName string, composer ComposerJSON) *Project {
+	p.TB.Helper()
+	return p.File(path.Join("custom", "plugins", dirName, "composer.json"), composer.String())
+}

--- a/internal/tui/dev/migration_wizard_test.go
+++ b/internal/tui/dev/migration_wizard_test.go
@@ -10,13 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
 func writeLockWithCore(t *testing.T, dir, phpRequire string) {
 	t.Helper()
-	content := `{"packages":[{"name":"shopware/core","version":"v6.6.10.0","require":{"php":"` + phpRequire + `"}}]}`
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(content), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.6.10.0", Require: map[string]string{"php": phpRequire}},
+	))
 }
 
 func TestResolvePHPVersions_NoLockFile(t *testing.T) {
@@ -211,13 +213,10 @@ func TestMergeLocalProfilerSecrets(t *testing.T) {
 
 func TestEnsureDeploymentHelper_AddsWhenMissing(t *testing.T) {
 	dir := t.TempDir()
-	composer := `{
-  "name": "shopware/production",
-  "require": {
-    "shopware/core": "^6.6"
-  }
-}`
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "shopware/production",
+		Require: map[string]string{"shopware/core": "^6.6"},
+	}.String())
 
 	changed, err := ensureDeploymentHelper(dir)
 	assert.NoError(t, err)
@@ -231,14 +230,10 @@ func TestEnsureDeploymentHelper_AddsWhenMissing(t *testing.T) {
 
 func TestEnsureDeploymentHelper_NoOpWhenAlreadyInRequire(t *testing.T) {
 	dir := t.TempDir()
-	composer := `{
-  "name": "shopware/production",
-  "require": {
-    "shopware/core": "^6.6",
-    "shopware/deployment-helper": "^1.0"
-  }
-}`
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "shopware/production",
+		Require: map[string]string{"shopware/core": "^6.6", "shopware/deployment-helper": "^1.0"},
+	}.String())
 
 	changed, err := ensureDeploymentHelper(dir)
 	assert.NoError(t, err)
@@ -252,12 +247,11 @@ func TestEnsureDeploymentHelper_NoOpWhenAlreadyInRequire(t *testing.T) {
 
 func TestEnsureDeploymentHelper_NoOpWhenInRequireDev(t *testing.T) {
 	dir := t.TempDir()
-	composer := `{
-  "name": "shopware/production",
-  "require": {"shopware/core": "^6.6"},
-  "require-dev": {"shopware/deployment-helper": "^1.0"}
-}`
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:       "shopware/production",
+		Require:    map[string]string{"shopware/core": "^6.6"},
+		RequireDev: map[string]string{"shopware/deployment-helper": "^1.0"},
+	}.String())
 
 	changed, err := ensureDeploymentHelper(dir)
 	assert.NoError(t, err)
@@ -272,8 +266,9 @@ func TestEnsureDeploymentHelper_MissingComposerJson(t *testing.T) {
 
 func TestResolvePHPVersions_PlatformFallback(t *testing.T) {
 	dir := t.TempDir()
-	content := `{"packages":[{"name":"shopware/platform","version":"v6.5.0.0","require":{"php":">=8.2"}}]}`
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(content), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/platform", Version: "v6.5.0.0", Require: map[string]string{"php": ">=8.2"}},
+	))
 
 	versions, _, constraint := resolvePHPVersions(dir)
 	assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, versions)

--- a/internal/tui/dev/tab_overview_health_test.go
+++ b/internal/tui/dev/tab_overview_health_test.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/symfony"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestParsePHPMemoryLimit(t *testing.T) {
@@ -49,8 +49,9 @@ func TestMemoryLimitCheck(t *testing.T) {
 
 func writeComposerLock(t *testing.T, dir, phpConstraint string) {
 	t.Helper()
-	lock := `{"packages":[{"name":"shopware/core","version":"v6.7.0.0","require":{"php":"` + phpConstraint + `"}}]}`
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(lock), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.7.0.0", Require: map[string]string{"php": phpConstraint}},
+	))
 }
 
 func TestPHPVersionCheck(t *testing.T) {
@@ -83,10 +84,8 @@ func TestAdminWorkerCheck(t *testing.T) {
 
 func writeMonologConfig(t *testing.T, dir, level string) {
 	t.Helper()
-	packages := filepath.Join(dir, "config", "packages")
-	require.NoError(t, os.MkdirAll(packages, 0o755))
 	yaml := "monolog:\n    handlers:\n        business_event_handler_buffer:\n            level: " + level + "\n"
-	require.NoError(t, os.WriteFile(filepath.Join(packages, "monolog.yaml"), []byte(yaml), 0o644))
+	testhelper.WriteFile(t, filepath.Join(dir, "config", "packages", "monolog.yaml"), yaml)
 }
 
 func TestFlowBuilderLogLevelCheck(t *testing.T) {

--- a/internal/verifier/project_test.go
+++ b/internal/verifier/project_test.go
@@ -2,11 +2,12 @@ package verifier
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 // stubShopwareVersions replaces the network-backed version lookup with a
@@ -26,71 +27,63 @@ build:
     - path: src/MyBundle
 `
 
+var testProjectComposerJSON = testhelper.ComposerJSON{
+	Type:    "project",
+	Require: map[string]string{"shopware/core": "~6.6.0"},
+}
+
 func TestGetConfigFromProjectYAMLBundles(t *testing.T) {
 	stubShopwareVersions(t)
-	tmpDir := t.TempDir()
-
-	// Minimal composer.json with shopware/core requirement
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{
-		"type": "project",
-		"require": {"shopware/core": "~6.6.0"}
-	}`), 0o644))
+	p := testhelper.NewProject(t).
+		File("composer.json", testProjectComposerJSON.String()).
+		File(".shopware-project.yml", testProjectYAMLSingleBundle)
 
 	// Create bundle directory with an admin subfolder
-	adminPath := filepath.Join(tmpDir, "src", "MyBundle", "Resources", "app", "administration")
-	assert.NoError(t, os.MkdirAll(adminPath, 0o755))
+	p.Dir("src/MyBundle/Resources/app/administration")
+	adminPath := filepath.Join(p.Root, "src", "MyBundle", "Resources", "app", "administration")
 
-	// Write .shopware-project.yml with the bundle declared
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
-
-	cfg, err := GetConfigFromProject(tmpDir, true)
+	cfg, err := GetConfigFromProject(p.Root, true)
 	assert.NoError(t, err)
 
-	assert.Contains(t, cfg.SourceDirectories, filepath.Join(tmpDir, "src", "MyBundle"))
+	assert.Contains(t, cfg.SourceDirectories, filepath.Join(p.Root, "src", "MyBundle"))
 	assert.Contains(t, cfg.AdminDirectories, adminPath)
 }
 
 func TestGetConfigFromProjectYAMLBundleStorefront(t *testing.T) {
 	stubShopwareVersions(t)
-	tmpDir := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{
-		"type": "project",
-		"require": {"shopware/core": "~6.6.0"}
-	}`), 0o644))
+	p := testhelper.NewProject(t).
+		File("composer.json", testProjectComposerJSON.String()).
+		File(".shopware-project.yml", testProjectYAMLSingleBundle)
 
 	// Create bundle directory with a storefront subfolder only
-	storefrontPath := filepath.Join(tmpDir, "src", "MyBundle", "Resources", "app", "storefront")
-	assert.NoError(t, os.MkdirAll(storefrontPath, 0o755))
+	p.Dir("src/MyBundle/Resources/app/storefront")
+	storefrontPath := filepath.Join(p.Root, "src", "MyBundle", "Resources", "app", "storefront")
 
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
-
-	cfg, err := GetConfigFromProject(tmpDir, true)
+	cfg, err := GetConfigFromProject(p.Root, true)
 	assert.NoError(t, err)
 
-	assert.Contains(t, cfg.SourceDirectories, filepath.Join(tmpDir, "src", "MyBundle"))
+	assert.Contains(t, cfg.SourceDirectories, filepath.Join(p.Root, "src", "MyBundle"))
 	assert.Contains(t, cfg.StorefrontDirectories, storefrontPath)
 }
 
 func TestGetConfigFromProjectYAMLBundleDeduplication(t *testing.T) {
 	stubShopwareVersions(t)
-	tmpDir := t.TempDir()
 
-	// composer.json declares the same bundle
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{
-		"type": "project",
-		"require": {"shopware/core": "~6.6.0"},
-		"extra": {"shopware-bundles": {"src/MyBundle": {"name": "MyBundle"}}}
-	}`), 0o644))
+	// composer.json declares the same bundle as the YAML config
+	bundleComposer := testProjectComposerJSON
+	bundleComposer.Extra = map[string]any{
+		"shopware-bundles": map[string]any{"src/MyBundle": map[string]string{"name": "MyBundle"}},
+	}
+	p := testhelper.NewProject(t).
+		File("composer.json", bundleComposer.String()).
+		File(".shopware-project.yml", testProjectYAMLSingleBundle)
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
+	p.Dir("src/MyBundle")
 
-	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
-
-	cfg, err := GetConfigFromProject(tmpDir, true)
+	cfg, err := GetConfigFromProject(p.Root, true)
 	assert.NoError(t, err)
 
-	bundleSrcPath := filepath.Join(tmpDir, "src", "MyBundle")
+	bundleSrcPath := filepath.Join(p.Root, "src", "MyBundle")
 	count := 0
 	for _, d := range cfg.SourceDirectories {
 		if d == bundleSrcPath {

--- a/internal/verifier/stylelint_test.go
+++ b/internal/verifier/stylelint_test.go
@@ -1,11 +1,12 @@
 package verifier
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 func TestHasSCSSFiles(t *testing.T) {
@@ -18,10 +19,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "directory with SCSS files",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				err := os.WriteFile(filepath.Join(dir, "styles.scss"), []byte("body { color: red; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "styles.scss"), "body { color: red; }")
 			},
 			expectedResult: true,
 		},
@@ -29,15 +27,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "directory with SCSS files in subdirectory",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				subdir := filepath.Join(dir, "css")
-				err := os.MkdirAll(subdir, 0755)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = os.WriteFile(filepath.Join(subdir, "main.scss"), []byte("body { color: blue; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "css", "main.scss"), "body { color: blue; }")
 			},
 			expectedResult: true,
 		},
@@ -45,10 +35,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "directory without SCSS files",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				err := os.WriteFile(filepath.Join(dir, "styles.css"), []byte("body { color: red; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "styles.css"), "body { color: red; }")
 			},
 			expectedResult: false,
 		},
@@ -64,15 +51,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "SCSS files in node_modules should be ignored",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				nodeModules := filepath.Join(dir, "node_modules")
-				err := os.MkdirAll(nodeModules, 0755)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = os.WriteFile(filepath.Join(nodeModules, "library.scss"), []byte("body { color: green; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "node_modules", "library.scss"), "body { color: green; }")
 			},
 			expectedResult: false,
 		},
@@ -80,15 +59,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "SCSS files in vendor should be ignored",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				vendor := filepath.Join(dir, "vendor")
-				err := os.MkdirAll(vendor, 0755)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = os.WriteFile(filepath.Join(vendor, "library.scss"), []byte("body { color: yellow; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "vendor", "library.scss"), "body { color: yellow; }")
 			},
 			expectedResult: false,
 		},
@@ -96,15 +67,7 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "SCSS files in dist should be ignored",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				dist := filepath.Join(dir, "dist")
-				err := os.MkdirAll(dist, 0755)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = os.WriteFile(filepath.Join(dist, "compiled.scss"), []byte("body { color: purple; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "dist", "compiled.scss"), "body { color: purple; }")
 			},
 			expectedResult: false,
 		},
@@ -112,22 +75,10 @@ func TestHasSCSSFiles(t *testing.T) {
 			name: "SCSS files outside ignored directories should be found",
 			setupFunc: func(t *testing.T, dir string) {
 				t.Helper()
-				// Create ignored directories with SCSS files
-				nodeModules := filepath.Join(dir, "node_modules")
-				err := os.MkdirAll(nodeModules, 0755)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = os.WriteFile(filepath.Join(nodeModules, "library.scss"), []byte("body { color: green; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-
+				// Create an ignored directory with SCSS files
+				testhelper.WriteFile(t, filepath.Join(dir, "node_modules", "library.scss"), "body { color: green; }")
 				// Create SCSS file in valid location
-				err = os.WriteFile(filepath.Join(dir, "main.scss"), []byte("body { color: black; }"), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
+				testhelper.WriteFile(t, filepath.Join(dir, "main.scss"), "body { color: black; }")
 			},
 			expectedResult: true,
 		},


### PR DESCRIPTION
## What changed?

New `internal/testhelper` package providing shared fixture builders for tests, plus a migration of 28 test files onto it (test-only — no TUI or CLI output changes):

- `WriteFile(t, path, content)` — the mkdir-p + write atom that was copy-pasted verbatim into three packages (`shop/pluginmigrate`, `shop/upgrade`, `executor`).
- `Project` — chainable temp-dir project builder (`File`, `Dir`, `VendorPackage`, `CustomPlugin`) replacing two near-identical `setupProject` fixtures and hand-joined `custom/plugins/<name>/composer.json` paths.
- `ComposerJSON` / `PluginComposer(name, version, class)` — renders composer.json, omitting zero-valued fields so degenerate manifests stay expressible; the plugin constructor derives the en-GB label and PSR-4 prefix from the bootstrap class. Replaces ~110 raw JSON string fixtures.
- `ComposerLock(packages...)` / `LockPackage` — the ever-identical lock shape, incl. per-package `require` for php-constraint tests.
- `AppManifest` / `NewAppManifest(name)` — manifest.xml builder with omittable fields; `app_test.go`'s ~107 lines of near-identical XML consts (each missing exactly one element) became ~19 lines of one-field mutations.
- `ExtensionDir` / `AppDir` and `NewPlugin` / `NewApp` — standalone extension roots in one line.
- A `README.md` documenting intended use, examples, and when to deliberately keep fixtures as raw strings (byte-exact assertions, broken-JSON parse-path fixtures, intentionally arbitrary XML, special file permissions). Those sites were left raw on purpose.

## Why?

Fixture boilerplate was duplicated everywhere: ~270 `os.WriteFile` calls across 261 test files re-rolled the same composer.json/lock/manifest shapes with no shared helper, so every new test copied 10–15 lines of JSON/XML and permission-literal noise. The builders make tests state *what* the fixture is instead of how to write it, and new tests get one-liners.

## How was this tested?

- `go test ./...` — all packages pass.
- `golangci-lint run ./...` — 0 issues.
- The builders themselves have unit coverage in `internal/testhelper` (rendering, field omission, lock/manifest shapes, derived plugin metadata).
- Migrations are behavior-preserving: sites asserting exact content, metadata absence, or parse errors either kept explicit builder values or stayed raw.

## Related issue or discussion

None — test-only refactor, no command behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage across project, extension, app, plugin, migration, verification, and upgrade scenarios.
  * Added validation for Composer metadata, lock files, app manifests, YAML-defined bundles, and duplicate bundle handling.

* **Refactor**
  * Standardized test fixture creation with shared builders for more consistent and maintainable test setup.

* **Documentation**
  * Documented shared test fixture tools and supported fixture formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->