### PR TITLE
Improve Docker setup wizard copy

### DIFF
--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -197,9 +197,13 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, releases []repositor
 
 		if !cmd.PersistentFlags().Changed("docker") {
 			formGroups = append(formGroups, huh.NewGroup(
-				tui.NewYesNo().
+				huh.NewSelect[string]().
 					Title("Docker").
-					Description("Use Docker for local setup.").
+					Description("How do you want to run Shopware?").
+					Options(
+						huh.NewOption("Yes — Run Shopware with Docker", tui.Yes),
+						huh.NewOption("No — Use PHP and Composer; Shopware CLI handles the installation", tui.No),
+					).
 					Value(&selectDocker),
 			))
 		}


### PR DESCRIPTION
## What changed?
_If this PR makes TUI or CLI output changes, please add screenshots or examples that show the before and after behavior._

I showed this on the screen during retro 

## Why?

So users know what "No" means/that you can use the CLI without Docker -- some confusion there

## How was this tested?
go test, go build ...

## Related issue or discussion

https://github.com/shopware/shopware-cli/issues/1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Improved the Docker setup prompt during project creation with clearer, more descriptive options.
  * Explained the difference between running Shopware with Docker and using PHP, Composer, and Shopware CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->