### PR TITLE
fix: only require deployment-helper on Shopware >= 6.5.8

### DIFF
--- a/internal/shop/project_composer_json.go
+++ b/internal/shop/project_composer_json.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shyim/go-version"
+
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -56,14 +58,34 @@ func (o ComposerJsonOptions) IsDeployer() bool {
 	return o.DeploymentMethod == DeploymentDeployer
 }
 
+// deploymentHelperConstraint is the Shopware version range the
+// shopware/deployment-helper package can be installed with. Older releases
+// pin Symfony versions that conflict with the helper's requirements.
+var deploymentHelperConstraint = version.MustConstraints(version.NewConstraint(">=6.5.8"))
+
+// supportsDeploymentHelper reports whether the given Shopware version can
+// require shopware/deployment-helper. Dev branch names (e.g. dev-trunk) are
+// not parseable and report false; callers resolve them to their fallback
+// version first.
+func supportsDeploymentHelper(rawVersion string) bool {
+	v, err := version.NewVersion(rawVersion)
+	if err != nil {
+		return false
+	}
+
+	return deploymentHelperConstraint.Check(v)
+}
+
 func GenerateComposerJson(ctx context.Context, opts ComposerJsonOptions) (string, error) {
 	opts.DependingVersion = "*"
+	withDeploymentHelper := supportsDeploymentHelper(opts.Version)
 
 	if strings.HasPrefix(opts.Version, "dev-") {
 		fallbackVersion, err := getLatestFallbackVersion(ctx, strings.TrimPrefix(opts.Version, "dev-"))
 		if err != nil {
 			return "", err
 		}
+		withDeploymentHelper = supportsDeploymentHelper(fallbackVersion)
 
 		if strings.HasPrefix(opts.Version, "dev-6") {
 			opts.Version = strings.TrimPrefix(opts.Version, "dev-") + "-dev"
@@ -75,7 +97,9 @@ func GenerateComposerJson(ctx context.Context, opts ComposerJsonOptions) (string
 
 	require := newOrderedMap()
 	require.set("composer-runtime-api", "^2.0")
-	require.set("shopware/deployment-helper", "*")
+	if withDeploymentHelper {
+		require.set("shopware/deployment-helper", "*")
+	}
 	require.set("shopware/administration", opts.DependingVersion)
 	require.set("shopware/core", opts.Version)
 	if opts.UseElasticsearch {

--- a/internal/shop/project_composer_json_test.go
+++ b/internal/shop/project_composer_json_test.go
@@ -2,6 +2,7 @@ package shop
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -170,4 +171,48 @@ func TestGenerateComposerJson(t *testing.T) {
 		assert.True(t, data.Config.AllowPlugins["symfony/flex"], "allow-plugins should include symfony/flex")
 		assert.True(t, data.Config.AllowPlugins["symfony/runtime"], "allow-plugins should include symfony/runtime")
 	})
+
+	t.Run("deployment-helper requires Shopware 6.5.8 or higher", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			version string
+			want    bool
+		}{
+			{version: "6.4.18.0", want: false},
+			{version: "6.4.19.0", want: false},
+			{version: "6.5.7.0", want: false},
+			{version: "6.5.8.0", want: true},
+			{version: "6.5.8.0-rc1", want: true},
+			{version: "6.6.0.0", want: true},
+			{version: "6.7.0.0-rc2", want: true},
+		}
+
+		for _, test := range tests {
+			t.Run(test.version, func(t *testing.T) {
+				t.Parallel()
+				ctx := t.Context()
+				jsonStr, err := GenerateComposerJson(ctx, ComposerJsonOptions{Version: test.version, RC: strings.Contains(test.version, "rc")})
+				assert.NoError(t, err)
+
+				var data struct {
+					Require map[string]string `json:"require"`
+				}
+				assert.NoError(t, json.Unmarshal([]byte(jsonStr), &data))
+
+				_, ok := data.Require["shopware/deployment-helper"]
+				assert.Equal(t, test.want, ok, "deployment-helper presence mismatch for %s", test.version)
+			})
+		}
+	})
+}
+
+func TestSupportsDeploymentHelper(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, supportsDeploymentHelper("6.4.19.0"))
+	assert.False(t, supportsDeploymentHelper("6.5"))
+	assert.False(t, supportsDeploymentHelper("dev-trunk"), "dev branches are not parseable; callers use the fallback version")
+	assert.True(t, supportsDeploymentHelper("6.5.8"))
+	assert.True(t, supportsDeploymentHelper("6.6"))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

`shopware-cli project create` now only adds `shopware/deployment-helper` to the generated `composer.json` when the target Shopware version is 6.5.8 or higher.

Before (6.4.19.0):
```json
"require": {
    "composer-runtime-api": "^2.0",
    "shopware/deployment-helper": "*",
    "shopware/administration": "*",
    "shopware/core": "6.4.19.0",
    ...
}
```

After (6.4.19.0):
```json
"require": {
    "composer-runtime-api": "^2.0",
    "shopware/administration": "*",
    "shopware/core": "6.4.19.0",
    ...
}
```

## Why?

`shopware/deployment-helper` requires `symfony/yaml ^6.0 || ^7.0`, while Shopware 6.4.x pins `symfony/yaml ~5.4.0`. Creating a project for those versions therefore failed during `composer install` with an unresolvable dependency conflict. Dev branches (`dev-trunk`, `dev-6.x`) are evaluated against the fallback version read from the branch's `Kernel.php`, so they keep getting the helper.

## How was this tested?

- Added a table-driven subtest in `internal/shop/project_composer_json_test.go` covering 6.4.18.0/6.4.19.0/6.5.7.0 (helper absent) and 6.5.8.0/6.5.8.0-rc1/6.6.0.0/6.7.0.0-rc2 (helper present), plus direct `supportsDeploymentHelper` unit tests.
- `go test ./...`, `go vet ./...`, and `gofmt` all pass.
- Manually inspected the generated `composer.json` for 6.4.19.0 (no helper) and 6.6.0.0 (helper present).

## Related issue or discussion

Fixes #1541
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09e20e18-87ea-4291-aef7-788533d51017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09e20e18-87ea-4291-aef7-788533d51017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Composer configuration now includes the deployment helper only for Shopware 6.5.8 and later.
  * Version handling correctly supports release, short, development, and release-candidate versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->