### PR TITLE
fix(project): drop duplicate hint from create name placeholder

### DIFF
--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -154,7 +154,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, releases []repositor
 				huh.NewInput().
 					Title("Project Name").
 					Description(projectNameHelp).
-					Placeholder("my-shopware-project (leave empty for current directory)").
+					Placeholder("my-shopware-project").
 					Value(&opts.projectFolder).
 					Validate(func(s string) error {
 						if s == "" {


### PR DESCRIPTION
## What changed?
The Project Name input in `shopware-cli project create` showed "leave empty to use the current directory" twice: once in the field description and once again inside the placeholder. The placeholder is now just `my-shopware-project`. The description keeps the hint.

Before:
```
Project Name
The name of the project directory to create (leave empty to use the current directory)
> my-shopware-project (leave empty for current directory)
```

After:
```
Project Name
The name of the project directory to create (leave empty to use the current directory)
> my-shopware-project
```

## Why?
The repeated sentence adds noise without adding information. See the screenshot in the linked issue.

## How was this tested?
`go build ./...`, `go vet ./cmd/project/`, `go test ./cmd/project/` pass. No test referenced the placeholder text, so none needed updating.

## Related issue or discussion
Fixes #1494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Shortened the project-name input placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->