### PR TITLE
feat(telemetry): classify project install failures

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -172,7 +172,9 @@ the language step carries no `language` tag).
 |----------------------|---------------------------------------------------------------|------------------|
 | `result`             | Outcome of the wizard                                         | `success` / `failure` / `cancelled` / `skipped` |
 | `abandoned_at`       | Step shown when the user quit (only for `cancelled`)          | `ask` / `language` / `currency` / `credentials` / `installing` |
-| `failed_step`        | Last install step that had started (only for `failure`); `save_credentials` when the install succeeded but the config write failed | `system:install` |
+| `failed_step`        | Step that was running when the install failed (only for `failure`). `install_start` means the helper failed before any step began; `save_credentials` means the install succeeded but writing the admin credentials to the project config failed. | `system:install` / `install_start` / `save_credentials` |
+| `failure_category`   | Classified reason the install failed (only for `failure`). Closed enum — the raw error text is **never** sent. | `db_connection` / `db_version` / `env_config` / `migration` / `permission` / `php` / `invalid_input` / `already_exists` / `missing_prerequisite` / `theme_compile` / `transport` / `unknown` |
+| `retryable`          | Whether retrying from the failed step is safe (only for `failure`) | `true` / `false` |
 | `duration_ms`        | Install runtime, once the install actually started            | `84213`          |
 | `language`           | Selected default language                                     | `de-DE`          |
 | `currency`           | Selected default currency                                     | `EUR`            |

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -174,7 +174,6 @@ the language step carries no `language` tag).
 | `abandoned_at`       | Step shown when the user quit (only for `cancelled`)          | `ask` / `language` / `currency` / `credentials` / `installing` |
 | `failed_step`        | Step that was running when the install failed (only for `failure`). `install_start` means the helper failed before any step began; `save_credentials` means the install succeeded but writing the admin credentials to the project config failed. | `system:install` / `install_start` / `save_credentials` |
 | `failure_category`   | Classified reason the install failed (only for `failure`). Closed enum — the raw error text is **never** sent. | `db_connection` / `db_version` / `env_config` / `migration` / `permission` / `php` / `invalid_input` / `already_exists` / `missing_prerequisite` / `theme_compile` / `transport` / `unknown` |
-| `retryable`          | Whether retrying from the failed step is safe (only for `failure`) | `true` / `false` |
 | `duration_ms`        | Install runtime, once the install actually started            | `84213`          |
 | `language`           | Selected default language                                     | `de-DE`          |
 | `currency`           | Selected default currency                                     | `EUR`            |

