### PR TITLE
fix: detect local path-repository plugins during project upgrade

### DIFF
--- a/internal/shop/pluginmigrate/migrator.go
+++ b/internal/shop/pluginmigrate/migrator.go
@@ -184,6 +184,8 @@ func (m *PluginMigrator) Scan(ctx context.Context) []ScannedExtension {
 	}
 	customDir := filepath.Join(root, "custom")
 
+	managed := m.managedComposerNames()
+
 	var result []ScannedExtension
 	for _, ext := range found {
 		extPath := filepath.Clean(ext.GetPath())
@@ -215,9 +217,44 @@ func (m *PluginMigrator) Scan(ctx context.Context) []ScannedExtension {
 			scanned.Version = v.String()
 		}
 
+		// Path-repository plugins live under custom/ (often via a vendor/
+		// symlink). Composer already manages them — do not offer to migrate
+		// them again.
+		if scanned.ComposerName != "" {
+			if _, ok := managed[scanned.ComposerName]; ok {
+				continue
+			}
+		}
+
 		result = append(result, scanned)
 	}
 
 	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
 	return result
+}
+
+// managedComposerNames lists packages Composer already requires or has locked.
+// Path-repository plugins under custom/ are included.
+func (m *PluginMigrator) managedComposerNames() map[string]struct{} {
+	names := make(map[string]struct{})
+
+	if lock, err := composer.ReadLock(filepath.Join(m.projectRoot, "composer.lock")); err == nil {
+		for _, pkg := range lock.Packages {
+			names[pkg.Name] = struct{}{}
+		}
+		for _, pkg := range lock.PackagesDev {
+			names[pkg.Name] = struct{}{}
+		}
+	}
+
+	if composerJSON, err := composer.ReadJson(filepath.Join(m.projectRoot, "composer.json")); err == nil {
+		for name := range composerJSON.Require {
+			names[name] = struct{}{}
+		}
+		for name := range composerJSON.RequireDev {
+			names[name] = struct{}{}
+		}
+	}
+
+	return names
 }

