### PR TITLE
refactor: simplify CLI entry point

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -60,7 +60,8 @@ func commandNameFromArgs(argv []string) string {
 func commandNameFromBinaryPath(binaryPath string) string {
 	normalizedPath := strings.ReplaceAll(binaryPath, "\\", "/")
 	binaryName := strings.TrimSuffix(path.Base(normalizedPath), path.Ext(normalizedPath))
-	if binaryName == "" {
+	// path.Base yields "." for an empty path and "" for extension-only names.
+	if binaryName == "" || binaryName == "." {
 		return rootCmd.Use
 	}
 

--- a/cmd/args.go
+++ b/cmd/args.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"path"
+	"strings"
+)
+
+func mapAliasArgs(argv []string) []string {
+	if len(argv) == 0 {
+		return nil
+	}
+
+	args := argv[1:]
+	if !isSwxAlias(argv[0]) {
+		return args
+	}
+
+	if len(args) > 0 {
+		// Let users generate completion scripts for `swx` itself.
+		if args[0] == "completion" {
+			return args
+		}
+
+		// Cobra shell completion calls these internal commands.
+		// Prefixing `project console` preserves swx-as-console behavior for completions.
+		if args[0] == "__complete" || args[0] == "__completeNoDesc" {
+			aliasedCompletionArgs := make([]string, 0, len(args)+2)
+			aliasedCompletionArgs = append(aliasedCompletionArgs, args[0], "project", "console")
+			aliasedCompletionArgs = append(aliasedCompletionArgs, args[1:]...)
+
+			return aliasedCompletionArgs
+		}
+	}
+
+	// When invoked via the `swx` symlink, forward everything to `project console`.
+	aliasedArgs := make([]string, 0, len(args)+3)
+	aliasedArgs = append(aliasedArgs, "project", "console")
+
+	if len(args) == 0 {
+		aliasedArgs = append(aliasedArgs, "list")
+	} else {
+		aliasedArgs = append(aliasedArgs, args...)
+	}
+
+	return aliasedArgs
+}
+
+func isSwxAlias(binaryPath string) bool {
+	return strings.EqualFold(commandNameFromBinaryPath(binaryPath), "swx")
+}
+
+func commandNameFromArgs(argv []string) string {
+	if len(argv) == 0 {
+		return rootCmd.Use
+	}
+
+	return commandNameFromBinaryPath(argv[0])
+}
+
+func commandNameFromBinaryPath(binaryPath string) string {
+	normalizedPath := strings.ReplaceAll(binaryPath, "\\", "/")
+	binaryName := strings.TrimSuffix(path.Base(normalizedPath), path.Ext(normalizedPath))
+	if binaryName == "" {
+		return rootCmd.Use
+	}
+
+	return binaryName
+}

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapAliasArgs_EmptyArgv(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, mapAliasArgs(nil))
+	assert.Nil(t, mapAliasArgs([]string{}))
+}
+
+func TestMapAliasArgs_NoArgs(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{}, mapAliasArgs([]string{"shopware-cli"}))
+}
+
+func TestMapAliasArgs_RegularBinary(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"shopware-cli", "project", "console", "debug:router"})
+
+	assert.Equal(t, []string{"project", "console", "debug:router"}, args)
+}
+
+func TestMapAliasArgs_RenamedBinaryIsNotAliased(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/opt/bin/custom-cli", "cache:clear"})
+
+	assert.Equal(t, []string{"cache:clear"}, args)
+}
+
+func TestMapAliasArgs_SwxAlias(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/swx", "debug:router", "--env=prod"})
+
+	assert.Equal(t, []string{"project", "console", "debug:router", "--env=prod"}, args)
+}
+
+func TestMapAliasArgs_SwxAliasWithoutArgs(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/swx"})
+
+	assert.Equal(t, []string{"project", "console", "list"}, args)
+}
+
+func TestMapAliasArgs_SwxExeAlias(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"C:\\tools\\swx.exe", "cache:clear"})
+
+	assert.Equal(t, []string{"project", "console", "cache:clear"}, args)
+}
+
+func TestMapAliasArgs_SwxCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/SWX", "cache:clear"})
+
+	assert.Equal(t, []string{"project", "console", "cache:clear"}, args)
+}
+
+func TestMapAliasArgs_SwxCompletion(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/swx", "completion", "bash"})
+
+	assert.Equal(t, []string{"completion", "bash"}, args)
+}
+
+func TestMapAliasArgs_SwxInternalCompletion(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/swx", "__complete", "cache:clear"})
+
+	assert.Equal(t, []string{"__complete", "project", "console", "cache:clear"}, args)
+}
+
+func TestMapAliasArgs_SwxInternalCompletionNoDesc(t *testing.T) {
+	t.Parallel()
+	args := mapAliasArgs([]string{"/usr/local/bin/swx", "__completeNoDesc", "cache:clear"})
+
+	assert.Equal(t, []string{"__completeNoDesc", "project", "console", "cache:clear"}, args)
+}
+
+func TestMapAliasArgs_SwxHelp(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"project", "console", "--help"}, mapAliasArgs([]string{"/usr/local/bin/swx", "--help"}))
+	assert.Equal(t, []string{"project", "console", "-h"}, mapAliasArgs([]string{"/usr/local/bin/swx", "-h"}))
+}
+
+func TestMapAliasArgs_SwxVersion(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"project", "console", "--version"}, mapAliasArgs([]string{"/usr/local/bin/swx", "--version"}))
+	assert.Equal(t, []string{"project", "console", "-v"}, mapAliasArgs([]string{"/usr/local/bin/swx", "-v"}))
+}
+
+func TestMapAliasArgs_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	argv := []string{"/usr/local/bin/swx", "cache:clear"}
+
+	mapAliasArgs(argv)
+
+	assert.Equal(t, []string{"/usr/local/bin/swx", "cache:clear"}, argv)
+}
+
+func TestIsSwxAlias(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isSwxAlias("swx"))
+	assert.True(t, isSwxAlias("/usr/local/bin/swx"))
+	assert.True(t, isSwxAlias(`C:\tools\Swx.exe`))
+	assert.False(t, isSwxAlias("shopware-cli"))
+	assert.False(t, isSwxAlias("/usr/local/bin/swx-dev"))
+	assert.False(t, isSwxAlias(""))
+}
+
+func TestCommandNameFromArgs(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "shopware-cli", commandNameFromArgs([]string{"/usr/local/bin/shopware-cli"}))
+	assert.Equal(t, "swx", commandNameFromArgs([]string{"C:\\tools\\swx.exe"}))
+	assert.Equal(t, "custom-cli", commandNameFromArgs([]string{"custom-cli", "project"}))
+	assert.Equal(t, "shopware-cli", commandNameFromArgs(nil))
+}
+
+func TestCommandNameFromBinaryPath(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "shopware-cli", commandNameFromBinaryPath("shopware-cli"))
+	assert.Equal(t, "shopware-cli", commandNameFromBinaryPath("/usr/local/bin/shopware-cli"))
+	assert.Equal(t, "shopware-cli", commandNameFromBinaryPath(`C:\Program Files\shopware-cli.exe`))
+	assert.Equal(t, "swx", commandNameFromBinaryPath("./swx"))
+	assert.Equal(t, "shopware-cli", commandNameFromBinaryPath(""), "empty path falls back to the root command name")
+	assert.Equal(t, "shopware-cli", commandNameFromBinaryPath(".exe"), "extension-only path falls back to the root command name")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"slices"
@@ -52,14 +53,24 @@ func Execute(ctx context.Context) int {
 	err := rootCmd.ExecuteContext(ctx)
 
 	trackCommandExecution(ctx, args, start, err)
-	printUpdateHint(ctx, updateHandle.Wait(ctx).Release)
+	printUpdateHint(ctx, os.Stderr, updateHandle.Wait(ctx).Release)
 
-	if err != nil {
-		logging.FromContext(ctx).Errorln(err)
-		return 1
+	return exitCode(ctx, err)
+}
+
+// exitCode maps the command error to the process exit code. Status errors are
+// already printed by the command as a human-readable status, so they exit 1
+// without logging the error again.
+func exitCode(ctx context.Context, err error) int {
+	if err == nil {
+		return 0
 	}
 
-	return 0
+	if !errors.Is(err, project.ErrEnvironmentDown) && !errors.Is(err, project.ErrProxyNotRegistered) {
+		logging.FromContext(ctx).Errorln(err)
+	}
+
+	return 1
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ func Execute(ctx context.Context) int {
 	start := time.Now()
 	err := rootCmd.ExecuteContext(ctx)
 
-	trackCommandExecution(ctx, os.Args[1:], start, err)
+	trackCommandExecution(ctx, args, start, err)
 	printUpdateHint(ctx, updateHandle.Wait(ctx).Release)
 
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,16 +2,9 @@ package cmd
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
-	"path"
-	"runtime"
 	"slices"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -24,9 +17,7 @@ import (
 	"github.com/shopware/shopware-cli/cmd/project"
 	accountApi "github.com/shopware/shopware-cli/internal/account-api"
 	"github.com/shopware/shopware-cli/internal/system"
-	"github.com/shopware/shopware-cli/internal/tracking"
 	"github.com/shopware/shopware-cli/internal/tui"
-	"github.com/shopware/shopware-cli/internal/update"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -39,13 +30,8 @@ var rootCmd = &cobra.Command{
 	Version: version,
 }
 
-func Execute(ctx context.Context) {
-	os.Exit(run(ctx))
-}
-
-// run executes the root command and returns the process exit code. It is kept
-// separate from Execute so its deferred cleanup runs before os.Exit is called.
-func run(ctx context.Context) int {
+// Execute runs the root command and returns the process exit code after cleanup.
+func Execute(ctx context.Context) int {
 	rootCmd.Use = commandNameFromArgs(os.Args)
 	args := mapAliasArgs(os.Args)
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
@@ -59,81 +45,14 @@ func run(ctx context.Context) int {
 	accountApi.SetUserAgent("shopware-cli/" + version)
 	rootCmd.SetArgs(args)
 
-	// Check for update in the background. Interactive TUIs consume the same
-	// result through the shared header's update hint.
-	updateCtx, updateCancel := context.WithTimeout(ctx, 900*time.Millisecond)
+	updateHandle, updateCancel := startUpdateCheck(ctx, args)
 	defer updateCancel()
-	updateHandle := update.NewCheckHandle()
-	tui.UpdateAvailable = func(waitCtx context.Context) bool {
-		result := updateHandle.Wait(waitCtx)
-		if result.Release == nil {
-			return false
-		}
-		binaryPath, _ := os.Executable()
-		return update.ShouldNotify(result.Release, binaryPath)
-	}
-
-	go func() {
-		var releaseInfo *update.ReleaseInfo
-		var err error
-		if !update.ShouldCheckForUpdate(version, args) {
-			err = update.ErrNoUpdateAvailable
-		} else {
-			releaseInfo, err = update.CheckForUpdate(updateCtx, version, &http.Client{Timeout: 5 * time.Second})
-		}
-		if err != nil && !errors.Is(err, update.ErrNoUpdateAvailable) {
-			logging.FromContext(ctx).Debugf("checking for shopware cli update failed: %v", err)
-		}
-		updateHandle.Complete(update.CheckResult{Release: releaseInfo, Err: err})
-	}()
 
 	start := time.Now()
 	err := rootCmd.ExecuteContext(ctx)
 
-	if cmd, _, findErr := rootCmd.Find(os.Args[1:]); findErr == nil && cmd != rootCmd && cmd.RunE != nil {
-		result := tracking.ResultSuccess
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				result = tracking.ResultCancelled
-			} else {
-				result = tracking.ResultFailure
-			}
-		}
-		name := strings.TrimPrefix(cmd.CommandPath(), "shopware-cli ")
-		name = strings.ReplaceAll(name, " ", ".")
-		name = strings.ReplaceAll(name, "-", "_")
-		trackCtx, trackCancel := context.WithTimeout(context.WithoutCancel(ctx), 300*time.Millisecond)
-		defer trackCancel()
-		tracking.Track(trackCtx, tracking.EventCommand, map[string]string{
-			tracking.TagCommandName: name,
-			tracking.TagResult:      result,
-			tracking.TagDurationMS:  strconv.FormatInt(time.Since(start).Milliseconds(), 10),
-			tracking.TagCLIVersion:  version,
-			tracking.TagOS:          runtime.GOOS,
-			tracking.TagIsTUI:       strconv.FormatBool(system.IsInteractionEnabled(ctx)),
-		})
-	}
-
-	updateResult := updateHandle.Wait(ctx)
-	newRelease := updateResult.Release
-	if newRelease != nil {
-		binaryPath, err := os.Executable()
-		if err != nil {
-			logging.FromContext(ctx).Debugf("could not determine binary path: %v", err)
-		}
-		if update.ShouldNotify(newRelease, binaryPath) && update.ShouldPrintUpdateHint() {
-			fmt.Fprintln(os.Stderr, update.RenderUpdateNotification(newRelease.Version, version))
-			if err := update.MarkUpdateNotificationPrinted(); err != nil {
-				logging.FromContext(ctx).Debugf("could not save update notification timestamp: %v", err)
-			}
-		}
-	}
-
-	if errors.Is(err, project.ErrEnvironmentDown) || errors.Is(err, project.ErrProxyNotRegistered) {
-		// The command already printed a human-readable status; exit 1 without
-		// logging an error.
-		return 1
-	}
+	trackCommandExecution(ctx, os.Args[1:], start, err)
+	printUpdateHint(ctx, updateHandle.Wait(ctx).Release)
 
 	if err != nil {
 		logging.FromContext(ctx).Errorln(err)
@@ -141,68 +60,6 @@ func run(ctx context.Context) int {
 	}
 
 	return 0
-}
-
-func mapAliasArgs(argv []string) []string {
-	if len(argv) == 0 {
-		return nil
-	}
-
-	args := argv[1:]
-	if !isSwxAlias(argv[0]) {
-		return args
-	}
-
-	if len(args) > 0 {
-		// Let users generate completion scripts for `swx` itself.
-		if args[0] == "completion" {
-			return args
-		}
-
-		// Cobra shell completion calls these internal commands.
-		// Prefixing `project console` preserves swx-as-console behavior for completions.
-		if args[0] == "__complete" || args[0] == "__completeNoDesc" {
-			aliasedCompletionArgs := make([]string, 0, len(args)+2)
-			aliasedCompletionArgs = append(aliasedCompletionArgs, args[0], "project", "console")
-			aliasedCompletionArgs = append(aliasedCompletionArgs, args[1:]...)
-
-			return aliasedCompletionArgs
-		}
-	}
-
-	// When invoked via the `swx` symlink, forward everything to `project console`.
-	aliasedArgs := make([]string, 0, len(args)+3)
-	aliasedArgs = append(aliasedArgs, "project", "console")
-
-	if len(args) == 0 {
-		aliasedArgs = append(aliasedArgs, "list")
-	} else {
-		aliasedArgs = append(aliasedArgs, args...)
-	}
-
-	return aliasedArgs
-}
-
-func isSwxAlias(binaryPath string) bool {
-	return strings.EqualFold(commandNameFromBinaryPath(binaryPath), "swx")
-}
-
-func commandNameFromArgs(argv []string) string {
-	if len(argv) == 0 {
-		return rootCmd.Use
-	}
-
-	return commandNameFromBinaryPath(argv[0])
-}
-
-func commandNameFromBinaryPath(binaryPath string) string {
-	normalizedPath := strings.ReplaceAll(binaryPath, "\\", "/")
-	binaryName := strings.TrimSuffix(path.Base(normalizedPath), path.Ext(normalizedPath))
-	if binaryName == "" {
-		return rootCmd.Use
-	}
-
-	return binaryName
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,91 +4,18 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/shopware/shopware-cli/cmd/project"
+	"github.com/shopware/shopware-cli/logging"
 )
-
-func TestMapAliasArgs_NoArgs(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, []string{}, mapAliasArgs([]string{"shopware-cli"}))
-}
-
-func TestMapAliasArgs_RegularBinary(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"shopware-cli", "project", "console", "debug:router"})
-
-	assert.Equal(t, []string{"project", "console", "debug:router"}, args)
-}
-
-func TestMapAliasArgs_SwxAlias(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/swx", "debug:router", "--env=prod"})
-
-	assert.Equal(t, []string{"project", "console", "debug:router", "--env=prod"}, args)
-}
-
-func TestMapAliasArgs_SwxAliasWithoutArgs(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/swx"})
-
-	assert.Equal(t, []string{"project", "console", "list"}, args)
-}
-
-func TestMapAliasArgs_SwxExeAlias(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"C:\\tools\\swx.exe", "cache:clear"})
-
-	assert.Equal(t, []string{"project", "console", "cache:clear"}, args)
-}
-
-func TestMapAliasArgs_SwxCaseInsensitive(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/SWX", "cache:clear"})
-
-	assert.Equal(t, []string{"project", "console", "cache:clear"}, args)
-}
-
-func TestMapAliasArgs_SwxCompletion(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/swx", "completion", "bash"})
-
-	assert.Equal(t, []string{"completion", "bash"}, args)
-}
-
-func TestMapAliasArgs_SwxInternalCompletion(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/swx", "__complete", "cache:clear"})
-
-	assert.Equal(t, []string{"__complete", "project", "console", "cache:clear"}, args)
-}
-
-func TestMapAliasArgs_SwxInternalCompletionNoDesc(t *testing.T) {
-	t.Parallel()
-	args := mapAliasArgs([]string{"/usr/local/bin/swx", "__completeNoDesc", "cache:clear"})
-
-	assert.Equal(t, []string{"__completeNoDesc", "project", "console", "cache:clear"}, args)
-}
-
-func TestMapAliasArgs_SwxHelp(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, []string{"project", "console", "--help"}, mapAliasArgs([]string{"/usr/local/bin/swx", "--help"}))
-	assert.Equal(t, []string{"project", "console", "-h"}, mapAliasArgs([]string{"/usr/local/bin/swx", "-h"}))
-}
-
-func TestMapAliasArgs_SwxVersion(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, []string{"project", "console", "--version"}, mapAliasArgs([]string{"/usr/local/bin/swx", "--version"}))
-	assert.Equal(t, []string{"project", "console", "-v"}, mapAliasArgs([]string{"/usr/local/bin/swx", "-v"}))
-}
-
-func TestCommandNameFromArgs(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "shopware-cli", commandNameFromArgs([]string{"/usr/local/bin/shopware-cli"}))
-	assert.Equal(t, "swx", commandNameFromArgs([]string{"C:\\tools\\swx.exe"}))
-	assert.Equal(t, "shopware-cli", commandNameFromArgs(nil))
-}
 
 func executeRootWithCommand(t *testing.T, runErr error, args ...string) (string, error) {
 	t.Helper()
@@ -130,4 +57,62 @@ func TestInvocationErrorPrintsUsage(t *testing.T) {
 
 	assert.ErrorContains(t, err, "unknown flag")
 	assert.Contains(t, out, "Usage:")
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantLog  []string
+	}{
+		{
+			name:     "success",
+			err:      nil,
+			wantCode: 0,
+		},
+		{
+			name:     "runtime error is logged",
+			err:      errors.New("something broke"),
+			wantCode: 1,
+			wantLog:  []string{"something broke"},
+		},
+		{
+			name:     "wrapped runtime error is logged",
+			err:      fmt.Errorf("running command: %w", errors.New("something broke")),
+			wantCode: 1,
+			wantLog:  []string{"running command: something broke"},
+		},
+		{
+			name:     "environment down exits silently",
+			err:      project.ErrEnvironmentDown,
+			wantCode: 1,
+		},
+		{
+			name:     "wrapped environment down exits silently",
+			err:      fmt.Errorf("status: %w", project.ErrEnvironmentDown),
+			wantCode: 1,
+		},
+		{
+			name:     "proxy not registered exits silently",
+			err:      project.ErrProxyNotRegistered,
+			wantCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			ctx := logging.WithLogger(context.Background(), zap.New(core).Sugar())
+
+			assert.Equal(t, tt.wantCode, exitCode(ctx, tt.err))
+
+			var messages []string
+			for _, entry := range logs.All() {
+				assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+				messages = append(messages, entry.Message)
+			}
+			assert.Equal(t, tt.wantLog, messages)
+		})
+	}
 }