--- a/internal/tracking/events.go
+++ b/internal/tracking/events.go
@@ -55,7 +55,6 @@ const (
 	TagAbandonedAt       = "abandoned_at"
 	TagFailedStep        = "failed_step"
 	TagFailureCategory   = "failure_category"
-	TagRetryable         = "retryable"
 	TagLanguage          = "language"
 	TagCurrency          = "currency"
 	TagCustomCredentials = "custom_credentials"

--- a/internal/tracking/events.go
+++ b/internal/tracking/events.go
@@ -54,6 +54,8 @@ const (
 	// EventDevInstall
 	TagAbandonedAt       = "abandoned_at"
 	TagFailedStep        = "failed_step"
+	TagFailureCategory   = "failure_category"
+	TagRetryable         = "retryable"
 	TagLanguage          = "language"
 	TagCurrency          = "currency"
 	TagCustomCredentials = "custom_credentials"

--- a/internal/tui/dev/install_failure.go
+++ b/internal/tui/dev/install_failure.go
@@ -1,9 +1,6 @@
 package dev
 
 import (
-	"errors"
-	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -29,8 +26,6 @@ const (
 	installFailureUnknown             installFailureCategory = "unknown"
 
 	installStartStep = "install_start"
-
-	installFailureDetailLines = 3
 )
 
 // installFailure is the classified result of one failed helper run. Raw
@@ -38,7 +33,6 @@ const (
 type installFailure struct {
 	failingStep string
 	category    installFailureCategory
-	detail      string
 }
 
 type installFailureRule struct {
@@ -151,13 +145,12 @@ func installFailurePatterns(patterns ...string) []*regexp.Regexp {
 	return compiled
 }
 
-func classifyInstallFailure(output []string, processErr error) installFailure {
+func classifyInstallFailure(output []string) installFailure {
 	lines := cleanInstallOutput(output)
 
 	failure := installFailure{
 		failingStep: installFailureStep(lines),
 		category:    installFailureUnknown,
-		detail:      installFailureDetail(lines, processErr),
 	}
 
 	for i := len(lines) - 1; i >= 0; i-- {
@@ -165,7 +158,6 @@ func classifyInstallFailure(output []string, processErr error) installFailure {
 			for _, pattern := range rule.patterns {
 				if pattern.MatchString(lines[i]) {
 					failure.category = rule.category
-					failure.detail = installFailureMessage(lines, i)
 					return failure
 				}
 			}
@@ -191,23 +183,6 @@ func installFailureStep(output []string) string {
 	return failingStep
 }
 
-func installFailureDetail(output []string, processErr error) string {
-	for i := len(output) - 1; i >= 0; i-- {
-		if output[i] != "" {
-			return installFailureMessage(output, i)
-		}
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(processErr, &exitErr) {
-		return fmt.Sprintf("deployment helper exited with code %d", exitErr.ExitCode())
-	}
-	if processErr != nil {
-		return processErr.Error()
-	}
-	return "deployment helper failed without diagnostic output"
-}
-
 var installRelayPrefix = regexp.MustCompile(`^\[deployment-helper] ?`)
 
 func cleanInstallOutput(output []string) []string {
@@ -221,15 +196,4 @@ func cleanInstallOutput(output []string) []string {
 func cleanInstallLine(line string) string {
 	line = installRelayPrefix.ReplaceAllString(ansi.Strip(line), "")
 	return strings.TrimSpace(line)
-}
-
-func installFailureMessage(lines []string, idx int) string {
-	start, end := idx, idx
-	for start > 0 && lines[start-1] != "" && end-start+1 < installFailureDetailLines {
-		start--
-	}
-	for end < len(lines)-1 && lines[end+1] != "" && end-start+1 < installFailureDetailLines {
-		end++
-	}
-	return strings.Join(lines[start:end+1], " ")
 }

--- a/internal/tui/dev/install_failure.go
+++ b/internal/tui/dev/install_failure.go
@@ -28,8 +28,7 @@ const (
 	installFailureTransport           installFailureCategory = "transport"
 	installFailureUnknown             installFailureCategory = "unknown"
 
-	installStartStep      = "install_start"
-	installUserCreateStep = "user:create"
+	installStartStep = "install_start"
 
 	installFailureDetailLines = 3
 )
@@ -40,21 +39,18 @@ type installFailure struct {
 	failingStep string
 	category    installFailureCategory
 	detail      string
-	retryable   bool
 }
 
 type installFailureRule struct {
-	category  installFailureCategory
-	retryable bool
-	patterns  []*regexp.Regexp
+	category installFailureCategory
+	patterns []*regexp.Regexp
 }
 
 // installFailureRules lists known failure patterns. Output lines are checked
 // from the end, so a terminal error wins over an earlier warning.
 var installFailureRules = []installFailureRule{
 	{
-		category:  installFailurePHP,
-		retryable: true,
+		category: installFailurePHP,
 		patterns: installFailurePatterns(
 			`allowed memory size`,
 			`outofmemoryerror`,
@@ -68,8 +64,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailureEnvironmentConfig,
-		retryable: true,
+		category: installFailureEnvironmentConfig,
 		patterns: installFailurePatterns(
 			`environment variable .* is not defined`,
 			`connection information is not valid\. missing parameter`,
@@ -83,8 +78,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailureDatabaseConnection,
-		retryable: true,
+		category: installFailureDatabaseConnection,
 		patterns: installFailurePatterns(
 			`sqlstate\[hy000\] \[2002\]`,
 			`sqlstate\[hy000\] \[1045\]`,
@@ -108,8 +102,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailurePermission,
-		retryable: true,
+		category: installFailurePermission,
 		patterns: installFailurePatterns(
 			`permission denied`,
 			`could not create directory`,
@@ -122,8 +115,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailureMissingPrerequisite,
-		retryable: true,
+		category: installFailureMissingPrerequisite,
 		patterns: installFailurePatterns(
 			`snippet set with isocode`,
 			`could not get id of`,
@@ -132,8 +124,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailureThemeCompile,
-		retryable: true,
+		category: installFailureThemeCompile,
 		patterns: installFailurePatterns(
 			`unable to compile the theme`,
 			`error while trying to concatenate styles`,
@@ -144,8 +135,7 @@ var installFailureRules = []installFailureRule{
 		),
 	},
 	{
-		category:  installFailureTransport,
-		retryable: true,
+		category: installFailureTransport,
 		patterns: installFailurePatterns(
 			`while setting up the .* transport`,
 			`transport does not exist`,
@@ -176,30 +166,13 @@ func classifyInstallFailure(output []string, processErr error) installFailure {
 				if pattern.MatchString(lines[i]) {
 					failure.category = rule.category
 					failure.detail = installFailureMessage(lines, i)
-					failure.retryable = canRetryInstallFailure(failure.failingStep, rule.retryable)
 					return failure
 				}
 			}
 		}
 	}
 
-	failure.retryable = canRetryInstallFailure(failure.failingStep, true)
 	return failure
-}
-
-func canRetryInstallFailure(step string, categoryAllowsRetry bool) bool {
-	return categoryAllowsRetry &&
-		step != installUserCreateStep &&
-		installFailureStepIndex(step) > 0
-}
-
-func installFailureStepIndex(step string) int {
-	for i, candidate := range install.Steps {
-		if candidate.Pattern == step {
-			return i
-		}
-	}
-	return 0
 }
 
 func installFailureStep(output []string) string {

--- a/internal/tui/dev/install_failure.go
+++ b/internal/tui/dev/install_failure.go
@@ -1,0 +1,262 @@
+package dev
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/shopware/shopware-cli/internal/shop/install"
+)
+
+type installFailureCategory string
+
+const (
+	installFailurePHP                 installFailureCategory = "php"
+	installFailureEnvironmentConfig   installFailureCategory = "env_config"
+	installFailureDatabaseVersion     installFailureCategory = "db_version"
+	installFailureDatabaseConnection  installFailureCategory = "db_connection"
+	installFailureMigration           installFailureCategory = "migration"
+	installFailureAlreadyExists       installFailureCategory = "already_exists"
+	installFailurePermission          installFailureCategory = "permission"
+	installFailureInvalidInput        installFailureCategory = "invalid_input"
+	installFailureMissingPrerequisite installFailureCategory = "missing_prerequisite"
+	installFailureThemeCompile        installFailureCategory = "theme_compile"
+	installFailureTransport           installFailureCategory = "transport"
+	installFailureUnknown             installFailureCategory = "unknown"
+
+	installStartStep      = "install_start"
+	installUserCreateStep = "user:create"
+
+	installFailureDetailLines = 3
+)
+
+// installFailure is the classified result of one failed helper run. Raw
+// details are retained for classification tests but never sent in telemetry.
+type installFailure struct {
+	failingStep string
+	category    installFailureCategory
+	detail      string
+	retryable   bool
+}
+
+type installFailureRule struct {
+	category  installFailureCategory
+	retryable bool
+	patterns  []*regexp.Regexp
+}
+
+// installFailureRules lists known failure patterns. Output lines are checked
+// from the end, so a terminal error wins over an earlier warning.
+var installFailureRules = []installFailureRule{
+	{
+		category:  installFailurePHP,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`allowed memory size`,
+			`outofmemoryerror`,
+		),
+	},
+	{
+		category: installFailurePHP,
+		patterns: installFailurePatterns(
+			`php fatal error`,
+			`syntax error, unexpected`,
+		),
+	},
+	{
+		category:  installFailureEnvironmentConfig,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`environment variable .* is not defined`,
+			`connection information is not valid\. missing parameter`,
+		),
+	},
+	{
+		category: installFailureDatabaseVersion,
+		patterns: installFailurePatterns(
+			`requires at least mysql`,
+			`failed to select database version`,
+		),
+	},
+	{
+		category:  installFailureDatabaseConnection,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`sqlstate\[hy000\] \[2002\]`,
+			`sqlstate\[hy000\] \[1045\]`,
+			`sqlstate\[hy000\] \[1044\]`,
+		),
+	},
+	{
+		category: installFailureMigration,
+		patterns: installFailurePatterns(
+			`\[42s01\]`,
+			`\[42s02\]`,
+			`\[42s22\]`,
+			`base table or view not found`,
+		),
+	},
+	{
+		category: installFailureAlreadyExists,
+		patterns: installFailurePatterns(
+			`username .* already exists\.`,
+			`install\.lock already exists`,
+		),
+	},
+	{
+		category:  installFailurePermission,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`permission denied`,
+			`could not create directory`,
+		),
+	},
+	{
+		category: installFailureInvalidInput,
+		patterns: installFailurePatterns(
+			`the password must have at least`,
+		),
+	},
+	{
+		category:  installFailureMissingPrerequisite,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`snippet set with isocode`,
+			`could not get id of`,
+			`could not find theme with`,
+			`invalid theme name`,
+		),
+	},
+	{
+		category:  installFailureThemeCompile,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`unable to compile the theme`,
+			`error while trying to concatenate styles`,
+			`unable to .* theme\.json`,
+			`unable to find setter for config field`,
+			`error loading runtime config for theme`,
+			`error while trying to write compiled files`,
+		),
+	},
+	{
+		category:  installFailureTransport,
+		retryable: true,
+		patterns: installFailurePatterns(
+			`while setting up the .* transport`,
+			`transport does not exist`,
+		),
+	},
+}
+
+func installFailurePatterns(patterns ...string) []*regexp.Regexp {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		compiled = append(compiled, regexp.MustCompile(`(?i)`+pattern))
+	}
+	return compiled
+}
+
+func classifyInstallFailure(output []string, processErr error) installFailure {
+	lines := cleanInstallOutput(output)
+
+	failure := installFailure{
+		failingStep: installFailureStep(lines),
+		category:    installFailureUnknown,
+		detail:      installFailureDetail(lines, processErr),
+	}
+
+	for i := len(lines) - 1; i >= 0; i-- {
+		for _, rule := range installFailureRules {
+			for _, pattern := range rule.patterns {
+				if pattern.MatchString(lines[i]) {
+					failure.category = rule.category
+					failure.detail = installFailureMessage(lines, i)
+					failure.retryable = canRetryInstallFailure(failure.failingStep, rule.retryable)
+					return failure
+				}
+			}
+		}
+	}
+
+	failure.retryable = canRetryInstallFailure(failure.failingStep, true)
+	return failure
+}
+
+func canRetryInstallFailure(step string, categoryAllowsRetry bool) bool {
+	return categoryAllowsRetry &&
+		step != installUserCreateStep &&
+		installFailureStepIndex(step) > 0
+}
+
+func installFailureStepIndex(step string) int {
+	for i, candidate := range install.Steps {
+		if candidate.Pattern == step {
+			return i
+		}
+	}
+	return 0
+}
+
+func installFailureStep(output []string) string {
+	failingStep := installStartStep
+	for _, line := range output {
+		if !strings.HasPrefix(line, "Start: ") {
+			continue
+		}
+		for _, step := range install.Steps {
+			if strings.Contains(line, step.Pattern) {
+				failingStep = step.Pattern
+				break
+			}
+		}
+	}
+	return failingStep
+}
+
+func installFailureDetail(output []string, processErr error) string {
+	for i := len(output) - 1; i >= 0; i-- {
+		if output[i] != "" {
+			return installFailureMessage(output, i)
+		}
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(processErr, &exitErr) {
+		return fmt.Sprintf("deployment helper exited with code %d", exitErr.ExitCode())
+	}
+	if processErr != nil {
+		return processErr.Error()
+	}
+	return "deployment helper failed without diagnostic output"
+}
+
+var installRelayPrefix = regexp.MustCompile(`^\[deployment-helper] ?`)
+
+func cleanInstallOutput(output []string) []string {
+	cleaned := make([]string, len(output))
+	for i, line := range output {
+		cleaned[i] = cleanInstallLine(line)
+	}
+	return cleaned
+}
+
+func cleanInstallLine(line string) string {
+	line = installRelayPrefix.ReplaceAllString(ansi.Strip(line), "")
+	return strings.TrimSpace(line)
+}
+
+func installFailureMessage(lines []string, idx int) string {
+	start, end := idx, idx
+	for start > 0 && lines[start-1] != "" && end-start+1 < installFailureDetailLines {
+		start--
+	}
+	for end < len(lines)-1 && lines[end+1] != "" && end-start+1 < installFailureDetailLines {
+		end++
+	}
+	return strings.Join(lines[start:end+1], " ")
+}

--- a/internal/tui/dev/install_failure_test.go
+++ b/internal/tui/dev/install_failure_test.go
@@ -1,0 +1,50 @@
+package dev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyInstallFailure(t *testing.T) {
+	failure := classifyInstallFailure([]string{
+		"Start: system:install",
+		"[deployment-helper] \x1b[31mSQLSTATE[42S01]: Base table or view already exists\x1b[0m",
+	}, assert.AnError)
+
+	assert.Equal(t, "system:install", failure.failingStep)
+	assert.Equal(t, installFailureMigration, failure.category)
+	assert.False(t, failure.retryable)
+	assert.NotContains(t, failure.detail, "\x1b")
+}
+
+func TestClassifyInstallFailureUsesTerminalError(t *testing.T) {
+	failure := classifyInstallFailure([]string{
+		"Start: system:install",
+		"SQLSTATE[HY000] [2002] Connection refused",
+		"PHP Fatal error: syntax error, unexpected token",
+	}, assert.AnError)
+
+	assert.Equal(t, installFailurePHP, failure.category)
+	assert.False(t, failure.retryable)
+}
+
+func TestClassifyInstallFailureBeforeFirstStep(t *testing.T) {
+	failure := classifyInstallFailure([]string{
+		"[deployment-helper] SQLSTATE[HY000] [2002] Connection refused",
+	}, assert.AnError)
+
+	assert.Equal(t, installStartStep, failure.failingStep)
+	assert.Equal(t, installFailureDatabaseConnection, failure.category)
+	assert.False(t, failure.retryable)
+}
+
+func TestClassifyInstallFailureUnknownAfterSafeStep(t *testing.T) {
+	failure := classifyInstallFailure([]string{
+		"Start: messenger:setup-transports",
+		"unexpected helper failure",
+	}, assert.AnError)
+
+	assert.Equal(t, installFailureUnknown, failure.category)
+	assert.True(t, failure.retryable)
+}

--- a/internal/tui/dev/install_failure_test.go
+++ b/internal/tui/dev/install_failure_test.go
@@ -10,11 +10,10 @@ func TestClassifyInstallFailure(t *testing.T) {
 	failure := classifyInstallFailure([]string{
 		"Start: system:install",
 		"[deployment-helper] \x1b[31mSQLSTATE[42S01]: Base table or view already exists\x1b[0m",
-	}, assert.AnError)
+	})
 
 	assert.Equal(t, "system:install", failure.failingStep)
 	assert.Equal(t, installFailureMigration, failure.category)
-	assert.NotContains(t, failure.detail, "\x1b")
 }
 
 func TestClassifyInstallFailureUsesTerminalError(t *testing.T) {
@@ -22,7 +21,7 @@ func TestClassifyInstallFailureUsesTerminalError(t *testing.T) {
 		"Start: system:install",
 		"SQLSTATE[HY000] [2002] Connection refused",
 		"PHP Fatal error: syntax error, unexpected token",
-	}, assert.AnError)
+	})
 
 	assert.Equal(t, installFailurePHP, failure.category)
 }
@@ -30,7 +29,7 @@ func TestClassifyInstallFailureUsesTerminalError(t *testing.T) {
 func TestClassifyInstallFailureBeforeFirstStep(t *testing.T) {
 	failure := classifyInstallFailure([]string{
 		"[deployment-helper] SQLSTATE[HY000] [2002] Connection refused",
-	}, assert.AnError)
+	})
 
 	assert.Equal(t, installStartStep, failure.failingStep)
 	assert.Equal(t, installFailureDatabaseConnection, failure.category)
@@ -40,7 +39,7 @@ func TestClassifyInstallFailureUnknownAfterSafeStep(t *testing.T) {
 	failure := classifyInstallFailure([]string{
 		"Start: messenger:setup-transports",
 		"unexpected helper failure",
-	}, assert.AnError)
+	})
 
 	assert.Equal(t, installFailureUnknown, failure.category)
 }

--- a/internal/tui/dev/install_failure_test.go
+++ b/internal/tui/dev/install_failure_test.go
@@ -14,7 +14,6 @@ func TestClassifyInstallFailure(t *testing.T) {
 
 	assert.Equal(t, "system:install", failure.failingStep)
 	assert.Equal(t, installFailureMigration, failure.category)
-	assert.False(t, failure.retryable)
 	assert.NotContains(t, failure.detail, "\x1b")
 }
 
@@ -26,7 +25,6 @@ func TestClassifyInstallFailureUsesTerminalError(t *testing.T) {
 	}, assert.AnError)
 
 	assert.Equal(t, installFailurePHP, failure.category)
-	assert.False(t, failure.retryable)
 }
 
 func TestClassifyInstallFailureBeforeFirstStep(t *testing.T) {
@@ -36,7 +34,6 @@ func TestClassifyInstallFailureBeforeFirstStep(t *testing.T) {
 
 	assert.Equal(t, installStartStep, failure.failingStep)
 	assert.Equal(t, installFailureDatabaseConnection, failure.category)
-	assert.False(t, failure.retryable)
 }
 
 func TestClassifyInstallFailureUnknownAfterSafeStep(t *testing.T) {
@@ -46,5 +43,4 @@ func TestClassifyInstallFailureUnknownAfterSafeStep(t *testing.T) {
 	}, assert.AnError)
 
 	assert.Equal(t, installFailureUnknown, failure.category)
-	assert.True(t, failure.retryable)
 }

--- a/internal/tui/dev/lifecycle.go
+++ b/internal/tui/dev/lifecycle.go
@@ -69,10 +69,9 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 
 	case shopwareInstallDoneMsg:
 		if msg.err != nil {
+			failure := classifyInstallFailure(msg.output, msg.err)
 			if m.telemetry.installOnce() {
-				tags := m.telemetry.installTags(tracking.ResultFailure, m.install)
-				tags[tracking.TagFailedStep] = install.FailedStep(m.installProg.currentStep)
-				trackEvent(tracking.EventDevInstall, tags)
+				trackEvent(tracking.EventDevInstall, m.telemetry.installFailureTags(m.install, failure))
 			}
 			m.installProg.showLogs = true
 			m.overlayLines = append(m.overlayLines, "", errorStyle.Render("Installation failed: "+msg.err.Error()))

--- a/internal/tui/dev/lifecycle.go
+++ b/internal/tui/dev/lifecycle.go
@@ -69,7 +69,7 @@ func (m Model) updateLifecycle(msg tea.Msg) (app.Content, tea.Cmd) {
 
 	case shopwareInstallDoneMsg:
 		if msg.err != nil {
-			failure := classifyInstallFailure(msg.output, msg.err)
+			failure := classifyInstallFailure(msg.output)
 			if m.telemetry.installOnce() {
 				trackEvent(tracking.EventDevInstall, m.telemetry.installFailureTags(m.install, failure))
 			}

--- a/internal/tui/dev/model.go
+++ b/internal/tui/dev/model.go
@@ -107,7 +107,10 @@ type dockerOutputDoneMsg struct{}
 
 type shopwareInstalledMsg struct{}
 type shopwareNotInstalledMsg struct{}
-type shopwareInstallDoneMsg struct{ err error }
+type shopwareInstallDoneMsg struct {
+	output []string
+	err    error
+}
 
 type configRestartDoneMsg struct{ err error }
 

--- a/internal/tui/dev/model_commands.go
+++ b/internal/tui/dev/model_commands.go
@@ -99,9 +99,13 @@ func (m *Model) runShopwareInstall() tea.Cmd {
 	m.dockerOutChan = ch
 
 	doneCmd := func() tea.Msg {
-		err := install.Run(ctx, e, opts, func(line string) { ch <- line })
+		var output []string
+		err := install.Run(ctx, e, opts, func(line string) {
+			output = append(output, line)
+			ch <- line
+		})
 		close(ch)
-		return shopwareInstallDoneMsg{err: err}
+		return shopwareInstallDoneMsg{output: output, err: err}
 	}
 
 	return tea.Batch(readFromChan(ch), doneCmd)

--- a/internal/tui/dev/telemetry.go
+++ b/internal/tui/dev/telemetry.go
@@ -172,6 +172,16 @@ func (t *telemetryState) installTags(result string, w installWizard) map[string]
 	return tags
 }
 
+// installFailureTags enriches the install event with a closed-enum category.
+// The raw failure detail is deliberately never included in telemetry.
+func (t *telemetryState) installFailureTags(w installWizard, f installFailure) map[string]string {
+	tags := t.installTags(tracking.ResultFailure, w)
+	tags[tracking.TagFailedStep] = f.failingStep
+	tags[tracking.TagFailureCategory] = string(f.category)
+	tags[tracking.TagRetryable] = strconv.FormatBool(f.retryable)
+	return tags
+}
+
 func installStepTagName(step installStep) string {
 	switch step {
 	case installStepAsk:

--- a/internal/tui/dev/telemetry.go
+++ b/internal/tui/dev/telemetry.go
@@ -178,7 +178,6 @@ func (t *telemetryState) installFailureTags(w installWizard, f installFailure) m
 	tags := t.installTags(tracking.ResultFailure, w)
 	tags[tracking.TagFailedStep] = f.failingStep
 	tags[tracking.TagFailureCategory] = string(f.category)
-	tags[tracking.TagRetryable] = strconv.FormatBool(f.retryable)
 	return tags
 }
 

--- a/internal/tui/dev/telemetry_test.go
+++ b/internal/tui/dev/telemetry_test.go
@@ -238,14 +238,12 @@ func TestInstallFailureTags(t *testing.T) {
 		failingStep: installStartStep,
 		category:    installFailureDatabaseConnection,
 		detail:      `SQLSTATE[HY000] [1045] Access denied for super-secret-host`,
-		retryable:   false,
 	}
 	tags := tel.installFailureTags(w, f)
 
 	assert.Equal(t, tracking.ResultFailure, tags[tracking.TagResult])
 	assert.Equal(t, installStartStep, tags[tracking.TagFailedStep])
 	assert.Equal(t, "db_connection", tags[tracking.TagFailureCategory])
-	assert.Equal(t, "false", tags[tracking.TagRetryable])
 	assert.Equal(t, "de-DE", tags[tracking.TagLanguage])
 	for _, value := range tags {
 		assert.NotContains(t, value, "super-secret-host")
@@ -261,5 +259,4 @@ func TestInstallFailureTagsFromClassifier(t *testing.T) {
 
 	assert.Equal(t, "db_connection", tags[tracking.TagFailureCategory])
 	assert.Equal(t, installStartStep, tags[tracking.TagFailedStep])
-	assert.Contains(t, tags, tracking.TagRetryable)
 }

--- a/internal/tui/dev/telemetry_test.go
+++ b/internal/tui/dev/telemetry_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/tracking"
 )
 
 // TestMain disables telemetry for the whole package: tests drive Model.Update
@@ -226,4 +228,38 @@ func TestNilTelemetryStateIsSafe(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = tel.configRestartTags(nil)
 	assert.False(t, ok)
+}
+
+func TestInstallFailureTags(t *testing.T) {
+	tel := &telemetryState{}
+	w := installWizard{language: "de-DE", currency: "EUR"}
+
+	f := installFailure{
+		failingStep: installStartStep,
+		category:    installFailureDatabaseConnection,
+		detail:      `SQLSTATE[HY000] [1045] Access denied for super-secret-host`,
+		retryable:   false,
+	}
+	tags := tel.installFailureTags(w, f)
+
+	assert.Equal(t, tracking.ResultFailure, tags[tracking.TagResult])
+	assert.Equal(t, installStartStep, tags[tracking.TagFailedStep])
+	assert.Equal(t, "db_connection", tags[tracking.TagFailureCategory])
+	assert.Equal(t, "false", tags[tracking.TagRetryable])
+	assert.Equal(t, "de-DE", tags[tracking.TagLanguage])
+	for _, value := range tags {
+		assert.NotContains(t, value, "super-secret-host")
+	}
+}
+
+func TestInstallFailureTagsFromClassifier(t *testing.T) {
+	tel := &telemetryState{}
+	failure := classifyInstallFailure([]string{
+		"[deployment-helper] SQLSTATE[HY000] [2002] No such file or directory",
+	}, assert.AnError)
+	tags := tel.installFailureTags(installWizard{}, failure)
+
+	assert.Equal(t, "db_connection", tags[tracking.TagFailureCategory])
+	assert.Equal(t, installStartStep, tags[tracking.TagFailedStep])
+	assert.Contains(t, tags, tracking.TagRetryable)
 }

--- a/internal/tui/dev/telemetry_test.go
+++ b/internal/tui/dev/telemetry_test.go
@@ -237,7 +237,6 @@ func TestInstallFailureTags(t *testing.T) {
 	f := installFailure{
 		failingStep: installStartStep,
 		category:    installFailureDatabaseConnection,
-		detail:      `SQLSTATE[HY000] [1045] Access denied for super-secret-host`,
 	}
 	tags := tel.installFailureTags(w, f)
 
@@ -254,7 +253,7 @@ func TestInstallFailureTagsFromClassifier(t *testing.T) {
 	tel := &telemetryState{}
 	failure := classifyInstallFailure([]string{
 		"[deployment-helper] SQLSTATE[HY000] [2002] No such file or directory",
-	}, assert.AnError)
+	})
 	tags := tel.installFailureTags(installWizard{}, failure)
 
 	assert.Equal(t, "db_connection", tags[tracking.TagFailureCategory])


### PR DESCRIPTION
Needs to be merged before https://github.com/shopware/shopware-cli/pull/1489

PR created because of decision: https://github.com/shopware/shopware-cli/issues/1380#issuecomment-5493952223

## Summary by CodeRabbit

- **Improvements**
  - Installation failures are now categorized with clearer failing-step and retryability information.
  - Diagnostic messages are sanitized and summarized, helping identify issues without exposing sensitive details.
  - Failure reporting now distinguishes common issues such as database, migration, and application errors.

- **Documentation**
  - Documented the available installation failure categories, failed steps, and retryability indicators.
  - Clarified that raw error messages are excluded from telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development installation failure reporting by identifying the failing step and categorizing common failure types.
  - Improved detection of database connection failures, including SQLSTATE 2002, 1045, and 1044 formats.
  - Installation output is sanitized before failures are classified, helping prevent terminal formatting or sensitive credential details from affecting reporting.

- **Telemetry**
  - Installation failure events now include the failure category and affected step.
  - Failure details and retryability indicators are no longer included in telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->