### PR TITLE
fix(extension): validate the icon once per extension

### DIFF
--- a/internal/extension/app_test.go
+++ b/internal/extension/app_test.go
@@ -31,6 +31,26 @@ var (
 	})
 )
 
+func TestRunValidationReportsMissingAppIconOnce(t *testing.T) {
+	appPath := testhelper.AppDir(t, testAppManifest)
+
+	app, err := newApp(t.Context(), appPath)
+
+	assert.NoError(t, err)
+
+	check := &testCheck{}
+	RunValidation(getTestContext(), app, check)
+
+	iconResults := 0
+	for _, result := range check.Results {
+		if result.Identifier == "metadata.icon" {
+			iconResults++
+		}
+	}
+
+	assert.Equal(t, 1, iconResults)
+}
+
 func TestIconNotExists(t *testing.T) {
 	appPath := testhelper.AppDir(t, testAppManifest)
 

--- a/internal/extension/bundle_test.go
+++ b/internal/extension/bundle_test.go
@@ -76,3 +76,24 @@ func TestCreateBundle(t *testing.T) {
 
 	assert.Equal(t, "FALLBACK", bundle.GetMetaData().Description.German)
 }
+
+func TestRunValidationSkipsIconCheckForBundle(t *testing.T) {
+	setupMockPHPVersionServer(t)
+	dir := testhelper.ExtensionDir(t, testhelper.ComposerJSON{
+		Name:    "shopware/test-bundle",
+		Version: "1.0.0",
+		Type:    "shopware-bundle",
+		Extra:   map[string]any{"shopware-bundle-name": "TestBundle"},
+		Psr4:    map[string]string{`TestBundle\`: "src/"},
+	})
+
+	bundle, err := newShopwareBundle(t.Context(), dir)
+	assert.NoError(t, err)
+
+	check := &testCheck{}
+	RunValidation(getTestContext(), bundle, check)
+
+	for _, result := range check.Results {
+		assert.NotEqual(t, "metadata.icon", result.Identifier, "a bundle has no icon path and must not report a missing icon")
+	}
+}

--- a/internal/extension/platform_test.go
+++ b/internal/extension/platform_test.go
@@ -96,6 +96,26 @@ func TestPluginIconNotExists(t *testing.T) {
 	assert.Equal(t, "The extension icon Resources/config/plugin.png does not exist", check.Results[0].Message)
 }
 
+func TestRunValidationReportsMissingPluginIconOnce(t *testing.T) {
+	setupMockPHPVersionServer(t)
+	dir := t.TempDir()
+
+	plugin := getTestPlugin(dir)
+
+	check := &testCheck{}
+
+	RunValidation(getTestContext(), plugin, check)
+
+	iconResults := 0
+	for _, result := range check.Results {
+		if result.Identifier == "metadata.icon" {
+			iconResults++
+		}
+	}
+
+	assert.Equal(t, 1, iconResults)
+}
+
 func TestPluginIconExists(t *testing.T) {
 	setupMockPHPVersionServer(t)
 	dir := t.TempDir()

--- a/internal/extension/validator.go
+++ b/internal/extension/validator.go
@@ -94,7 +94,6 @@ func RunValidation(ctx context.Context, ext Extension, check validation.Check) {
 	validateAdministrationSnippets(ext, check)
 	validateStorefrontSnippets(ext, check)
 	validateAssets(ext, check)
-	validateExtensionIcon(ext, check)
 	validateSymfonyXml(ext, check)
 	// Note: ignores are now applied in the verifier layer
 }


### PR DESCRIPTION
## What changed?

`RunValidation` no longer calls `validateExtensionIcon`. The plugin and app `Validate` methods already run that check, so the extra call made every icon problem appear twice. Three regression tests cover plugin, app and bundle; all three fail on `main`.

Before, on a plugin without an icon:

```
## Resources/config/plugin.png (2 problems)
- Error Resources/config/plugin.png: The extension icon Resources/config/plugin.png does not exist (`metadata.icon`)
- Error Resources/config/plugin.png: The extension icon Resources/config/plugin.png does not exist (`metadata.icon`)
```

Before, on any bundle (`ShopwareBundle.GetIconPath()` returns an empty string and the shared check has no empty-path guard):

```
- Error ..: The extension icon .. does not exist (`metadata.icon`)
```

After: the plugin reports the missing icon once, the bundle reports no icon problem.

## Why?

The second call arrived with c1ae665d (July 2025), which added `validateExtensionIcon` to `RunValidation` without removing it from the per-type `Validate` methods. Found while testing the Store readiness skill in #1462, whose evidence output showed every icon error duplicated.

## How was this tested?

- New tests `TestRunValidationReportsMissingPluginIconOnce`, `TestRunValidationReportsMissingAppIconOnce` and `TestRunValidationSkipsIconCheckForBundle` fail against the current `validator.go` (expected 1, actual 2; bundle gets an icon result) and pass with the fix.
- `go test ./internal/extension/`, `go vet`, `gofmt` clean.
- Built binary: plugin fixture and app fixture report `metadata.icon` exactly once, a minimal `shopware-bundle` fixture reports "No problems found" with exit 0.

## Related issue or discussion

Found during QA of #1462. No separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate missing-icon validation reports for applications and plugins.
  - Bundle extensions no longer receive irrelevant missing-icon validation errors.
  - Other validation checks continue to run as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->