--- a/cmd/tracking.go
+++ b/cmd/tracking.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/tracking"
+)
+
+func trackCommandExecution(ctx context.Context, args []string, start time.Time, runErr error) {
+	cmd, _, err := rootCmd.Find(args)
+	if err != nil || cmd == rootCmd || cmd.RunE == nil {
+		return
+	}
+
+	result := tracking.ResultSuccess
+	if runErr != nil {
+		if errors.Is(runErr, context.Canceled) {
+			result = tracking.ResultCancelled
+		} else {
+			result = tracking.ResultFailure
+		}
+	}
+	name := strings.TrimPrefix(cmd.CommandPath(), "shopware-cli ")
+	name = strings.ReplaceAll(name, " ", ".")
+	name = strings.ReplaceAll(name, "-", "_")
+	trackCtx, trackCancel := context.WithTimeout(context.WithoutCancel(ctx), 300*time.Millisecond)
+	defer trackCancel()
+	tracking.Track(trackCtx, tracking.EventCommand, map[string]string{
+		tracking.TagCommandName: name,
+		tracking.TagResult:      result,
+		tracking.TagDurationMS:  strconv.FormatInt(time.Since(start).Milliseconds(), 10),
+		tracking.TagCLIVersion:  version,
+		tracking.TagOS:          runtime.GOOS,
+		tracking.TagIsTUI:       strconv.FormatBool(system.IsInteractionEnabled(ctx)),
+	})
+}

