### PR TITLE
Deprecate `project upgrade-check` for October 2026

### DIFF
--- a/cmd/project/project_upgrade_check.go
+++ b/cmd/project/project_upgrade_check.go
@@ -24,8 +24,9 @@ import (
 )
 
 var projectUpgradeCheckCmd = &cobra.Command{
-	Use:   "upgrade-check",
-	Short: "Check that installed extensions are compatible with a future Shopware version",
+	Use:        "upgrade-check",
+	Short:      "Check that installed extensions are compatible with a future Shopware version",
+	Deprecated: "Will be removed in October 2026",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var shopwareVersion *version.Version
 		var extensions map[string]string


### PR DESCRIPTION
## What changed?

`shopware-cli project upgrade-check` now prints a Cobra deprecation notice and stays fully executable.

Example when the command is used or `--help` is shown:

```
Command "upgrade-check" is deprecated, will be removed in October 2026
```

The command is hidden from parent `--help` listings, which is Cobra's default for deprecated commands, but it can still be invoked by name.

## Why?

`upgrade-check` is being replaced by the guided `project upgrade` flow. Keep a deprecation window before removal in October 2026, matching `project generate-jwt` and `extension prepare`.

## How was this tested?

The change only sets Cobra's `Deprecated` field. Cobra prints the notice and hides the command from parent help automatically.

## Related issue or discussion

—