### PR TITLE
feat: move and make findClosestShopwareProject public

### DIFF
--- a/cmd/project/executor.go
+++ b/cmd/project/executor.go
@@ -32,7 +32,7 @@ func resolveExecutor(cmd *cobra.Command, projectRoot string) (executor.Executor,
 // resolveProjectDatabaseConnection resolves the database credentials of the
 // current environment through its executor.
 func resolveProjectDatabaseConnection(cmd *cobra.Command) (*executor.DatabaseConnection, error) {
-	projectRoot, err := findClosestShopwareProject(false)
+	projectRoot, err := shop.FindClosestShopwareProject(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -20,56 +19,6 @@ import (
 )
 
 const storefrontBundleName = "Storefront"
-
-func findClosestShopwareProject(allowFallback bool) (string, error) {
-	projectRoot := os.Getenv("PROJECT_ROOT")
-
-	if projectRoot != "" {
-		return projectRoot, nil
-	}
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	cwd := currentDir
-
-	for {
-		files := []string{
-			currentDir + "/composer.json",
-			currentDir + "/composer.lock",
-		}
-
-		for _, file := range files {
-			if _, err := os.Stat(file); err == nil {
-				content, err := os.ReadFile(file)
-				if err != nil {
-					return "", err
-				}
-				contentString := string(content)
-
-				if strings.Contains(contentString, "shopware/core") {
-					if _, err := os.Stat(currentDir + "/bin/console"); err == nil {
-						return currentDir, nil
-					}
-				}
-			}
-		}
-
-		currentDir = filepath.Dir(currentDir)
-
-		if currentDir == filepath.Dir(currentDir) {
-			break
-		}
-	}
-
-	if allowFallback {
-		return cwd, nil
-	}
-
-	return "", errors.New("cannot find Shopware project in current directory")
-}
 
 func filterAndWritePluginJson(cmd *cobra.Command, projectRoot string, shopCfg *shop.Config, cmdExecutor executor.Executor) error {
 	sources, err := filterAndGetSources(cmd, projectRoot, shopCfg)

--- a/cmd/project/platform_test.go
+++ b/cmd/project/platform_test.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -35,26 +34,6 @@ func TestSelectExtensionsRequiresInteractiveTerminal(t *testing.T) {
 
 	err := validateExtensionSelection(system.WithInteraction(context.Background(), false), "", true)
 	require.EqualError(t, err, "--select-extensions requires an interactive terminal; use --only-extensions with a comma-separated list instead")
-}
-
-func TestFindClosestShopwareProjectFallback(t *testing.T) {
-	t.Setenv("PROJECT_ROOT", "")
-	t.Chdir(t.TempDir())
-
-	_, err := findClosestShopwareProject(false)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "cannot find Shopware project")
-	}
-
-	cwd, err := os.Getwd()
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	root, err := findClosestShopwareProject(true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, cwd, root)
-	}
 }
 
 func TestSelectExtensionsCannotBeCombinedWithOnlyExtensions(t *testing.T) {

--- a/cmd/project/project_admin_api.go
+++ b/cmd/project/project_admin_api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shopware/shopware-cli/internal/curl"
+	"github.com/shopware/shopware-cli/internal/shop"
 )
 
 var skipDefaultHeaders bool
@@ -18,7 +19,7 @@ var projectAdminApiCmd = &cobra.Command{
 	Use:   "admin-api [method] [path]",
 	Short: "Pre-authenticated curl interface to the Admin API",
 	RunE: func(cobraCmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -25,7 +25,7 @@ var projectAdminBuildCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-		} else if projectRoot, err = findClosestShopwareProject(false); err != nil {
+		} else if projectRoot, err = shop.FindClosestShopwareProject(false); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -22,7 +22,7 @@ var projectAdminWatchCmd = &cobra.Command{
 
 		if len(args) == 1 {
 			projectRoot = args[0]
-		} else if projectRoot, err = findClosestShopwareProject(false); err != nil {
+		} else if projectRoot, err = shop.FindClosestShopwareProject(false); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_autofix_composer.go
+++ b/cmd/project/project_autofix_composer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/shop/pluginmigrate"
 	"github.com/shopware/shopware-cli/internal/system"
 	pluginmigratetui "github.com/shopware/shopware-cli/internal/tui/pluginmigrate"
@@ -16,7 +17,7 @@ var projectAutofixComposerCmd = &cobra.Command{
 	Long: "Migrates the extensions living in custom/ under Composer management: Shopware Store plugins are required from packages.shopware.com and their local copy removed, everything else is registered as a Composer path repository.\n" +
 		"In a terminal this runs as an interactive wizard. With --no-interaction (or without a terminal) the migration runs headless: set SHOPWARE_PACKAGIST_TOKEN to migrate Store plugins (otherwise everything becomes a path repository) and use --dry-run to preview the plan.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_autofix_flex.go
+++ b/cmd/project/project_autofix_flex.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shopware/shopware-cli/internal/flexmigrator"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
@@ -18,7 +19,7 @@ var projectAutofixFlexCmd = &cobra.Command{
 	Use:   "flex",
 	Short: "Autofix project to Symfony Flex",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		project, err := findClosestShopwareProject(false)
+		project, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_clear_cache.go
+++ b/cmd/project/project_clear_cache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -13,7 +14,7 @@ var projectClearCacheCmd = &cobra.Command{
 	Use:   "clear-cache",
 	Short: "Clears the Shop cache",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}
@@ -27,7 +28,7 @@ var projectClearCacheCmd = &cobra.Command{
 		if cfg == nil || cfg.AdminApi == nil {
 			logging.FromContext(cmd.Context()).Infof("Clearing cache localy")
 
-			projectRoot, err = findClosestShopwareProject(false)
+			projectRoot, err = shop.FindClosestShopwareProject(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/project/project_composer.go
+++ b/cmd/project/project_composer.go
@@ -2,6 +2,8 @@ package project
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/shop"
 )
 
 var projectComposerCmd = &cobra.Command{
@@ -13,7 +15,7 @@ var projectComposerCmd = &cobra.Command{
   shopware-cli project composer update --with-all-dependencies`,
 	DisableFlagParsing: true,
 	ValidArgsFunction: func(cmd *cobra.Command, input []string, _ string) ([]string, cobra.ShellCompDirective) {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveDefault
 		}
@@ -26,7 +28,7 @@ var projectComposerCmd = &cobra.Command{
 		return composerCommandCompletions(cmd, projectRoot, input, cmdExecutor)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_console.go
+++ b/cmd/project/project_console.go
@@ -30,7 +30,7 @@ var projectConsoleCmd = &cobra.Command{
 	Args:               cobra.MinimumNArgs(1),
 	DisableFlagParsing: true,
 	ValidArgsFunction: func(cmd *cobra.Command, input []string, _ string) ([]string, cobra.ShellCompDirective) {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveDefault
 		}
@@ -99,7 +99,7 @@ var projectConsoleCmd = &cobra.Command{
 		return completions, cobra.ShellCompDirectiveDefault
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_console.go
+++ b/cmd/project/project_console.go
@@ -172,6 +172,10 @@ func parseConsoleEnvironment(cmd *cobra.Command, args []string) ([]string, error
 		return args, nil
 	}
 
+	if value == "" {
+		return nil, errors.New("missing value for --env flag")
+	}
+
 	if err := cmd.Flags().Set("env", value); err != nil {
 		return nil, err
 	}

--- a/cmd/project/project_console_test.go
+++ b/cmd/project/project_console_test.go
@@ -129,4 +129,9 @@ func TestParseConsoleEnvironment(t *testing.T) {
 		_, err := parseConsoleEnvironment(&cobra.Command{}, []string{flag})
 		assert.EqualError(t, err, "missing value for --env flag")
 	}
+
+	for _, flag := range []string{"-e=", "--env="} {
+		_, err := parseConsoleEnvironment(&cobra.Command{}, []string{flag})
+		assert.EqualError(t, err, "missing value for --env flag")
+	}
 }

--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -101,7 +101,7 @@ var projectDevCmd = &cobra.Command{
 	Short: "Start the development environment",
 	Long:  "Start the development environment. Launches the interactive TUI dashboard when run in a terminal, or starts containers in the background otherwise.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func runMigrationWizardTUI(ctx context.Context, projectRoot string, cfg *shop.Co
 }
 
 func setupDevEnvironment(cmd *cobra.Command) (*devEnvironment, error) {
-	projectRoot, err := findClosestShopwareProject(false)
+	projectRoot, err := shop.FindClosestShopwareProject(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -123,7 +123,7 @@ func assembleConnectionURI(cmd *cobra.Command) (*mysql.Config, error) {
 // commands, but keeps dump usable outside a Shopware project: there the
 // process environment and the connection flags are all that is needed.
 func resolveDumpDatabaseConnection(cmd *cobra.Command) (*executor.DatabaseConnection, error) {
-	if _, err := findClosestShopwareProject(false); err != nil {
+	if _, err := shop.FindClosestShopwareProject(false); err != nil {
 		return executor.NewLocal("").DatabaseConnection(cmd.Context())
 	}
 

--- a/cmd/project/project_extension_activate.go
+++ b/cmd/project/project_extension_activate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionActivateCmd = &cobra.Command{
 	Short: "Activate a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_deactivate.go
+++ b/cmd/project/project_extension_deactivate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionDeactivateCmd = &cobra.Command{
 	Short: "Deactivate a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_delete.go
+++ b/cmd/project/project_extension_delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionDeleteCmd = &cobra.Command{
 	Short: "Delete a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_install.go
+++ b/cmd/project/project_extension_install.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionInstallCmd = &cobra.Command{
 	Short: "Install a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_list.go
+++ b/cmd/project/project_extension_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -19,7 +20,7 @@ var projectExtensionListCmd = &cobra.Command{
 			return err
 		}
 
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_outdated.go
+++ b/cmd/project/project_extension_outdated.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/logging"
 )
@@ -21,7 +22,7 @@ var projectExtensionOutdatedCmd = &cobra.Command{
 			return err
 		}
 
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_uninstall.go
+++ b/cmd/project/project_extension_uninstall.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionUninstallCmd = &cobra.Command{
 	Short: "Uninstall a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_update.go
+++ b/cmd/project/project_extension_update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -14,7 +15,7 @@ var projectExtensionUpdateCmd = &cobra.Command{
 	Short: "Update a extension",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -19,6 +19,7 @@ import (
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
 	"github.com/shopware/shopware-cli/internal/archiver"
 	"github.com/shopware/shopware-cli/internal/extension"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -111,7 +112,7 @@ var projectExtensionUploadCmd = &cobra.Command{
 			}
 		}
 
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_fix.go
+++ b/cmd/project/project_fix.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/verifier"
 )
 
@@ -26,7 +27,7 @@ var projectFixCmd = &cobra.Command{
 		if len(args) > 0 {
 			projectPath = args[0]
 		} else {
-			projectPath, err = findClosestShopwareProject(false)
+			projectPath, err = shop.FindClosestShopwareProject(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/project/project_format.go
+++ b/cmd/project/project_format.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/verifier"
 )
 
@@ -27,7 +28,7 @@ var projectFormatCmd = &cobra.Command{
 		if len(args) > 0 {
 			projectPath = args[0]
 		} else {
-			projectPath, err = findClosestShopwareProject(false)
+			projectPath, err = shop.FindClosestShopwareProject(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/project/project_image_proxy.go
+++ b/cmd/project/project_image_proxy.go
@@ -78,7 +78,7 @@ var projectImageProxyCmd = &cobra.Command{
 	Long: `Start an HTTP server that serves files from the public folder of the closest Shopware project.
 If a file is not found locally, it proxies the request to the upstream server.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		path, err := findClosestShopwareProject(false)
+		path, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_logs.go
+++ b/cmd/project/project_logs.go
@@ -47,25 +47,16 @@ func runProjectLogs(cmd *cobra.Command, args []string, cmdExecutor executor.Exec
 		return printLogFileList(files)
 	}
 
+	if len(args) > 0 {
+		follow, _ := cmd.Flags().GetBool("follow")
+		return cmdExecutor.GetLog(cmd.Context(), args[0], lines, follow, cmd.OutOrStdout())
+	}
+
 	if len(files) == 0 {
 		return errors.New("no log files found in var/log")
 	}
 
 	target := files[0].Name
-	if len(args) > 0 {
-		target = ""
-		for _, f := range files {
-			if f.Name == args[0] {
-				target = f.Name
-				break
-			}
-		}
-
-		if target == "" {
-			return fmt.Errorf("log file not found: %s", args[0])
-		}
-	}
-
 	follow, _ := cmd.Flags().GetBool("follow")
 
 	return cmdExecutor.GetLog(cmd.Context(), target, lines, follow, cmd.OutOrStdout())

--- a/cmd/project/project_logs.go
+++ b/cmd/project/project_logs.go
@@ -48,8 +48,22 @@ func runProjectLogs(cmd *cobra.Command, args []string, cmdExecutor executor.Exec
 	}
 
 	if len(args) > 0 {
+		target := args[0]
+		if len(files) > 0 {
+			found := false
+			for _, f := range files {
+				if f.Name == target {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("log file not found: %s", target)
+			}
+		}
+
 		follow, _ := cmd.Flags().GetBool("follow")
-		return cmdExecutor.GetLog(cmd.Context(), args[0], lines, follow, cmd.OutOrStdout())
+		return cmdExecutor.GetLog(cmd.Context(), target, lines, follow, cmd.OutOrStdout())
 	}
 
 	if len(files) == 0 {

--- a/cmd/project/project_logs.go
+++ b/cmd/project/project_logs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -22,7 +23,7 @@ var projectLogsCmd = &cobra.Command{
 	Long:  "Show the last lines of a Shopware log file. Without arguments, shows the most recently modified log file. Use --list to discover available log files.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_logs_test.go
+++ b/cmd/project/project_logs_test.go
@@ -61,18 +61,29 @@ func TestProjectLogsPassesValidLinesToGetLog(t *testing.T) {
 	assert.Equal(t, "prod.log", fakeExec.gotFile)
 }
 
-func TestProjectLogsUsesExplicitFileEvenWhenNotListed(t *testing.T) {
+func TestProjectLogsUsesExplicitFileWhenListingIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	cmd := newLogsTestCmd(t)
 	require.NoError(t, cmd.Flags().Set("lines", "50"))
 
-	fakeExec := &logsFakeExecutor{files: []executor.LogFile{{Name: "prod.log"}}}
+	fakeExec := &logsFakeExecutor{files: nil}
 
 	require.NoError(t, runProjectLogs(cmd, []string{"custom.log"}, fakeExec))
 	require.True(t, fakeExec.getLogCalled)
 	assert.Equal(t, 50, fakeExec.gotLines)
 	assert.Equal(t, "custom.log", fakeExec.gotFile)
+}
+
+func TestProjectLogsRejectsUnknownExplicitFile(t *testing.T) {
+	t.Parallel()
+
+	cmd := newLogsTestCmd(t)
+	fakeExec := &logsFakeExecutor{files: []executor.LogFile{{Name: "prod.log"}}}
+
+	err := runProjectLogs(cmd, []string{"custom.log"}, fakeExec)
+	require.EqualError(t, err, "log file not found: custom.log")
+	assert.False(t, fakeExec.getLogCalled)
 }
 
 func TestFormatSize(t *testing.T) {

--- a/cmd/project/project_logs_test.go
+++ b/cmd/project/project_logs_test.go
@@ -61,6 +61,20 @@ func TestProjectLogsPassesValidLinesToGetLog(t *testing.T) {
 	assert.Equal(t, "prod.log", fakeExec.gotFile)
 }
 
+func TestProjectLogsUsesExplicitFileEvenWhenNotListed(t *testing.T) {
+	t.Parallel()
+
+	cmd := newLogsTestCmd(t)
+	require.NoError(t, cmd.Flags().Set("lines", "50"))
+
+	fakeExec := &logsFakeExecutor{files: []executor.LogFile{{Name: "prod.log"}}}
+
+	require.NoError(t, runProjectLogs(cmd, []string{"custom.log"}, fakeExec))
+	require.True(t, fakeExec.getLogCalled)
+	assert.Equal(t, 50, fakeExec.gotLines)
+	assert.Equal(t, "custom.log", fakeExec.gotFile)
+}
+
 func TestFormatSize(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/project/project_proxy.go
+++ b/cmd/project/project_proxy.go
@@ -53,7 +53,7 @@ down" to revert it. Run "proxy setup" once per machine first (DNS + trust).`,
 // newProxyEnvironment resolves the current project, its hostname and its
 // Docker executor. It requires Docker, since the shared proxy is Docker-only.
 func newProxyEnvironment(cmd *cobra.Command) (*proxyEnvironment, error) {
-	projectRoot, err := findClosestShopwareProject(false)
+	projectRoot, err := shop.FindClosestShopwareProject(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/project/project_proxy_list.go
+++ b/cmd/project/project_proxy_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/proxy"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -17,7 +18,7 @@ var projectProxyStatusCmd = &cobra.Command{
 	Short:        "Report whether the current project is registered with the shared proxy",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_proxy_setup.go
+++ b/cmd/project/project_proxy_setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shopware/shopware-cli/internal/proxy"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
@@ -161,7 +162,7 @@ func setupProjectHostnames(ctx context.Context) []string {
 		return nil
 	}
 
-	projectRoot, err := findClosestShopwareProject(false)
+	projectRoot, err := shop.FindClosestShopwareProject(false)
 	if err != nil {
 		return nil
 	}

--- a/cmd/project/project_sbom.go
+++ b/cmd/project/project_sbom.go
@@ -79,5 +79,5 @@ func resolveProjectSbomRoot(args []string) (string, error) {
 		return filepath.Abs(args[0])
 	}
 
-	return findClosestShopwareProject(false)
+	return shop.FindClosestShopwareProject(false)
 }

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -25,7 +25,7 @@ var projectStorefrontBuildCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-		} else if projectRoot, err = findClosestShopwareProject(false); err != nil {
+		} else if projectRoot, err = shop.FindClosestShopwareProject(false); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -30,7 +30,7 @@ var projectStorefrontWatchCmd = &cobra.Command{
 
 		if len(args) == 1 {
 			projectRoot = args[0]
-		} else if projectRoot, err = findClosestShopwareProject(false); err != nil {
+		} else if projectRoot, err = shop.FindClosestShopwareProject(false); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_upgrade.go
+++ b/cmd/project/project_upgrade.go
@@ -16,7 +16,7 @@ var projectUpgradeCmd = &cobra.Command{
 		"In a terminal this runs as an interactive wizard. With --no-interaction (or without a terminal, e.g. CI) the upgrade runs headless:\n" +
 		"--target is required there, --dry-run stops after the read-only preflight, and --no-audit continues when dependencies are blocked by security advisories.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectRoot, err := findClosestShopwareProject(false)
+		projectRoot, err := shop.FindClosestShopwareProject(false)
 		if err != nil {
 			return err
 		}

--- a/cmd/project/project_upgrade_check.go
+++ b/cmd/project/project_upgrade_check.go
@@ -17,6 +17,7 @@ import (
 	account_api "github.com/shopware/shopware-cli/internal/account-api"
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
 	"github.com/shopware/shopware-cli/internal/extension"
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tracking"
 	"github.com/shopware/shopware-cli/internal/tui"
@@ -31,7 +32,7 @@ var projectUpgradeCheckCmd = &cobra.Command{
 		var shopwareVersion *version.Version
 		var extensions map[string]string
 
-		projectRoot, err := findClosestShopwareProject(true)
+		projectRoot, err := shop.FindClosestShopwareProject(true)
 		if err != nil {
 			return err
 		}
@@ -186,7 +187,7 @@ func init() {
 }
 
 func getLocalExtensions() (*version.Version, map[string]string, error) {
-	project, err := findClosestShopwareProject(false)
+	project, err := shop.FindClosestShopwareProject(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/shopware/shopware-cli/internal/verifier"
@@ -43,7 +44,7 @@ var projectValidateCmd = &cobra.Command{
 		if len(args) > 0 {
 			projectPath = args[0]
 		} else {
-			projectPath, err = findClosestShopwareProject(false)
+			projectPath, err = shop.FindClosestShopwareProject(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -38,7 +38,7 @@ queue. The count per queue is optional and defaults to 1.`,
 		gracefulStopLimit, _ := cobraCmd.Flags().GetUint("graceful-stop-limit")
 		messagesLimit, _ := cobraCmd.Flags().GetUint("limit")
 
-		if projectRoot, err = findClosestShopwareProject(false); err != nil {
+		if projectRoot, err = shop.FindClosestShopwareProject(false); err != nil {
 			return err
 		}
 

--- a/internal/executor/ssh.go
+++ b/internal/executor/ssh.go
@@ -176,7 +176,7 @@ func (s *SSHExecutor) NPMCommand(ctx context.Context, args ...string) *Process {
 }
 
 func (s *SSHExecutor) AvailableLogFiles(ctx context.Context) ([]LogFile, error) {
-	out, err := s.PHPCommand(ctx, "-r", listLogFilesPHP(path.Join(s.directory, "var", "log"))).Output()
+	out, err := s.PHPCommand(ctx, "-r", listLogFilesPHP(path.Join(s.remoteDir(), "var", "log"))).Output()
 	if err != nil {
 		return nil, fmt.Errorf("could not list log files: %w", err)
 	}
@@ -207,7 +207,7 @@ func (s *SSHExecutor) NormalizePath(hostPath string) string {
 		return hostPath
 	}
 
-	return filepath.Join(s.directory, rel)
+	return path.Join(s.directory, filepath.ToSlash(rel))
 }
 
 func (s *SSHExecutor) Type() string {

--- a/internal/executor/ssh.go
+++ b/internal/executor/ssh.go
@@ -185,7 +185,7 @@ func (s *SSHExecutor) AvailableLogFiles(ctx context.Context) ([]LogFile, error) 
 }
 
 func (s *SSHExecutor) GetLog(ctx context.Context, file string, lines int, follow bool, w io.Writer) error {
-	p := s.command(ctx, "tail", tailArgs(path.Join(s.directory, "var", "log", file), lines, follow)...)
+	p := s.command(ctx, "tail", tailArgs(path.Join(s.remoteDir(), "var", "log", file), lines, follow)...)
 
 	return runStreaming(ctx, p.Cmd, w)
 }

--- a/internal/executor/ssh.go
+++ b/internal/executor/ssh.go
@@ -203,6 +203,9 @@ func (s *SSHExecutor) NormalizePath(hostPath string) string {
 	if err != nil {
 		return hostPath
 	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return hostPath
+	}
 
 	return filepath.Join(s.directory, rel)
 }

--- a/internal/executor/ssh_test.go
+++ b/internal/executor/ssh_test.go
@@ -447,6 +447,24 @@ func TestSSHExecutorAvailableLogFiles(t *testing.T) {
 	assert.Contains(t, string(recorded), "/var/www/shop/var/log/*.log")
 }
 
+func TestSSHExecutorAvailableLogFilesWithRelDir(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	outFile := filepath.Join(tmp, "out.txt")
+
+	require.NoError(t, os.WriteFile(outFile, []byte(`[{"name":"prod.log","size":10,"mtime":2000}]`), 0o644))
+	writeRecordingSSH(t, argsFile, outFile, "", "")
+
+	e := testSSHExecutor().WithRelDir("custom/plugins/Foo")
+
+	_, err := e.AvailableLogFiles(t.Context())
+	require.NoError(t, err)
+
+	recorded, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(recorded), "/var/www/shop/custom/plugins/Foo/var/log/*.log")
+}
+
 func TestSSHExecutorGetLog(t *testing.T) {
 	tmp := t.TempDir()
 	argsFile := filepath.Join(tmp, "args.txt")

--- a/internal/executor/ssh_test.go
+++ b/internal/executor/ssh_test.go
@@ -484,6 +484,24 @@ func TestSSHExecutorGetLog(t *testing.T) {
 	assert.Contains(t, string(recorded), "tail -n 100 /var/www/shop/var/log/prod.log")
 }
 
+func TestSSHExecutorGetLogWithRelDir(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	outFile := filepath.Join(tmp, "out.txt")
+
+	require.NoError(t, os.WriteFile(outFile, []byte("line1\n"), 0o644))
+	writeRecordingSSH(t, argsFile, outFile, "", "")
+
+	e := testSSHExecutor().WithRelDir("custom/plugins/Foo")
+
+	var buf bytes.Buffer
+	require.NoError(t, e.GetLog(t.Context(), "prod.log", 100, false, &buf))
+
+	recorded, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(recorded), "tail -n 100 /var/www/shop/custom/plugins/Foo/var/log/prod.log")
+}
+
 func TestShellQuoteArg(t *testing.T) {
 	assert.Equal(t, "cache:clear", shellQuoteArg("cache:clear"))
 	assert.Equal(t, "''", shellQuoteArg(""))

--- a/internal/executor/ssh_test.go
+++ b/internal/executor/ssh_test.go
@@ -238,9 +238,7 @@ func TestSSHExecutorNormalizePath(t *testing.T) {
 	e := testSSHExecutor()
 
 	assert.Equal(t, "/var/www/shop/custom/plugins/Foo", e.NormalizePath("/project/custom/plugins/Foo"))
-	// Mirrors the Docker executor: relative paths escaping the project root
-	// are joined into the remote project directory as-is.
-	assert.Equal(t, "/var/www/outside/project", e.NormalizePath("/outside/project"))
+	assert.Equal(t, "/outside/project", e.NormalizePath("/outside/project"))
 
 	noRoot := &SSHExecutor{host: "shop.example.com", directory: "/var/www/shop"}
 	assert.Equal(t, "/project/custom/plugins/Foo", noRoot.NormalizePath("/project/custom/plugins/Foo"))

--- a/internal/shop/project_root.go
+++ b/internal/shop/project_root.go
@@ -1,0 +1,76 @@
+package shop
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FindClosestShopwareProject walks from the current directory towards the
+// filesystem root until it finds a Shopware project. When allowFallback is
+// true, it returns the current directory if no project is found.
+func FindClosestShopwareProject(allowFallback bool) (string, error) {
+	if projectRoot := os.Getenv("PROJECT_ROOT"); projectRoot != "" {
+		// PROJECT_ROOT is an explicit override used by local tooling and tests.
+		// Keep it authoritative even when the project is only partially set up.
+		return filepath.Clean(projectRoot), nil
+	}
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	startDir := currentDir
+
+	for {
+		isProject, err := isShopwareProject(currentDir)
+		if err != nil {
+			return "", err
+		}
+		if isProject {
+			return currentDir, nil
+		}
+
+		parent := filepath.Dir(currentDir)
+		if parent == currentDir {
+			break
+		}
+		currentDir = parent
+	}
+
+	if allowFallback {
+		return startDir, nil
+	}
+
+	return "", errors.New("cannot find Shopware project in current directory")
+}
+
+func isShopwareProject(path string) (bool, error) {
+	info, err := os.Stat(filepath.Join(path, "bin", "console"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat bin/console: %w", err)
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+
+	for _, name := range []string{"composer.json", "composer.lock"} {
+		content, err := os.ReadFile(filepath.Join(path, name))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", filepath.Join(path, name), err)
+		}
+		if strings.Contains(string(content), "shopware/core") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/shop/project_root_test.go
+++ b/internal/shop/project_root_test.go
@@ -1,0 +1,102 @@
+package shop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindClosestShopwareProjectFallback(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	t.Chdir(t.TempDir())
+
+	_, err := FindClosestShopwareProject(false)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "cannot find Shopware project")
+	}
+
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	root, err := FindClosestShopwareProject(true)
+	if assert.NoError(t, err) {
+		assert.Equal(t, cwd, root)
+	}
+}
+
+func TestFindClosestShopwareProject(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	projectDir := createShopwareProject(t, "composer.json")
+	nestedDir := filepath.Join(projectDir, "custom", "plugins", "Example")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+	t.Chdir(nestedDir)
+
+	found, err := FindClosestShopwareProject(false)
+
+	require.NoError(t, err)
+	assert.Equal(t, projectDir, found)
+}
+
+func TestFindClosestShopwareProjectFromLockFile(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	projectDir := createShopwareProject(t, "composer.lock")
+	t.Chdir(projectDir)
+
+	found, err := FindClosestShopwareProject(false)
+
+	require.NoError(t, err)
+	assert.Equal(t, projectDir, found)
+}
+
+func TestFindClosestShopwareProjectUsesEnvironmentOverride(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "partly-configured-project")
+	t.Setenv("PROJECT_ROOT", projectDir+string(filepath.Separator))
+
+	found, err := FindClosestShopwareProject(false)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(projectDir), found)
+}
+
+func TestFindClosestShopwareProjectNotFound(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	t.Chdir(t.TempDir())
+
+	_, err := FindClosestShopwareProject(false)
+
+	assert.EqualError(t, err, "cannot find Shopware project in current directory")
+}
+
+func TestFindClosestShopwareProjectRequiresConsole(t *testing.T) {
+	t.Setenv("PROJECT_ROOT", "")
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "composer.json"),
+		[]byte(`{"require":{"shopware/core":"*" }}`),
+		0o644,
+	))
+	t.Chdir(projectDir)
+
+	_, err := FindClosestShopwareProject(false)
+
+	assert.ErrorContains(t, err, "cannot find Shopware project")
+}
+
+func createShopwareProject(t *testing.T, composerFile string) string {
+	t.Helper()
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(projectDir, "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "bin", "console"), nil, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, composerFile),
+		[]byte(`{"require":{"shopware/core":"*" }}`),
+		0o644,
+	))
+	return projectDir
+}


### PR DESCRIPTION
## What changed?
Moved the method "findClosestShopwareProject()" from platform to project_root and made it public. Also updated the usage in all findings of the deprecated private method.

## Why?
It is a helper function that other packages will also need to use, e.g. #1410 

## How was this tested?
- unit tests
- moved the related test with it

## Related issue or discussion
#1410 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project discovery now supports the `PROJECT_ROOT` environment override and consistently locates Shopware projects across project commands.
  - Project logs can be retrieved by specifying an explicit filename.

- **Bug Fixes**
  - Empty values passed to console environment options are now rejected with a clear error.
  - Explicitly requested missing log files now report an appropriate error.
  - Remote log access works correctly when using relative project directories.
  - Remote path handling now preserves paths outside the project root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->