### PR TITLE
chore(tui): remove unused fallbackShopURL constant

### DIFF
--- a/internal/tui/dev/model.go
+++ b/internal/tui/dev/model.go
@@ -53,10 +53,6 @@ const (
 	phasePortConflict
 )
 
-// fallbackShopURL is the URL a proxy project is reachable at once dev falls
-// back to fixed host ports; it matches project dev's own default.
-const fallbackShopURL = "http://127.0.0.1:8000"
-
 type Options struct {
 	ProjectRoot string
 	// ConfigPath is the path of the project configuration file; port overrides


### PR DESCRIPTION
## What changed?

Removes the unused `fallbackShopURL` constant and its comment from `internal/tui/dev/model.go`.

## Why?

The lint workflow on `main` fails since b0287f88 (#1489):

```
internal/tui/dev/model.go:58:7: const fallbackShopURL is unused (unused)
```

#1323 had replaced the constant's only use with `shop.DefaultShopURL`. #1489 was branched before that merge and, when brought up to date, re-added the constant and its comment but not the use.

## How was this tested?

`golangci-lint run ./internal/tui/...` reports 0 issues, `go build ./...` and `go test ./internal/tui/dev/` pass.

## Related issue or discussion

Unblocks lint on #1522 and every other open PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused fallback URL definition. Proxy fallback behavior continues using the default shop URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->