### PR TITLE
feat(install-form): checkbox can be toggled with space

### DIFF
--- a/internal/tui/README.md
+++ b/internal/tui/README.md
@@ -227,7 +227,8 @@ tui.ConfirmButtons("Initialize now", "No, skip", confirmYes)
 ### CredentialStep — username/password/show-password fieldset
 
 Embed in a wizard; `HandleKey` owns focus navigation, enter flow, and
-validation — the wizard decides what a submit means.
+validation — the wizard decides what a submit means. Enter submits from the
+password field and the checkbox, space toggles the checkbox.
 
 ```go
 type myWizard struct {

--- a/internal/tui/credentialstep.go
+++ b/internal/tui/credentialstep.go
@@ -146,24 +146,22 @@ func (c *CredentialStep) Focus(target CredFocus) tea.Cmd {
 }
 
 // HandleKey applies the shared credential-step key handling: tab/down and
-// shift+tab/up move focus, enter advances from the username, toggles the
-// checkbox, or submits from the password (after validation), and any other
-// key types into the focused input. It reports submitted=true when the
-// password passed validation and the step is complete — what a submit means
-// is the embedding wizard's decision.
+// shift+tab/up move focus, enter advances from the username or submits from
+// the password and the checkbox (after validation), space toggles the
+// checkbox, and any other key types into the focused input. It reports
+// submitted=true when the password passed validation and the step is
+// complete — what a submit means is the embedding wizard's decision.
 func (c *CredentialStep) HandleKey(msg tea.KeyPressMsg) (cmd tea.Cmd, submitted bool) {
 	switch KeyString(msg) {
 	case KeyEnter:
-		switch c.focus {
-		case CredFocusUsername:
+		if c.focus == CredFocusUsername {
 			return c.Focus(CredFocusPassword), false
-		case CredFocusShowPassword:
-			c.ToggleShowPassword()
-			return nil, false
-		case CredFocusPassword:
-			// Enter on the password submits; handled below.
 		}
 		if !c.ValidatePassword() {
+			if c.focus == CredFocusShowPassword {
+				// Put the cursor where the error can be fixed.
+				return c.Focus(CredFocusPassword), false
+			}
 			return nil, false
 		}
 		c.Blur()
@@ -260,14 +258,15 @@ func (c CredentialStep) Render(b *strings.Builder) {
 	b.WriteString(Checkbox(!c.PasswordMasked(), c.focus == CredFocusShowPassword, "Show password"))
 }
 
-// FooterHint returns the shortcut bar for the step: navigation plus what
-// enter does for the current focus (toggle on the checkbox, submitLabel
-// otherwise).
+// FooterHint returns the shortcut bar for the step: navigation, the space
+// toggle while the checkbox has focus, and enter for submitLabel on every
+// focus.
 func (c CredentialStep) FooterHint(submitLabel string) string {
 	if c.focus == CredFocusShowPassword {
 		return ShortcutBar(
 			Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
-			Shortcut{Key: "enter", Label: "Toggle"},
+			Shortcut{Key: "space", Label: "Toggle"},
+			Shortcut{Key: "enter", Label: submitLabel},
 		)
 	}
 	return ShortcutBar(

--- a/internal/tui/credentialstep_test.go
+++ b/internal/tui/credentialstep_test.go
@@ -86,16 +86,36 @@ func TestCredentialStep_CheckboxTogglesEcho(t *testing.T) {
 	c.Focus(CredFocusShowPassword)
 	require.True(t, c.PasswordMasked(), "password starts masked")
 
-	_, submitted := c.HandleKey(credKey(tea.KeyEnter))
+	_, submitted := c.HandleKey(credKey(tea.KeySpace))
 	assert.False(t, submitted)
 	assert.False(t, c.PasswordMasked())
 
-	c.HandleKey(credKey(tea.KeyEnter))
+	c.HandleKey(credKey(tea.KeySpace))
 	assert.True(t, c.PasswordMasked())
 
 	// Typed keys are swallowed while the checkbox has focus.
 	c.HandleKey(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
 	assert.Equal(t, "shopware", c.Password())
+}
+
+func TestCredentialStep_EnterOnCheckboxSubmits(t *testing.T) {
+	c := testCreds()
+	c.Focus(CredFocusShowPassword)
+
+	_, submitted := c.HandleKey(credKey(tea.KeyEnter))
+	assert.True(t, submitted)
+	assert.True(t, c.PasswordMasked(), "enter must not toggle the checkbox")
+}
+
+func TestCredentialStep_EnterOnCheckboxWithBadPasswordRefocusesPassword(t *testing.T) {
+	c := testCreds()
+	c.SetPassword("short")
+	c.Focus(CredFocusShowPassword)
+
+	_, submitted := c.HandleKey(credKey(tea.KeyEnter))
+	assert.False(t, submitted)
+	assert.NotEmpty(t, c.PasswordErr())
+	assert.Equal(t, CredFocusPassword, c.FocusTarget())
 }
 
 func TestCredentialStep_TypingReachesFocusedInput(t *testing.T) {

--- a/internal/tui/dev/install_wizard_test.go
+++ b/internal/tui/dev/install_wizard_test.go
@@ -231,18 +231,30 @@ func TestInstallStepCredentials_NavigationClampsAtBounds(t *testing.T) {
 	assert.Equal(t, tui.CredFocusShowPassword, updated.(Model).install.FocusTarget())
 }
 
-func TestInstallStepCredentials_EnterOnCheckboxTogglesEcho(t *testing.T) {
+func TestInstallStepCredentials_SpaceOnCheckboxTogglesEcho(t *testing.T) {
 	m := newTestInstallModel()
 	m.install.step = installStepCredentials
 	m.install.Focus(tui.CredFocusShowPassword)
 
-	updated, _ := m.updateInstallPrompt(enterKey())
+	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
 	mm := updated.(Model)
 	assert.False(t, mm.install.PasswordMasked())
 	assert.Equal(t, installStepCredentials, mm.install.step, "should stay on credentials step")
 
-	updated, _ = mm.updateInstallPrompt(enterKey())
+	updated, _ = mm.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
 	assert.True(t, updated.(Model).install.PasswordMasked())
+}
+
+func TestInstallStepCredentials_EnterOnCheckboxStartsInstall(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepCredentials
+	m.install.SetPassword("shopware")
+	m.install.Focus(tui.CredFocusShowPassword)
+
+	updated, _ := m.updateInstallPrompt(enterKey())
+	mm := updated.(Model)
+	assert.Equal(t, phaseInstalling, mm.phase)
+	assert.True(t, mm.install.PasswordMasked(), "enter must not toggle the checkbox")
 }
 
 func TestInstallStepCredentials_CheckboxFocusedSwallowsTypedKeys(t *testing.T) {

--- a/internal/tui/dev/migration_wizard_test.go
+++ b/internal/tui/dev/migration_wizard_test.go
@@ -112,17 +112,27 @@ func TestMigrationWizardAdminUser_TabNavigatesFocus(t *testing.T) {
 	assert.Equal(t, tui.CredFocusShowPassword, sg.FocusTarget())
 }
 
-func TestMigrationWizardAdminUser_EnterOnCheckboxTogglesEcho(t *testing.T) {
+func TestMigrationWizardAdminUser_SpaceOnCheckboxTogglesEcho(t *testing.T) {
+	sg := newMigrationWizard("")
+	sg.step = migrationStepAdminUser
+	sg.Focus(tui.CredFocusShowPassword)
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.False(t, sg.PasswordMasked())
+	assert.Equal(t, migrationStepAdminUser, sg.step)
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.True(t, sg.PasswordMasked())
+}
+
+func TestMigrationWizardAdminUser_EnterOnCheckboxContinues(t *testing.T) {
 	sg := newMigrationWizard("")
 	sg.step = migrationStepAdminUser
 	sg.Focus(tui.CredFocusShowPassword)
 
 	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.False(t, sg.PasswordMasked())
-	assert.Equal(t, migrationStepAdminUser, sg.step)
-
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.True(t, sg.PasswordMasked())
+	assert.Equal(t, migrationStepDockerPHP, sg.step)
+	assert.True(t, sg.PasswordMasked(), "enter must not toggle the checkbox")
 }
 
 func TestMigrationWizardReview_QuitButtonQuits(t *testing.T) {


### PR DESCRIPTION
## What changed?
In the installation screen the checkbox now can be toggled with the spacebar and the installation process can be started with Enter.

## Why?
The user had no way to start the installation process when focusing the checkbox.

## How was this tested?
- manual test
- unit tests

## Related issue or discussion
#1416 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credential and migration wizard keyboard behavior: Space toggles password visibility, while Enter submits or advances without changing visibility.
  * Invalid passwords now prevent submission and return focus to the password field.
  * Updated checkbox footer hints to show separate toggle and submit shortcuts.

* **Documentation**
  * Clarified the credential-step keyboard behavior in the TUI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->