### PR TITLE
fix(proxy): isolate shared-network service names between parallel projects

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -336,7 +336,7 @@ func consoleService(opts *ComposeOptions, webEnv yamlMap[string], webDependsOn y
 	// over TLS, so in proxy mode they join the proxy network (the CA and
 	// APP_URL env come from the shared webEnv). They publish no HTTP route.
 	if px := opts.proxy(); px != nil {
-		svc.Networks = []string{"default", px.NetworkName}
+		svc.Networks = proxyNetworks(px.NetworkName, "")
 	}
 
 	return svc
@@ -345,8 +345,10 @@ func consoleService(opts *ComposeOptions, webEnv yamlMap[string], webDependsOn y
 func baseWebEnv(px *ProxyOptions) yamlMap[string] {
 	webEnv := yamlMap[string]{}.
 		set("HOST", "0.0.0.0").
+		// database is not on the shared network (it publishes a loopback port), so
+		// its bare host never collides; shared-network services use proxyServiceHost.
 		set("DATABASE_URL", "mysql://root:root@database/shopware").
-		set("MAILER_DSN", "smtp://mailer:1025")
+		set("MAILER_DSN", "smtp://"+proxyServiceHost(px, "mailer")+":1025")
 
 	// In proxy mode Traefik terminates TLS and forwards plain HTTP from a
 	// private container address, so Shopware must trust its X-Forwarded-*
@@ -382,12 +384,12 @@ func applyLockEnv(webEnv yamlMap[string], px *ProxyOptions, features LockFeature
 	case features.RedisMessenger:
 		webEnv = webEnv.set("MESSENGER_TRANSPORT_DSN", redisMessengerDSN)
 	case features.AMQP:
-		webEnv = webEnv.set("MESSENGER_TRANSPORT_DSN", "amqp://guest:guest@lavinmq:5672")
+		webEnv = webEnv.set("MESSENGER_TRANSPORT_DSN", "amqp://guest:guest@"+proxyServiceHost(px, "lavinmq")+":5672")
 	}
 
 	if features.Elasticsearch {
 		webEnv = webEnv.
-			set("OPENSEARCH_URL", "http://opensearch:9200").
+			set("OPENSEARCH_URL", "http://"+proxyServiceHost(px, "opensearch")+":9200").
 			set("SHOPWARE_ES_ENABLED", "1").
 			set("SHOPWARE_ES_INDEXING_ENABLED", "1").
 			set("SHOPWARE_ES_INDEX_PREFIX", "sw")
@@ -488,7 +490,7 @@ func applyS3Env(webEnv yamlMap[string], px *ProxyOptions) yamlMap[string] {
 	return webEnv.
 		set("K8S_FILESYSTEM_PRIVATE_BUCKET", "shopware-private").
 		set("K8S_FILESYSTEM_PUBLIC_BUCKET", "shopware-public").
-		set("K8S_FILESYSTEM_ENDPOINT", "http://rustfs:9000").
+		set("K8S_FILESYSTEM_ENDPOINT", "http://"+proxyServiceHost(px, "rustfs")+":9000").
 		set("K8S_FILESYSTEM_PUBLIC_URL", publicURL).
 		set("K8S_FILESYSTEM_REGION", "us-east-1").
 		set("AWS_ACCESS_KEY_ID", rustfsAccessKey).

--- a/internal/docker/compose_proxy.go
+++ b/internal/docker/compose_proxy.go
@@ -136,20 +136,52 @@ func webProxyRoutes(p *ProxyOptions) []proxyRoute {
 	}
 }
 
+// proxyServiceAlias is the project-unique name a proxied service advertises on
+// the shared network, so parallel projects don't collide on the bare service
+// name there (issue #1484). Matches the Traefik router prefix (dots to dashes).
+func proxyServiceAlias(hostname, serviceName string) string {
+	return strings.ReplaceAll(hostname, ".", "-") + "-" + serviceName
+}
+
+// proxyServiceHost is the host web/console use to reach serviceName: the bare
+// name in plain mode, the project-unique alias in proxy mode (issue #1484).
+func proxyServiceHost(px *ProxyOptions, serviceName string) string {
+	if px == nil {
+		return serviceName
+	}
+
+	return proxyServiceAlias(px.Hostname, serviceName)
+}
+
+// proxyNetworks attaches a service to the default and shared proxy networks;
+// alias, when set, is the project-unique name it advertises on the shared one.
+func proxyNetworks(networkName, alias string) yamlMap[composeServiceNetwork] {
+	shared := composeServiceNetwork{}
+	if alias != "" {
+		shared.Aliases = []string{alias}
+	}
+
+	return yamlMap[composeServiceNetwork]{}.
+		set("default", composeServiceNetwork{}).
+		set(networkName, shared)
+}
+
 // addProxyRouting joins serviceName to the shared proxy network and adds a
 // Traefik router per route. buildCompose calls it in proxy mode instead of
 // publishing fixed host ports.
 func addProxyRouting(svc *composeService, p *ProxyOptions, serviceName string, routes ...proxyRoute) {
-	svc.Networks = []string{"default", p.NetworkName}
+	// Router/service names must be unique across every project sharing the one
+	// Traefik instance, so they are prefixed with the project's own hostname
+	// (dots replaced, since Traefik router names must be alphanumeric).
+	routerPrefix := proxyServiceAlias(p.Hostname, serviceName)
+
+	// The service advertises that same alias on the shared network, so internal
+	// calls resolve to it and not to a parallel project's service (#1484).
+	svc.Networks = proxyNetworks(p.NetworkName, routerPrefix)
 
 	labels := yamlMap[string]{}.
 		set("traefik.enable", "true").
 		set("traefik.docker.network", p.NetworkName)
-
-	// Router/service names must be unique across every project sharing the one
-	// Traefik instance, so they are prefixed with the project's own hostname
-	// (dots replaced, since Traefik router names must be alphanumeric).
-	routerPrefix := strings.ReplaceAll(p.Hostname, ".", "-") + "-" + serviceName
 
 	for _, route := range routes {
 		name := route.nameSuffix

--- a/internal/docker/compose_proxy_test.go
+++ b/internal/docker/compose_proxy_test.go
@@ -147,7 +147,7 @@ func TestGenerateComposeFileProxyRoutesRustfs(t *testing.T) {
 	assert.Contains(t, out, "Host(`s3.my-shop.shopware.local`)")
 	assert.Contains(t, out, "Host(`rustfs.my-shop.shopware.local`)")
 	assert.Contains(t, out, "K8S_FILESYSTEM_PUBLIC_URL: https://s3.my-shop.shopware.local/shopware-public")
-	assert.Contains(t, out, "K8S_FILESYSTEM_ENDPOINT: http://rustfs:9000")
+	assert.Contains(t, out, "K8S_FILESYSTEM_ENDPOINT: http://my-shop-shopware-local-rustfs:9000")
 	assert.Contains(t, out, "127.0.0.1::3306")
 	assert.NotContains(t, out, "127.0.0.1::6379")
 	assert.NotContains(t, out, "9000:9000")
@@ -169,4 +169,70 @@ func TestGenerateComposeFilePlainModeHasPorts(t *testing.T) {
 	assert.NotContains(t, out, "traefik.enable")
 	assert.NotContains(t, out, "external: true")
 	assert.NotContains(t, out, "Host(`")
+}
+
+// TestGenerateComposeFileProxyInternalAliases guards issue #1484: on the shared
+// proxy network every project's services would otherwise advertise the same
+// bare name (opensearch, mailer, ...), so an internal call from one project
+// could reach another's container. In proxy mode the services must join the
+// shared network under a project-unique alias, and web/console must address
+// them by that alias.
+func TestGenerateComposeFileProxyInternalAliases(t *testing.T) {
+	t.Parallel()
+
+	lock := &composer.Lock{
+		Packages: []composer.LockPackage{
+			{Name: "shopware/core", Version: "6.6.0.0"},
+			{Name: "symfony/amqp-messenger", Version: "v7.0.0"},
+			{Name: "shopware/elasticsearch", Version: "6.6.0.0"},
+		},
+	}
+
+	out, err := GenerateComposeFile(lock, proxyComposeOptions())
+	require.NoError(t, err)
+	compose := string(out)
+
+	// Internal traffic uses the project-unique alias, not the bare service name.
+	assert.Contains(t, compose, "MAILER_DSN: smtp://my-shop-shopware-local-mailer:1025")
+	assert.Contains(t, compose, "OPENSEARCH_URL: http://my-shop-shopware-local-opensearch:9200")
+	assert.Contains(t, compose, "MESSENGER_TRANSPORT_DSN: amqp://guest:guest@my-shop-shopware-local-lavinmq:5672")
+
+	// The bare, collision-prone forms must be gone in proxy mode.
+	assert.NotContains(t, compose, "http://opensearch:9200")
+	assert.NotContains(t, compose, "smtp://mailer:1025")
+	assert.NotContains(t, compose, "amqp://guest:guest@lavinmq:5672")
+
+	// Each proxied service advertises the project-unique alias on the shared
+	// network, so parallel projects never collide on the bare name there.
+	assert.Contains(t, compose, "- my-shop-shopware-local-opensearch")
+	assert.Contains(t, compose, "- my-shop-shopware-local-mailer")
+	assert.Contains(t, compose, "- my-shop-shopware-local-lavinmq")
+
+	// The database is not on the shared network (it publishes a loopback port),
+	// so it keeps the bare host and never collided.
+	assert.Contains(t, compose, "DATABASE_URL: mysql://root:root@database/shopware")
+}
+
+// TestGenerateComposeFilePlainModeKeepsBareServiceHosts is the regression guard
+// for the alias change: without proxy mode, services are addressed by their
+// bare names (no shared network, no collision to avoid).
+func TestGenerateComposeFilePlainModeKeepsBareServiceHosts(t *testing.T) {
+	t.Parallel()
+
+	lock := &composer.Lock{
+		Packages: []composer.LockPackage{
+			{Name: "shopware/core", Version: "6.6.0.0"},
+			{Name: "symfony/amqp-messenger", Version: "v7.0.0"},
+			{Name: "shopware/elasticsearch", Version: "6.6.0.0"},
+		},
+	}
+
+	out, err := GenerateComposeFile(lock, nil)
+	require.NoError(t, err)
+	compose := string(out)
+
+	assert.Contains(t, compose, "MAILER_DSN: smtp://mailer:1025")
+	assert.Contains(t, compose, "OPENSEARCH_URL: http://opensearch:9200")
+	assert.Contains(t, compose, "MESSENGER_TRANSPORT_DSN: amqp://guest:guest@lavinmq:5672")
+	assert.NotContains(t, compose, "my-shop-shopware-local-")
 }

--- a/internal/docker/types.go
+++ b/internal/docker/types.go
@@ -12,20 +12,27 @@ type composeFile struct {
 }
 
 type composeService struct {
-	Image       string                     `yaml:"image"`
-	User        string                     `yaml:"user,omitempty"`
-	Entrypoint  []string                   `yaml:"entrypoint,omitempty"`
-	Command     []string                   `yaml:"command,omitempty"`
-	Ports       []string                   `yaml:"ports,omitempty"`
-	EnvFile     []string                   `yaml:"env_file,omitempty"`
-	Environment yamlMap[string]            `yaml:"environment,omitempty"`
-	Volumes     []string                   `yaml:"volumes,omitempty"`
-	DependsOn   yamlMap[composeDependency] `yaml:"depends_on,omitempty"`
-	Healthcheck *composeHealthcheck        `yaml:"healthcheck,omitempty"`
-	Restart     string                     `yaml:"restart,omitempty"`
-	StopSignal  string                     `yaml:"stop_signal,omitempty"`
-	Labels      yamlMap[string]            `yaml:"labels,omitempty"`
-	Networks    []string                   `yaml:"networks,omitempty"`
+	Image       string                         `yaml:"image"`
+	User        string                         `yaml:"user,omitempty"`
+	Entrypoint  []string                       `yaml:"entrypoint,omitempty"`
+	Command     []string                       `yaml:"command,omitempty"`
+	Ports       []string                       `yaml:"ports,omitempty"`
+	EnvFile     []string                       `yaml:"env_file,omitempty"`
+	Environment yamlMap[string]                `yaml:"environment,omitempty"`
+	Volumes     []string                       `yaml:"volumes,omitempty"`
+	DependsOn   yamlMap[composeDependency]     `yaml:"depends_on,omitempty"`
+	Healthcheck *composeHealthcheck            `yaml:"healthcheck,omitempty"`
+	Restart     string                         `yaml:"restart,omitempty"`
+	StopSignal  string                         `yaml:"stop_signal,omitempty"`
+	Labels      yamlMap[string]                `yaml:"labels,omitempty"`
+	Networks    yamlMap[composeServiceNetwork] `yaml:"networks,omitempty"`
+}
+
+// composeServiceNetwork is a service's per-network config; a project-unique
+// alias keeps parallel projects from colliding on the bare service name on the
+// shared proxy network (issue #1484).
+type composeServiceNetwork struct {
+	Aliases []string `yaml:"aliases,omitempty"`
 }
 
 // composeDependency is the long-form depends_on entry; an empty Condition


### PR DESCRIPTION
## What changed?

When several shops run behind the local proxy at once, each shop's internal services (opensearch, mailer, lavinmq, rustfs) now join the shared network under a project-unique name, and the shop talks to them by that name instead of the bare service name.

## Why?

On the shared proxy network every project advertised the same bare name (e.g. `opensearch`), so an internal call like `http://opensearch:9200` from one shop could reach another shop's container. That broke isolation between parallel shops. The browser subdomains were already correct — only the internal names collided.

## How was this tested?

Unit tests on the generated compose (proxy mode uses the project-unique name, plain mode keeps the bare names). `go test ./...` and `golangci-lint run ./...` pass.

## Related issue or discussion

Fixes #1484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy-mode networking to prevent service-name conflicts between multiple projects.
  * Internal services now resolve reliably through project-specific hostnames when using the proxy.
  * Plain mode continues to use the existing service hostnames without changes.
  * Updated worker and scheduler networking for more consistent proxy connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->