--- a/internal/shop/pluginmigrate/pluginmigrate_test.go
+++ b/internal/shop/pluginmigrate/pluginmigrate_test.go
@@ -146,29 +146,19 @@ func TestScanFindsOnlyCustomExtensions(t *testing.T) {
 func TestScanSkipsComposerManagedPathPlugins(t *testing.T) {
 	dir := setupProject(t)
 
-	writeFile(t, filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin", "composer.json"), `{
-		"name": "acme/custom-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.7.0"},
-		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
-		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {"shopware/core": "6.7.3.0", "acme/custom-plugin": "*"}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{
-		"packages": [
-			{
-				"name": "acme/custom-plugin",
-				"version": "1.0.0",
-				"type": "shopware-platform-plugin",
-				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
-			}
-		],
-		"packages-dev": []
-	}`)
+	pathPlugin := testhelper.PluginComposer("acme/custom-plugin", "1.0.0", `Acme\MyCustomPlugin\MyCustomPlugin`)
+	pathPlugin.Require = map[string]string{"shopware/core": "~6.7.0"}
+	testhelper.WriteFile(t, filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin", "composer.json"), pathPlugin.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name:    "shopware/production",
+		Require: map[string]string{"shopware/core": "6.7.3.0", "acme/custom-plugin": "*"},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock(
+		testhelper.LockPackage{
+			Name: "acme/custom-plugin", Version: "1.0.0", Type: "shopware-platform-plugin",
+			Dist: map[string]string{"type": "path", "url": "custom/static-plugins/MyCustomPlugin"},
+		},
+	))
 
 	vendorDir := filepath.Join(dir, "vendor", "acme")
 	require.NoError(t, os.MkdirAll(vendorDir, 0o755))

--- a/internal/shop/pluginmigrate/pluginmigrate_test.go
+++ b/internal/shop/pluginmigrate/pluginmigrate_test.go
@@ -143,6 +143,50 @@ func TestScanFindsOnlyCustomExtensions(t *testing.T) {
 	assert.Equal(t, "3.1.0", scanned[1].Version)
 }
 
+func TestScanSkipsComposerManagedPathPlugins(t *testing.T) {
+	dir := setupProject(t)
+
+	writeFile(t, filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin", "composer.json"), `{
+		"name": "acme/custom-plugin",
+		"type": "shopware-platform-plugin",
+		"version": "1.0.0",
+		"require": {"shopware/core": "~6.7.0"},
+		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
+		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
+	}`)
+	writeFile(t, filepath.Join(dir, "composer.json"), `{
+		"name": "shopware/production",
+		"require": {"shopware/core": "6.7.3.0", "acme/custom-plugin": "*"}
+	}`)
+	writeFile(t, filepath.Join(dir, "composer.lock"), `{
+		"packages": [
+			{
+				"name": "acme/custom-plugin",
+				"version": "1.0.0",
+				"type": "shopware-platform-plugin",
+				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
+			}
+		],
+		"packages-dev": []
+	}`)
+
+	vendorDir := filepath.Join(dir, "vendor", "acme")
+	require.NoError(t, os.MkdirAll(vendorDir, 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin"),
+		filepath.Join(vendorDir, "custom-plugin"),
+	))
+
+	scanned := NewPluginMigrator(dir, nil).Scan(t.Context())
+	names := make([]string, 0, len(scanned))
+	for _, ext := range scanned {
+		names = append(names, ext.Name)
+	}
+	assert.NotContains(t, names, "MyCustomPlugin", "path-repository plugins Composer already manages must not be migrated again")
+	assert.Contains(t, names, "LocalPlugin")
+	assert.Contains(t, names, "StorePlugin")
+}
+
 func TestScanReturnsAbsolutePathsForRelativeProjectRoot(t *testing.T) {
 	dir := setupProject(t)
 	cwd, err := os.Getwd()

--- a/internal/shop/upgrade/compat.go
+++ b/internal/shop/upgrade/compat.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/shyim/go-version"
 
 	account_api "github.com/shopware/shopware-cli/internal/account-api"
+	"github.com/shopware/shopware-cli/internal/extension"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -61,7 +63,7 @@ func (u *ProjectUpgrader) loadStoreStatus(ctx context.Context, current, target *
 
 	toCheck := make([]account_api.UpdateCheckExtension, 0, len(extensions))
 	for _, ext := range extensions {
-		if !ext.ComposerManaged {
+		if !ext.ComposerManaged || ext.PathInstalled {
 			continue
 		}
 		v := ext.Version
@@ -96,7 +98,7 @@ func (u *ProjectUpgrader) loadStorePlugins(ctx context.Context, target *version.
 
 	names := make([]string, 0, len(extensions))
 	for _, ext := range extensions {
-		if ext.ComposerManaged {
+		if ext.ComposerManaged && !ext.PathInstalled {
 			names = append(names, ext.Name)
 		}
 	}
@@ -150,11 +152,18 @@ func classifyExtension(ctx context.Context, repos *repository.Set, target *versi
 		return res
 	}
 
+	// Path-repository packages have no published release stream. Judge them
+	// by the shopware/core constraint in the installed composer.json.
+	if ext.PathInstalled {
+		return classifyLocalConstraint(ctx, target, ext)
+	}
+
 	pkg, client, err := repos.GetPackage(ctx, ext.Package)
 	if err != nil {
-		res.Status = ExtBlocked
-		res.Detail = "The package was not found in any configured Composer repository."
-		return res
+		// Unpublished / private packages are missing from remote metadata
+		// the same way path packages are. Fall back to the installed
+		// constraint instead of treating "not on Packagist" as blocked.
+		return classifyLocalConstraint(ctx, target, ext)
 	}
 	if client != nil {
 		res.ChangelogURL = changelogURL(client.URL(), ext.Package)
@@ -213,20 +222,72 @@ func classifyExtension(ctx context.Context, repos *repository.Set, target *versi
 	return res
 }
 
+// classifyLocalConstraint judges an installed package by the Shopware
+// constraint it already declares (lock file, composer.json, or app manifest).
+// The installed files stay; only a constraint that excludes the target blocks.
+func classifyLocalConstraint(ctx context.Context, target *version.Version, ext InstalledExtension) ExtensionResult {
+	res := ExtensionResult{Extension: ext, Available: ext.Version}
+
+	constraint, raw := localShopwareConstraint(ctx, ext)
+	switch {
+	case constraint == nil:
+		res.Status = ExtReview
+		res.Detail = "The installed package does not declare Shopware compatibility; the Composer resolution check decides."
+	case target != nil && constraint.Check(target):
+		res.Status = ExtOK
+		res.Detail = "The installed release already supports the selected Shopware version."
+	default:
+		res.Status = ExtBlocked
+		res.Available = ""
+		if raw == "" {
+			res.Detail = "The installed package does not allow the selected Shopware version."
+		} else {
+			res.Detail = fmt.Sprintf("The installed package requires %s, which does not allow Shopware %s.", raw, target)
+		}
+	}
+	return res
+}
+
+func localShopwareConstraint(ctx context.Context, ext InstalledExtension) (*version.Constraints, string) {
+	if c, raw := shopwareConstraintFromRequire(ext.Require); c != nil {
+		return c, raw
+	}
+
+	if ext.Path != "" {
+		if cj, err := composer.ReadJson(filepath.Join(ext.Path, "composer.json")); err == nil {
+			if c, raw := shopwareConstraintFromRequire(cj.Require); c != nil {
+				return c, raw
+			}
+		}
+		if extObj, err := extension.GetExtensionByFolder(ctx, ext.Path); err == nil {
+			if c, err := extObj.GetShopwareVersionConstraint(); err == nil && c != nil {
+				return c, c.String()
+			}
+		}
+	}
+
+	return nil, ""
+}
+
 // shopwareConstraintOf extracts the Shopware platform constraint of a release.
 func shopwareConstraintOf(rel repository.Version) *version.Constraints {
+	c, _ := shopwareConstraintFromRequire(rel.Require)
+	return c
+}
+
+func shopwareConstraintFromRequire(require map[string]string) (*version.Constraints, string) {
 	for _, name := range shopwareConstraintPackages {
-		raw, ok := rel.Require[name]
+		raw, ok := require[name]
 		if !ok {
 			continue
 		}
 		c, err := version.NewConstraint(raw)
 		if err != nil {
-			return nil
+			return nil, raw
 		}
-		return &c
+		return &c, name + " " + raw
 	}
-	return nil
+	return nil, ""
 }
 
 // applyStoreStatus overlays the Store's verdict on the Composer-derived

--- a/internal/shop/upgrade/compat_test.go
+++ b/internal/shop/upgrade/compat_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/shyim/go-composer"
@@ -165,8 +166,8 @@ func TestCheckExtensionsPackageUnknownAndStoreDown(t *testing.T) {
 	})
 
 	require.Len(t, results, 1)
-	assert.Equal(t, ExtBlocked, results[0].Status)
-	assert.Contains(t, results[0].Detail, "not found")
+	assert.Equal(t, ExtReview, results[0].Status, "missing remote metadata without a local constraint is unknown, not blocked")
+	assert.Contains(t, results[0].Detail, "does not declare Shopware compatibility")
 	assert.Equal(t, "Not available in Store", results[0].StoreLabel)
 }
 
@@ -273,4 +274,78 @@ func TestClassifyExtensionWithoutConstraintMetadataIsReviewNotBlocked(t *testing
 
 	blocked := byName["SwagBlocked"]
 	assert.Equal(t, ExtBlocked, blocked.Status, "known constraints excluding the target still block")
+}
+
+func TestClassifyPathInstalledPluginUsesLocalConstraint(t *testing.T) {
+	dir := setupProject(t)
+	current, target := compatVersions(t)
+
+	u := compatUpgrader(t, dir, fakeProvider{}, nil, nil)
+
+	results := u.CheckExtensions(t.Context(), current, target, []InstalledExtension{
+		{
+			Name:            "MyCustomPlugin",
+			Package:         "acme/custom-plugin",
+			Version:         "1.0.0",
+			ComposerManaged: true,
+			PathInstalled:   true,
+			Require:         map[string]string{"shopware/core": "~6.7.0"},
+		},
+		{
+			Name:            "OldCustomPlugin",
+			Package:         "acme/old-plugin",
+			Version:         "1.0.0",
+			ComposerManaged: true,
+			PathInstalled:   true,
+			Require:         map[string]string{"shopware/core": "~6.6.0"},
+		},
+	})
+	require.Len(t, results, 2)
+
+	byName := make(map[string]ExtensionResult)
+	for _, r := range results {
+		byName[r.Extension.Name] = r
+	}
+
+	ok := byName["MyCustomPlugin"]
+	assert.Equal(t, ExtOK, ok.Status)
+	assert.Equal(t, "1.0.0", ok.Available)
+	assert.False(t, ok.Status.BlocksUpgrade())
+	assert.Contains(t, ok.Detail, "already supports")
+
+	blocked := byName["OldCustomPlugin"]
+	assert.Equal(t, ExtBlocked, blocked.Status)
+	assert.Empty(t, blocked.Available)
+	assert.True(t, blocked.Status.BlocksUpgrade())
+	assert.Contains(t, blocked.Detail, "shopware/core")
+	assert.Contains(t, blocked.Detail, "~6.6.0")
+}
+
+func TestClassifyUnpublishedPackageFallsBackToLocalComposerJSON(t *testing.T) {
+	dir := setupProject(t)
+	pluginDir := filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin")
+	writeFile(t, filepath.Join(pluginDir, "composer.json"), `{
+		"name": "acme/custom-plugin",
+		"type": "shopware-platform-plugin",
+		"version": "1.0.0",
+		"require": {"shopware/core": "~6.6.0 || ~6.7.0"},
+		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
+		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
+	}`)
+
+	current, target := compatVersions(t)
+	u := compatUpgrader(t, dir, fakeProvider{}, nil, nil)
+
+	results := u.CheckExtensions(t.Context(), current, target, []InstalledExtension{
+		{
+			Name:            "MyCustomPlugin",
+			Package:         "acme/custom-plugin",
+			Path:            pluginDir,
+			Version:         "1.0.0",
+			ComposerManaged: true,
+		},
+	})
+	require.Len(t, results, 1)
+	assert.Equal(t, ExtOK, results[0].Status, "local composer.json is used when the package is not on Packagist")
+	assert.Equal(t, "1.0.0", results[0].Available)
 }

--- a/internal/shop/upgrade/compat_test.go
+++ b/internal/shop/upgrade/compat_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	account_api "github.com/shopware/shopware-cli/internal/account-api"
+	"github.com/shopware/shopware-cli/internal/testhelper"
 )
 
 type fakeProvider map[string]*repository.Package
@@ -324,14 +325,9 @@ func TestClassifyPathInstalledPluginUsesLocalConstraint(t *testing.T) {
 func TestClassifyUnpublishedPackageFallsBackToLocalComposerJSON(t *testing.T) {
 	dir := setupProject(t)
 	pluginDir := filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin")
-	writeFile(t, filepath.Join(pluginDir, "composer.json"), `{
-		"name": "acme/custom-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.6.0 || ~6.7.0"},
-		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
-		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
-	}`)
+	pathPlugin := testhelper.PluginComposer("acme/custom-plugin", "1.0.0", `Acme\MyCustomPlugin\MyCustomPlugin`)
+	pathPlugin.Require = map[string]string{"shopware/core": "~6.6.0 || ~6.7.0"}
+	testhelper.WriteFile(t, filepath.Join(pluginDir, "composer.json"), pathPlugin.String())
 
 	current, target := compatVersions(t)
 	u := compatUpgrader(t, dir, fakeProvider{}, nil, nil)

--- a/internal/shop/upgrade/composerjson.go
+++ b/internal/shop/upgrade/composerjson.go
@@ -26,7 +26,7 @@ var shopwarePlatformPackages = []string{
 // the new platform — the web-installer approach), and makes sure the
 // Deployment Helper is required. It returns a human-readable list of the
 // changes it made.
-func applyTargetConstraints(c *composer.Json, target string, extensionPackages []string, resolved map[string]string) []string {
+func applyTargetConstraints(c *composer.Json, target string, extensionPackages []string, resolved map[string]string, pathInstalled map[string]bool) []string {
 	var changes []string
 
 	for _, pkg := range shopwarePlatformPackages {
@@ -47,6 +47,11 @@ func applyTargetConstraints(c *composer.Json, target string, extensionPackages [
 		}
 		current, ok := c.Require[pkg]
 		if !ok {
+			continue
+		}
+		// Path-repository packages stay at their local files; opening the
+		// constraint to "*" cannot discover a newer published release.
+		if pathInstalled[pkg] {
 			continue
 		}
 		constraint := "*"
@@ -86,6 +91,22 @@ func extensionPackages(projectRoot string) ([]string, error) {
 	return packages, nil
 }
 
+// pathInstalledPackageNames lists Composer packages installed from a path
+// repository (composer.lock dist.type == "path").
+func pathInstalledPackageNames(projectRoot string) map[string]bool {
+	info := lockExtensionInfo(projectRoot)
+	if len(info) == 0 {
+		return nil
+	}
+	names := make(map[string]bool, len(info))
+	for name, ext := range info {
+		if ext.pathInstalled {
+			names[name] = true
+		}
+	}
+	return names
+}
+
 // RewriteComposerJSON applies the target constraints to the project's real
 // composer.json and saves it, pinning extensions to the versions the
 // preflight resolution picked. Used by the runner after the user confirmed
@@ -101,7 +122,7 @@ func (u *ProjectUpgrader) RewriteComposerJSON(target string, resolved map[string
 		return nil, err
 	}
 
-	changes := applyTargetConstraints(c, target, extensions, resolved)
+	changes := applyTargetConstraints(c, target, extensions, resolved, pathInstalledPackageNames(u.projectRoot))
 	if err := c.Save(); err != nil {
 		return nil, err
 	}
@@ -122,7 +143,7 @@ func (u *ProjectUpgrader) renderUpgradeManifest(target string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	applyTargetConstraints(c, target, extensions, nil)
+	applyTargetConstraints(c, target, extensions, nil, pathInstalledPackageNames(u.projectRoot))
 
 	out, err := json.MarshalIndent(c, "", "    ")
 	if err != nil {

--- a/internal/shop/upgrade/composerjson_test.go
+++ b/internal/shop/upgrade/composerjson_test.go
@@ -56,29 +56,24 @@ func TestRewriteComposerJSON(t *testing.T) {
 
 func TestRewriteComposerJSONKeepsPathRepositoryConstraints(t *testing.T) {
 	dir := setupPathPluginProject(t)
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {
-			"shopware/core": "6.7.3.0",
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.json"), testhelper.ComposerJSON{
+		Name: "shopware/production",
+		Require: map[string]string{
+			"shopware/core":              "6.7.3.0",
 			"shopware/deployment-helper": "*",
-			"acme/custom-plugin": "1.0.0",
-			"swag/demo": "^2.0"
-		}
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{
-		"packages": [
-			{"name": "shopware/core", "version": "v6.7.3.0"},
-			{"name": "swag/demo", "version": "2.0.0", "type": "shopware-platform-plugin"},
-			{
-				"name": "acme/custom-plugin",
-				"version": "1.0.0",
-				"type": "shopware-platform-plugin",
-				"require": {"shopware/core": "~6.7.0"},
-				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
-			}
-		],
-		"packages-dev": []
-	}`)
+			"acme/custom-plugin":         "1.0.0",
+			"swag/demo":                  "^2.0",
+		},
+	}.String())
+	testhelper.WriteFile(t, filepath.Join(dir, "composer.lock"), testhelper.ComposerLock(
+		testhelper.LockPackage{Name: "shopware/core", Version: "v6.7.3.0"},
+		testhelper.LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
+		testhelper.LockPackage{
+			Name: "acme/custom-plugin", Version: "1.0.0", Type: "shopware-platform-plugin",
+			Require: map[string]string{"shopware/core": "~6.7.0"},
+			Dist:    map[string]string{"type": "path", "url": "custom/static-plugins/MyCustomPlugin"},
+		},
+	))
 
 	changes, err := newTestUpgrader(t, dir).RewriteComposerJSON("6.7.11.0", map[string]string{"swag/demo": "2.1.3"})
 	require.NoError(t, err)