--- a/cmd/tracking.go
+++ b/cmd/tracking.go
@@ -12,6 +12,8 @@ import (
 	"github.com/shopware/shopware-cli/internal/tracking"
 )
 
+var trackEvent = tracking.Track
+
 func trackCommandExecution(ctx context.Context, args []string, start time.Time, runErr error) {
 	cmd, _, err := rootCmd.Find(args)
 	if err != nil || cmd == rootCmd || cmd.RunE == nil {
@@ -26,12 +28,12 @@ func trackCommandExecution(ctx context.Context, args []string, start time.Time, 
 			result = tracking.ResultFailure
 		}
 	}
-	name := strings.TrimPrefix(cmd.CommandPath(), "shopware-cli ")
+	name := strings.TrimPrefix(cmd.CommandPath(), rootCmd.Name()+" ")
 	name = strings.ReplaceAll(name, " ", ".")
 	name = strings.ReplaceAll(name, "-", "_")
 	trackCtx, trackCancel := context.WithTimeout(context.WithoutCancel(ctx), 300*time.Millisecond)
 	defer trackCancel()
-	tracking.Track(trackCtx, tracking.EventCommand, map[string]string{
+	trackEvent(trackCtx, tracking.EventCommand, map[string]string{
 		tracking.TagCommandName: name,
 		tracking.TagResult:      result,
 		tracking.TagDurationMS:  strconv.FormatInt(time.Since(start).Milliseconds(), 10),

--- a/cmd/tracking_test.go
+++ b/cmd/tracking_test.go
@@ -2,84 +2,177 @@ package cmd
 
 import (
 	"context"
-	"os"
+	"errors"
+	"runtime"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tracking"
-	"github.com/shopware/shopware-cli/internal/tui"
 )
 
-func TestExecuteTracksConsoleAcrossBinaryNames(t *testing.T) {
+// useTrackingTestRoot swaps rootCmd for a minimal tree containing
+// `project console` and `extension build-me` and captures tracked events.
+func useTrackingTestRoot(t *testing.T, rootName string) *[]map[string]string {
+	t.Helper()
+
+	originalRoot, originalTrack := rootCmd, trackEvent
+	t.Cleanup(func() {
+		rootCmd, trackEvent = originalRoot, originalTrack
+	})
+
+	rootCmd = &cobra.Command{Use: rootName}
+	projectCmd := &cobra.Command{Use: "project"}
+	projectCmd.AddCommand(&cobra.Command{
+		Use:                "console",
+		DisableFlagParsing: true,
+		RunE:               func(*cobra.Command, []string) error { return nil },
+	})
+	extensionCmd := &cobra.Command{Use: "extension"}
+	extensionCmd.AddCommand(&cobra.Command{
+		Use:  "build-me",
+		RunE: func(*cobra.Command, []string) error { return nil },
+	})
+	rootCmd.AddCommand(projectCmd, extensionCmd)
+
+	events := &[]map[string]string{}
+	trackEvent = func(_ context.Context, event string, tags map[string]string) {
+		assert.Equal(t, tracking.EventCommand, event)
+		*events = append(*events, tags)
+	}
+
+	return events
+}
+
+func TestTrackCommandExecution_NormalizesNameAcrossBinaryNames(t *testing.T) {
 	tests := []struct {
-		name        string
-		argv        []string
-		consoleArgs []string
+		name string
+		argv []string
 	}{
-		{
-			name:        "regular binary",
-			argv:        []string{"shopware-cli", "project", "console", "cache:clear"},
-			consoleArgs: []string{"cache:clear"},
-		},
-		{
-			name:        "swx alias",
-			argv:        []string{"/usr/local/bin/swx", "cache:clear"},
-			consoleArgs: []string{"cache:clear"},
-		},
-		{
-			name:        "swx default command",
-			argv:        []string{"swx"},
-			consoleArgs: []string{"list"},
-		},
-		{
-			name:        "windows alias",
-			argv:        []string{`C:\tools\swx.exe`, "cache:clear"},
-			consoleArgs: []string{"cache:clear"},
-		},
-		{
-			name:        "renamed binary",
-			argv:        []string{"custom-cli", "project", "console", "cache:clear"},
-			consoleArgs: []string{"cache:clear"},
-		},
+		{name: "regular binary", argv: []string{"shopware-cli", "project", "console", "cache:clear"}},
+		{name: "swx alias", argv: []string{"/usr/local/bin/swx", "cache:clear"}},
+		{name: "swx default command", argv: []string{"swx"}},
+		{name: "windows alias", argv: []string{`C:\tools\swx.exe`, "cache:clear"}},
+		{name: "renamed binary", argv: []string{"custom-cli", "project", "console", "cache:clear"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalRoot, originalArgs, originalTrack := rootCmd, os.Args, trackEvent
-			originalUpdateAvailable := tui.UpdateAvailable
-			t.Cleanup(func() {
-				rootCmd, os.Args, trackEvent = originalRoot, originalArgs, originalTrack
-				tui.UpdateAvailable = originalUpdateAvailable
-			})
+			// Execute sets rootCmd.Use to the invoked binary name before tracking.
+			events := useTrackingTestRoot(t, commandNameFromArgs(tt.argv))
 
-			rootCmd = &cobra.Command{Use: "shopware-cli"}
-			projectCmd := &cobra.Command{Use: "project"}
-			var executedArgs []string
-			projectCmd.AddCommand(&cobra.Command{
-				Use:                "console",
-				DisableFlagParsing: true,
-				RunE: func(_ *cobra.Command, args []string) error {
-					executedArgs = args
-					return nil
-				},
-			})
-			rootCmd.AddCommand(projectCmd)
-			os.Args = tt.argv
+			trackCommandExecution(context.Background(), mapAliasArgs(tt.argv), time.Now(), nil)
 
-			var events []map[string]string
-			trackEvent = func(_ context.Context, event string, tags map[string]string) {
-				assert.Equal(t, tracking.EventCommand, event)
-				events = append(events, tags)
-			}
-
-			assert.Zero(t, Execute(t.Context()))
-			assert.Equal(t, tt.consoleArgs, executedArgs)
-			if assert.Len(t, events, 1) {
-				assert.Equal(t, "project.console", events[0][tracking.TagCommandName])
-				assert.Equal(t, tracking.ResultSuccess, events[0][tracking.TagResult])
-			}
+			require.Len(t, *events, 1)
+			assert.Equal(t, "project.console", (*events)[0][tracking.TagCommandName])
+			assert.Equal(t, tracking.ResultSuccess, (*events)[0][tracking.TagResult])
 		})
 	}
+}
+
+func TestTrackCommandExecution_ReplacesHyphensAndSpaces(t *testing.T) {
+	events := useTrackingTestRoot(t, "shopware-cli")
+
+	trackCommandExecution(context.Background(), []string{"extension", "build-me", "./plugin"}, time.Now(), nil)
+
+	require.Len(t, *events, 1)
+	assert.Equal(t, "extension.build_me", (*events)[0][tracking.TagCommandName])
+}
+
+func TestTrackCommandExecution_Result(t *testing.T) {
+	tests := []struct {
+		name   string
+		runErr error
+		want   string
+	}{
+		{name: "success", runErr: nil, want: tracking.ResultSuccess},
+		{name: "failure", runErr: errors.New("boom"), want: tracking.ResultFailure},
+		{name: "cancelled", runErr: context.Canceled, want: tracking.ResultCancelled},
+		{name: "wrapped cancelled", runErr: errors.Join(errors.New("stopped"), context.Canceled), want: tracking.ResultCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := useTrackingTestRoot(t, "shopware-cli")
+
+			trackCommandExecution(context.Background(), []string{"project", "console"}, time.Now(), tt.runErr)
+
+			require.Len(t, *events, 1)
+			assert.Equal(t, tt.want, (*events)[0][tracking.TagResult])
+		})
+	}
+}
+
+func TestTrackCommandExecution_Tags(t *testing.T) {
+	events := useTrackingTestRoot(t, "shopware-cli")
+	ctx := system.WithInteraction(context.Background(), true)
+
+	trackCommandExecution(ctx, []string{"project", "console"}, time.Now().Add(-2*time.Second), nil)
+
+	require.Len(t, *events, 1)
+	tags := (*events)[0]
+	assert.Equal(t, version, tags[tracking.TagCLIVersion])
+	assert.Equal(t, runtime.GOOS, tags[tracking.TagOS])
+	assert.Equal(t, "true", tags[tracking.TagIsTUI])
+
+	durationMS, err := strconv.ParseInt(tags[tracking.TagDurationMS], 10, 64)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, durationMS, int64(2000))
+}
+
+func TestTrackCommandExecution_IsTUIFollowsInteraction(t *testing.T) {
+	events := useTrackingTestRoot(t, "shopware-cli")
+	ctx := system.WithInteraction(context.Background(), false)
+
+	trackCommandExecution(ctx, []string{"project", "console"}, time.Now(), nil)
+
+	require.Len(t, *events, 1)
+	assert.Equal(t, "false", (*events)[0][tracking.TagIsTUI])
+}
+
+func TestTrackCommandExecution_SkipsNonRunnableInvocations(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "no arguments resolves to root", args: nil},
+		{name: "root flag only", args: []string{"--help"}},
+		{name: "group command without RunE", args: []string{"project"}},
+		{name: "unknown command", args: []string{"does-not-exist"}},
+		{name: "unknown subcommand", args: []string{"project", "does-not-exist"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := useTrackingTestRoot(t, "shopware-cli")
+
+			trackCommandExecution(context.Background(), tt.args, time.Now(), nil)
+
+			assert.Empty(t, *events)
+		})
+	}
+}
+
+func TestTrackCommandExecution_TracksAfterContextCancelled(t *testing.T) {
+	events := useTrackingTestRoot(t, "shopware-cli")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var trackCtxErr error
+	originalTrack := trackEvent
+	trackEvent = func(trackCtx context.Context, event string, tags map[string]string) {
+		trackCtxErr = trackCtx.Err()
+		originalTrack(trackCtx, event, tags)
+	}
+
+	trackCommandExecution(ctx, []string{"project", "console"}, time.Now(), ctx.Err())
+
+	require.Len(t, *events, 1)
+	assert.Equal(t, tracking.ResultCancelled, (*events)[0][tracking.TagResult])
+	assert.NoError(t, trackCtxErr, "tracking must get a live context even after the command context was cancelled")
 }

--- a/cmd/tracking_test.go
+++ b/cmd/tracking_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/tracking"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+func TestExecuteTracksConsoleAcrossBinaryNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		argv        []string
+		consoleArgs []string
+	}{
+		{
+			name:        "regular binary",
+			argv:        []string{"shopware-cli", "project", "console", "cache:clear"},
+			consoleArgs: []string{"cache:clear"},
+		},
+		{
+			name:        "swx alias",
+			argv:        []string{"/usr/local/bin/swx", "cache:clear"},
+			consoleArgs: []string{"cache:clear"},
+		},
+		{
+			name:        "swx default command",
+			argv:        []string{"swx"},
+			consoleArgs: []string{"list"},
+		},
+		{
+			name:        "windows alias",
+			argv:        []string{`C:\tools\swx.exe`, "cache:clear"},
+			consoleArgs: []string{"cache:clear"},
+		},
+		{
+			name:        "renamed binary",
+			argv:        []string{"custom-cli", "project", "console", "cache:clear"},
+			consoleArgs: []string{"cache:clear"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalRoot, originalArgs, originalTrack := rootCmd, os.Args, trackEvent
+			originalUpdateAvailable := tui.UpdateAvailable
+			t.Cleanup(func() {
+				rootCmd, os.Args, trackEvent = originalRoot, originalArgs, originalTrack
+				tui.UpdateAvailable = originalUpdateAvailable
+			})
+
+			rootCmd = &cobra.Command{Use: "shopware-cli"}
+			projectCmd := &cobra.Command{Use: "project"}
+			var executedArgs []string
+			projectCmd.AddCommand(&cobra.Command{
+				Use:                "console",
+				DisableFlagParsing: true,
+				RunE: func(_ *cobra.Command, args []string) error {
+					executedArgs = args
+					return nil
+				},
+			})
+			rootCmd.AddCommand(projectCmd)
+			os.Args = tt.argv
+
+			var events []map[string]string
+			trackEvent = func(_ context.Context, event string, tags map[string]string) {
+				assert.Equal(t, tracking.EventCommand, event)
+				events = append(events, tags)
+			}
+
+			assert.Zero(t, Execute(t.Context()))
+			assert.Equal(t, tt.consoleArgs, executedArgs)
+			if assert.Len(t, events, 1) {
+				assert.Equal(t, "project.console", events[0][tracking.TagCommandName])
+				assert.Equal(t, tracking.ResultSuccess, events[0][tracking.TagResult])
+			}
+		})
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -44,7 +45,9 @@ func startUpdateCheck(ctx context.Context, args []string) (*update.CheckHandle, 
 	return handle, cancel
 }
 
-func printUpdateHint(ctx context.Context, release *update.ReleaseInfo) {
+// printUpdateHint writes the update notification to w when a newer release is
+// available and the notification was not already printed recently.
+func printUpdateHint(ctx context.Context, w io.Writer, release *update.ReleaseInfo) {
 	if release == nil {
 		return
 	}
@@ -57,7 +60,7 @@ func printUpdateHint(ctx context.Context, release *update.ReleaseInfo) {
 		return
 	}
 
-	fmt.Fprintln(os.Stderr, update.RenderUpdateNotification(release.Version, version))
+	_, _ = fmt.Fprintln(w, update.RenderUpdateNotification(release.Version, version))
 	if err := update.MarkUpdateNotificationPrinted(); err != nil {
 		logging.FromContext(ctx).Debugf("could not save update notification timestamp: %v", err)
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+	"github.com/shopware/shopware-cli/internal/update"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+// startUpdateCheck shares the background update check with interactive TUIs.
+// The caller must cancel the check when command execution finishes.
+func startUpdateCheck(ctx context.Context, args []string) (*update.CheckHandle, context.CancelFunc) {
+	updateCtx, cancel := context.WithTimeout(ctx, 900*time.Millisecond)
+	handle := update.NewCheckHandle()
+	tui.UpdateAvailable = func(waitCtx context.Context) bool {
+		result := handle.Wait(waitCtx)
+		if result.Release == nil {
+			return false
+		}
+		binaryPath, _ := os.Executable()
+		return update.ShouldNotify(result.Release, binaryPath)
+	}
+
+	go func() {
+		var releaseInfo *update.ReleaseInfo
+		var err error
+		if !update.ShouldCheckForUpdate(version, args) {
+			err = update.ErrNoUpdateAvailable
+		} else {
+			releaseInfo, err = update.CheckForUpdate(updateCtx, version, &http.Client{Timeout: 5 * time.Second})
+		}
+		if err != nil && !errors.Is(err, update.ErrNoUpdateAvailable) {
+			logging.FromContext(ctx).Debugf("checking for shopware cli update failed: %v", err)
+		}
+		handle.Complete(update.CheckResult{Release: releaseInfo, Err: err})
+	}()
+
+	return handle, cancel
+}
+
+func printUpdateHint(ctx context.Context, release *update.ReleaseInfo) {
+	if release == nil {
+		return
+	}
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		logging.FromContext(ctx).Debugf("could not determine binary path: %v", err)
+	}
+	if !update.ShouldNotify(release, binaryPath) || !update.ShouldPrintUpdateHint() {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, update.RenderUpdateNotification(release.Version, version))
+	if err := update.MarkUpdateNotificationPrinted(); err != nil {
+		logging.FromContext(ctx).Debugf("could not save update notification timestamp: %v", err)
+	}
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+	"github.com/shopware/shopware-cli/internal/update"
+)
+
+// isolateUpdateEnvironment points caches at a temp dir, hides brew from PATH
+// so the binary never counts as Homebrew-managed, and clears CI markers.
+func isolateUpdateEnvironment(t *testing.T) string {
+	t.Helper()
+
+	cacheDir := t.TempDir()
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", cacheDir)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("SHOPWARE_CLI_NO_UPDATE_NOTIFICATION", "")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	return cacheDir
+}
+
+func setVersion(t *testing.T, v string) {
+	t.Helper()
+	original := version
+	version = v
+	t.Cleanup(func() { version = original })
+}
+
+func restoreUpdateAvailable(t *testing.T) {
+	t.Helper()
+	original := tui.UpdateAvailable
+	t.Cleanup(func() { tui.UpdateAvailable = original })
+}
+
+func TestStartUpdateCheck_DevBuildReportsNoRelease(t *testing.T) {
+	isolateUpdateEnvironment(t)
+	setVersion(t, "dev")
+	restoreUpdateAvailable(t)
+
+	handle, cancel := startUpdateCheck(context.Background(), nil)
+	defer cancel()
+
+	result := handle.Wait(context.Background())
+	assert.Nil(t, result.Release)
+	assert.ErrorIs(t, result.Err, update.ErrNoUpdateAvailable)
+
+	require.NotNil(t, tui.UpdateAvailable)
+	assert.False(t, tui.UpdateAvailable(context.Background()))
+}
+
+func TestStartUpdateCheck_OptOutFlagSkipsCheck(t *testing.T) {
+	isolateUpdateEnvironment(t)
+	setVersion(t, "1.0.0")
+	restoreUpdateAvailable(t)
+
+	for _, flag := range []string{"--no-update-hint", "-n"} {
+		t.Run(flag, func(t *testing.T) {
+			handle, cancel := startUpdateCheck(context.Background(), []string{"project", "console", flag})
+			defer cancel()
+
+			result := handle.Wait(context.Background())
+			assert.Nil(t, result.Release)
+			assert.ErrorIs(t, result.Err, update.ErrNoUpdateAvailable)
+			assert.False(t, tui.UpdateAvailable(context.Background()))
+		})
+	}
+}
+
+func TestPrintUpdateHint_NoReleaseDoesNothing(t *testing.T) {
+	cacheDir := isolateUpdateEnvironment(t)
+
+	var out bytes.Buffer
+	printUpdateHint(context.Background(), &out, nil)
+
+	assert.Empty(t, out.String())
+	assert.NoFileExists(t, filepath.Join(cacheDir, "update-notification.json"))
+}
+
+func TestPrintUpdateHint_PrintsOnceAndRecordsTimestamp(t *testing.T) {
+	cacheDir := isolateUpdateEnvironment(t)
+	setVersion(t, "1.0.0")
+
+	release := &update.ReleaseInfo{Version: "2.0.0", PublishedAt: time.Now().Add(-48 * time.Hour)}
+
+	var first bytes.Buffer
+	printUpdateHint(context.Background(), &first, release)
+
+	assert.Contains(t, first.String(), "Update available!")
+	assert.Contains(t, first.String(), "1.0.0")
+	assert.Contains(t, first.String(), "2.0.0")
+	assert.FileExists(t, filepath.Join(cacheDir, "update-notification.json"))
+
+	var second bytes.Buffer
+	printUpdateHint(context.Background(), &second, release)
+
+	assert.Empty(t, second.String(), "hint must not be repeated within the notification interval")
+}
+
+func TestPrintUpdateHint_RespectsRecentNotification(t *testing.T) {
+	cacheDir := isolateUpdateEnvironment(t)
+	setVersion(t, "1.0.0")
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cacheDir, "update-notification.json"),
+		[]byte(`{"last_printed_at":"`+time.Now().Add(-time.Hour).Format(time.RFC3339)+`"}`),
+		0o644,
+	))
+
+	var out bytes.Buffer
+	printUpdateHint(context.Background(), &out, &update.ReleaseInfo{Version: "2.0.0"})
+
+	assert.Empty(t, out.String())
+}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/shopware/shopware-cli/cmd"
 )
 
 func main() {
-	cmd.Execute(context.Background())
+	os.Exit(cmd.Execute(context.Background()))
 }


### PR DESCRIPTION
## What changed?

Extract argument aliases, command telemetry, and update checks/notifications from `cmd/root.go` into focused files. Inline `run` into `Execute`, return the exit code, and call `os.Exit` from `main` so deferred cleanup finishes before process exit.

## Why?

Keep the CLI entry point and execution flow easy to follow, with aliases, telemetry, and update handling maintained separately.

## How was this tested?

- `go test ./...`
- `golangci-lint run --timeout 10m` (0 issues)
- `git diff --check`

## Related issue or discussion

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using the `swx` alias to access project console commands.
  * `swx` defaults to listing projects when no command is provided.
  * Preserved command completion behavior for both `swx` and direct completion commands.
  * Update checks can provide notifications after command execution.

* **Bug Fixes**
  * Command failures and cancellations now return the appropriate process exit status.
  * Update notifications and checks no longer interrupt command execution when expected update information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->