--- a/internal/shop/upgrade/composerjson_test.go
+++ b/internal/shop/upgrade/composerjson_test.go
@@ -54,6 +54,50 @@ func TestRewriteComposerJSON(t *testing.T) {
 	assert.NotContains(t, parsed.Require, "shopware/elasticsearch", "absent platform packages are not added")
 }
 
+func TestRewriteComposerJSONKeepsPathRepositoryConstraints(t *testing.T) {
+	dir := setupPathPluginProject(t)
+	writeFile(t, filepath.Join(dir, "composer.json"), `{
+		"name": "shopware/production",
+		"require": {
+			"shopware/core": "6.7.3.0",
+			"shopware/deployment-helper": "*",
+			"acme/custom-plugin": "1.0.0",
+			"swag/demo": "^2.0"
+		}
+	}`)
+	writeFile(t, filepath.Join(dir, "composer.lock"), `{
+		"packages": [
+			{"name": "shopware/core", "version": "v6.7.3.0"},
+			{"name": "swag/demo", "version": "2.0.0", "type": "shopware-platform-plugin"},
+			{
+				"name": "acme/custom-plugin",
+				"version": "1.0.0",
+				"type": "shopware-platform-plugin",
+				"require": {"shopware/core": "~6.7.0"},
+				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
+			}
+		],
+		"packages-dev": []
+	}`)
+
+	changes, err := newTestUpgrader(t, dir).RewriteComposerJSON("6.7.11.0", map[string]string{"swag/demo": "2.1.3"})
+	require.NoError(t, err)
+	assert.Contains(t, changes, "shopware/core: 6.7.3.0 -> 6.7.11.0")
+	assert.Contains(t, changes, "swag/demo: ^2.0 -> 2.1.3")
+	for _, change := range changes {
+		assert.NotContains(t, change, "acme/custom-plugin")
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "composer.json"))
+	require.NoError(t, err)
+	var parsed struct {
+		Require map[string]string `json:"require"`
+	}
+	require.NoError(t, json.Unmarshal(content, &parsed))
+	assert.Equal(t, "1.0.0", parsed.Require["acme/custom-plugin"])
+	assert.Equal(t, "2.1.3", parsed.Require["swag/demo"])
+}
+
 func TestRenderUpgradeManifestLeavesProjectUntouched(t *testing.T) {
 	dir := t.TempDir()
 	original := `{

--- a/internal/shop/upgrade/readiness.go
+++ b/internal/shop/upgrade/readiness.go
@@ -138,9 +138,10 @@ func checkDeploymentHelper(projectRoot string) ReadinessCheck {
 
 // checkExtensionsComposerManaged enforces that every extension is managed
 // through Composer: the upgrade resolves and pins extension versions with
-// Composer, so extensions living outside vendor/ (e.g. custom/plugins) are
-// invisible to it and would silently stay on their current, possibly
-// incompatible release.
+// Composer, so extensions living outside Composer (e.g. custom/plugins copies
+// that are not required) are invisible to it and would silently stay on their
+// current, possibly incompatible release. Path-repository packages under
+// custom/static-plugins count as managed.
 func checkExtensionsComposerManaged(extensions []InstalledExtension) ReadinessCheck {
 	check := ReadinessCheck{
 		ID:       "extensions",
@@ -207,9 +208,11 @@ func (u *ProjectUpgrader) checkTooling(ctx context.Context) ReadinessCheck {
 }
 
 // discoverExtensions lists the project's extensions, marking whether each is
-// Composer-managed (living in vendor/) or a local extension in custom/.
+// Composer-managed (recorded in composer.lock / living in vendor/) or a local
+// extension in custom/ that Composer does not know about.
 func discoverExtensions(ctx context.Context, projectRoot string) []InstalledExtension {
 	found := extension.FindExtensionsFromProject(logging.DisableLogger(ctx), projectRoot, false)
+	lockInfo := lockExtensionInfo(projectRoot)
 
 	vendorDir := filepath.Clean(filepath.Join(projectRoot, "vendor"))
 
@@ -228,8 +231,16 @@ func discoverExtensions(ctx context.Context, projectRoot string) []InstalledExte
 		}
 
 		rel, err := filepath.Rel(vendorDir, filepath.Clean(ext.GetPath()))
-		isManaged := err == nil && rel != "." && rel != ".." &&
+		underVendor := err == nil && rel != "." && rel != ".." &&
 			!strings.HasPrefix(rel, ".."+string(filepath.Separator))
+
+		info := lockInfo[pkg]
+		isManaged := underVendor || info.inLock
+
+		require := info.require
+		if len(require) == 0 {
+			require = extensionRequire(ext)
+		}
 
 		result = append(result, InstalledExtension{
 			Name:            name,
@@ -237,8 +248,52 @@ func discoverExtensions(ctx context.Context, projectRoot string) []InstalledExte
 			Path:            ext.GetPath(),
 			Version:         ver,
 			ComposerManaged: isManaged,
+			PathInstalled:   info.pathInstalled,
+			Require:         require,
 		})
 	}
 
 	return result
+}
+
+type lockExtInfo struct {
+	require       map[string]string
+	pathInstalled bool
+	inLock        bool
+}
+
+// lockExtensionInfo indexes composer.lock packages by name.
+func lockExtensionInfo(projectRoot string) map[string]lockExtInfo {
+	lock, err := composer.ReadLock(filepath.Join(projectRoot, "composer.lock"))
+	if err != nil {
+		return nil
+	}
+
+	info := make(map[string]lockExtInfo, len(lock.Packages)+len(lock.PackagesDev))
+	add := func(pkgs []composer.LockPackage) {
+		for _, pkg := range pkgs {
+			info[pkg.Name] = lockExtInfo{
+				require:       pkg.Require,
+				pathInstalled: pkg.Dist.Type == "path",
+				inLock:        true,
+			}
+		}
+	}
+	add(lock.Packages)
+	add(lock.PackagesDev)
+	return info
+}
+
+// extensionRequire reads the Shopware-relevant require map from a discovered
+// extension. Platform plugins and bundles expose it on their composer.json;
+// apps typically do not.
+func extensionRequire(ext extension.Extension) map[string]string {
+	switch e := ext.(type) {
+	case *extension.PlatformPlugin:
+		return e.Composer.Require
+	case *extension.ShopwareBundle:
+		return e.Composer.Require
+	default:
+		return nil
+	}
 }

--- a/internal/shop/upgrade/readiness_test.go
+++ b/internal/shop/upgrade/readiness_test.go
@@ -19,6 +19,52 @@ var testComposerLock = testhelper.ComposerLock(
 	testhelper.LockPackage{Name: "swag/demo", Version: "2.0.0", Type: "shopware-platform-plugin"},
 )
 
+func setupPathPluginProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "composer.json"), `{
+		"name": "shopware/production",
+		"require": {
+			"shopware/core": "6.7.3.0",
+			"shopware/deployment-helper": "*",
+			"acme/custom-plugin": "*"
+		},
+		"repositories": [
+			{"type": "path", "url": "custom/static-plugins/*", "options": {"symlink": true}}
+		]
+	}`)
+	writeFile(t, filepath.Join(dir, "composer.lock"), `{
+		"packages": [
+			{"name": "shopware/core", "version": "v6.7.3.0"},
+			{
+				"name": "acme/custom-plugin",
+				"version": "1.0.0",
+				"type": "shopware-platform-plugin",
+				"require": {"shopware/core": "~6.7.0"},
+				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
+			}
+		],
+		"packages-dev": []
+	}`)
+
+	pluginDir := filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin")
+	writeFile(t, filepath.Join(pluginDir, "composer.json"), `{
+		"name": "acme/custom-plugin",
+		"type": "shopware-platform-plugin",
+		"version": "1.0.0",
+		"require": {"shopware/core": "~6.7.0"},
+		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
+		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
+	}`)
+
+	vendorDir := filepath.Join(dir, "vendor", "acme")
+	require.NoError(t, os.MkdirAll(vendorDir, 0o755))
+	require.NoError(t, os.Symlink(pluginDir, filepath.Join(vendorDir, "custom-plugin")))
+
+	return dir
+}
+
 func setupProject(t *testing.T) string {
 	t.Helper()
 
@@ -86,6 +132,24 @@ func TestRunReadinessChecks(t *testing.T) {
 		names[e.Name] = e.ComposerManaged
 	}
 	assert.Equal(t, map[string]bool{"Demo": true, "LocalPlugin": false}, names)
+}
+
+func TestDiscoverExtensionsPathRepositoryIsComposerManaged(t *testing.T) {
+	dir := setupPathPluginProject(t)
+
+	r := newTestUpgrader(t, dir).RunReadinessChecks(t.Context())
+
+	ext := checkByID(t, r.Checks, "extensions")
+	assert.Equal(t, StateOK, ext.State)
+	assert.Equal(t, "1 of 1", ext.Value)
+	assert.False(t, r.Blocked())
+
+	require.Len(t, r.Extensions, 1)
+	assert.Equal(t, "MyCustomPlugin", r.Extensions[0].Name)
+	assert.Equal(t, "acme/custom-plugin", r.Extensions[0].Package)
+	assert.True(t, r.Extensions[0].ComposerManaged)
+	assert.True(t, r.Extensions[0].PathInstalled)
+	assert.Equal(t, "~6.7.0", r.Extensions[0].Require["shopware/core"])
 }
 
 func TestReadinessAllExtensionsComposerManaged(t *testing.T) {

--- a/internal/shop/upgrade/readiness_test.go
+++ b/internal/shop/upgrade/readiness_test.go
@@ -21,48 +21,39 @@ var testComposerLock = testhelper.ComposerLock(
 
 func setupPathPluginProject(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
 
-	writeFile(t, filepath.Join(dir, "composer.json"), `{
-		"name": "shopware/production",
-		"require": {
-			"shopware/core": "6.7.3.0",
-			"shopware/deployment-helper": "*",
-			"acme/custom-plugin": "*"
-		},
-		"repositories": [
-			{"type": "path", "url": "custom/static-plugins/*", "options": {"symlink": true}}
-		]
-	}`)
-	writeFile(t, filepath.Join(dir, "composer.lock"), `{
-		"packages": [
-			{"name": "shopware/core", "version": "v6.7.3.0"},
-			{
-				"name": "acme/custom-plugin",
-				"version": "1.0.0",
-				"type": "shopware-platform-plugin",
-				"require": {"shopware/core": "~6.7.0"},
-				"dist": {"type": "path", "url": "custom/static-plugins/MyCustomPlugin"}
-			}
-		],
-		"packages-dev": []
-	}`)
+	pathPlugin := testhelper.PluginComposer("acme/custom-plugin", "1.0.0", `Acme\MyCustomPlugin\MyCustomPlugin`)
+	pathPlugin.Require = map[string]string{"shopware/core": "~6.7.0"}
 
-	pluginDir := filepath.Join(dir, "custom", "static-plugins", "MyCustomPlugin")
-	writeFile(t, filepath.Join(pluginDir, "composer.json"), `{
-		"name": "acme/custom-plugin",
-		"type": "shopware-platform-plugin",
-		"version": "1.0.0",
-		"require": {"shopware/core": "~6.7.0"},
-		"extra": {"shopware-plugin-class": "Acme\\MyCustomPlugin\\MyCustomPlugin", "label": {"en-GB": "Custom"}},
-		"autoload": {"psr-4": {"Acme\\MyCustomPlugin\\": "src/"}}
-	}`)
+	p := testhelper.NewProject(t).
+		File("composer.json", testhelper.ComposerJSON{
+			Name: "shopware/production",
+			Require: map[string]string{
+				"shopware/core":              "6.7.3.0",
+				"shopware/deployment-helper": "*",
+				"acme/custom-plugin":         "*",
+			},
+			Repositories: []map[string]any{
+				{"type": "path", "url": "custom/static-plugins/*", "options": map[string]any{"symlink": true}},
+			},
+		}.String()).
+		File("composer.lock", testhelper.ComposerLock(
+			testhelper.LockPackage{Name: "shopware/core", Version: "v6.7.3.0"},
+			testhelper.LockPackage{
+				Name: "acme/custom-plugin", Version: "1.0.0", Type: "shopware-platform-plugin",
+				Require: map[string]string{"shopware/core": "~6.7.0"},
+				Dist:    map[string]string{"type": "path", "url": "custom/static-plugins/MyCustomPlugin"},
+			},
+		)).
+		File("custom/static-plugins/MyCustomPlugin/composer.json", pathPlugin.String()).
+		Dir("vendor/acme")
 
-	vendorDir := filepath.Join(dir, "vendor", "acme")
-	require.NoError(t, os.MkdirAll(vendorDir, 0o755))
-	require.NoError(t, os.Symlink(pluginDir, filepath.Join(vendorDir, "custom-plugin")))
+	require.NoError(t, os.Symlink(
+		filepath.Join(p.Root, "custom", "static-plugins", "MyCustomPlugin"),
+		filepath.Join(p.Root, "vendor", "acme", "custom-plugin"),
+	))
 
-	return dir
+	return p.Root
 }
 
 func setupProject(t *testing.T) string {

--- a/internal/shop/upgrade/types.go
+++ b/internal/shop/upgrade/types.go
@@ -38,13 +38,23 @@ func (c ReadinessCheck) Failed() bool {
 }
 
 // InstalledExtension is an extension found in the project, either managed
-// through Composer (vendor/) or locally in custom/plugins and friends.
+// through Composer (vendor/ or a path repository) or locally in custom/plugins
+// and friends.
 type InstalledExtension struct {
 	Name            string // technical name, e.g. SwagPayPal
 	Package         string // composer package name, e.g. swag/paypal
 	Path            string
 	Version         string
 	ComposerManaged bool
+	// PathInstalled is true when Composer installed the package from a path
+	// repository (composer.lock dist.type == "path"). The installed files are
+	// the local project copy — typically under custom/static-plugins — not a
+	// published release that can be version-bumped independently.
+	PathInstalled bool
+	// Require is the package's composer.json/lock require map when known.
+	// Used to classify path and other unpublished packages against the
+	// target Shopware version.
+	Require map[string]string
 }
 
 // Readiness is the result of RunReadinessChecks.

--- a/internal/tui/upgrade/model_test.go
+++ b/internal/tui/upgrade/model_test.go
@@ -591,6 +591,27 @@ func TestPreparePanelComposerBlocked(t *testing.T) {
 	assert.Equal(t, panelPrepare, w.m.panel)
 }
 
+func TestExtensionDetailPathInstalledBlocked(t *testing.T) {
+	result := backend.ExtensionResult{
+		Extension: backend.InstalledExtension{
+			Name:            "MyCustomPlugin",
+			Package:         "acme/custom-plugin",
+			Version:         "1.0.0",
+			ComposerManaged: true,
+			PathInstalled:   true,
+			Path:            "custom/static-plugins/MyCustomPlugin",
+		},
+		Status: backend.ExtBlocked,
+		Detail: "The installed package requires shopware/core ~6.6.0, which does not allow Shopware 6.7.11.0.",
+	}
+	detail := newExtensionDetail(result, "Target 6.7.11.0")
+	content := ansi.Strip(detail.View(110, 34))
+	assert.Contains(t, content, "Blocked local extension")
+	assert.Contains(t, content, "Update the plugin's shopware/core constraint")
+	assert.Contains(t, content, "custom/static-plugins/MyCustomPlug")
+	assert.NotContains(t, content, "Ask the vendor for a compatible release")
+}
+
 func TestExtensionDetailOverlay(t *testing.T) {
 	// A failed resolve keeps the metadata blocker (a successful one would
 	// disprove and downgrade it).

--- a/internal/tui/upgrade/overlay_extension_detail.go
+++ b/internal/tui/upgrade/overlay_extension_detail.go
@@ -54,6 +54,10 @@ func (d *extensionDetail) headline() (title, badge string, kind tui.Variant, tex
 		return "Replace extension", "REPLACE REQUIRED", tui.VariantError,
 			"This extension is deprecated and has no planned support for the selected Shopware version."
 	case backend.ExtBlocked:
+		if d.result.Extension.PathInstalled {
+			return "Blocked local extension", "BLOCKED", tui.VariantError,
+				"The installed local plugin does not allow the selected Shopware version."
+		}
 		return "Blocked extension", "BLOCKED", tui.VariantError,
 			"No compatible Composer release exists for the selected Shopware version."
 	case backend.ExtReview:
@@ -124,7 +128,7 @@ func (d *extensionDetail) viewLeft() string {
 		b.WriteString(tui.LabelStyle.Render(r.Extension.Package))
 		b.WriteString("\n\n")
 	}
-	if r.Extension.Path != "" && !r.Extension.ComposerManaged {
+	if r.Extension.Path != "" && (!r.Extension.ComposerManaged || r.Extension.PathInstalled) {
 		b.WriteString(tui.BoldStyle.Render("Path"))
 		b.WriteString("\n")
 		b.WriteString("  ")
@@ -172,9 +176,15 @@ func (d *extensionDetail) viewRight() string {
 		bullet("Remove it if no longer needed")
 		bullet("Recheck compatibility")
 	case backend.ExtBlocked:
-		bullet("Ask the vendor for a compatible release")
-		bullet("Remove or replace the extension")
-		bullet("Recheck compatibility")
+		if r.Extension.PathInstalled {
+			bullet("Update the plugin's shopware/core constraint")
+			bullet("Or make the plugin compatible with the target")
+			bullet("Recheck compatibility")
+		} else {
+			bullet("Ask the vendor for a compatible release")
+			bullet("Remove or replace the extension")
+			bullet("Recheck compatibility")
+		}
 	case backend.ExtReview:
 		bullet("Review the extension code for breaking changes")
 		bullet("Test it against the target version")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/shopware/shopware-cli/issues/1463

## What changed?

`shopware-cli project upgrade` treated Composer path-repository plugins (typically under `custom/static-plugins`) as missing Packagist packages, so compatibility showed `1.0.0 -> none` and blocked the upgrade. `project autofix composer-plugins` also re-scanned those already-managed plugins after resolving vendor symlinks back into `custom/`, then failed on `composer require`.

- Path and other unpublished packages are now classified from the installed `composer.json` / lock `require` (usually `shopware/core`). A constraint that allows the target is OK; one that does not still blocks, with the actual constraint in the message.
- Autofix skips packages already present in `composer.lock` or `composer.json` require.
- Upgrade rewrites no longer open path packages to `*`.

## Why?

Plugin developers keep local plugins in `custom/static-plugins` and manage them with Composer path repositories. The upgrade wizard should check those plugins' own Shopware constraints instead of looking for a published release that does not exist.

## How was this tested?

Unit tests covering the reported layout (`custom/static-plugins/*` path repo, lock `dist.type: path`, vendor symlink):

- Compatible `~6.7.0` → `ExtOK`, available `1.0.0`
- Incompatible `~6.6.0` → `ExtBlocked` with the constraint in the detail
- Autofix scan no longer lists an already-managed path plugin
- Readiness treats the path plugin as Composer-managed
- Overlay copy for a blocked local plugin points at the `shopware/core` constraint instead of “ask the vendor”

```
go test ./internal/shop/upgrade/ ./internal/shop/pluginmigrate/ ./internal/tui/upgrade/ ./internal/tui/pluginmigrate/
```

## Related issue or discussion

https://github.com/shopware/shopware-cli/issues/1463

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e25f0e-3ae7-4bf4-b3ce-0beb21f781fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e25f0e-3ae7-4bf4-b3ce-0beb21f781fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Composer-managed extensions, including local path-based plugins, from being offered for migration again.
  - Improved compatibility checks for local and unpublished extensions using their declared Shopware requirements.
  - Extensions without remote metadata are now flagged for review instead of being incorrectly blocked.
  - Upgrade preparation now preserves constraints for locally installed path-based extensions.

- **User Experience**
  - Added clearer upgrade guidance and status messaging for blocked local extensions.
  - Local extension paths are now shown in relevant upgrade details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->